### PR TITLE
fix:入群/踢出的事件错误响应

### DIFF
--- a/nekro_agent/services/message/message_service.py
+++ b/nekro_agent/services/message/message_service.py
@@ -253,6 +253,10 @@ class MessageService:
         )
 
         if trigger_agent:
+            db_chat_channel: DBChatChannel = await DBChatChannel.get_channel(chat_key=chat_key)
+            if not db_chat_channel.is_active:
+                logger.info(f"聊天频道 {chat_key} 已被禁用，跳过本次处理...")
+                return
             await self.schedule_agent_task(chat_key=chat_key)
 
 


### PR DESCRIPTION
fix issue #24 
在push_system_message中添加与push_human_message相同的群聊禁用判断实现修复

对于issue中的响应三未能成功复现，暂未修复

## Sourcery 总结

Bug 修复：
- 修复了当聊天频道被禁用时，群组加入和踢出事件的错误响应

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect event responses for group joins and kicks when chat channels are disabled

</details>