### PR TITLE
feat: Add emo extension for fetching emoticons

### DIFF
--- a/docs/README_Extensions.md
+++ b/docs/README_Extensions.md
@@ -111,6 +111,17 @@ DEFAULT_PROXY: "" # 默认代理 (仅会在必要时使用，填写格式: http:
 ADMIN_CHAT_KEY: "" # 管理会话标识，用于接收管理通知
 ```
 
+### emo - 表情包获取
+
+提供表情包获取功能，基于 ALAPI。
+
+- **功能**: 让AI获取表情包
+- **配置**:
+
+```yaml
+ALAPI_API_TOKEN: "" # ALAPI Token密钥
+```
+
 ## 💡 使用说明
 
 1. 在配置文件中启用需要的扩展：
@@ -125,6 +136,7 @@ EXTENSION_MODULES:
   - extensions.ai_voice # AI 声聊扩展 (允许 AI 使用 QQ 声聊角色发送语音)
   - extensions.google_search # 谷歌搜索扩展 (允许 AI 使用谷歌搜索 需要配置谷歌 API 密钥)
   - extensions.timer # 定时器扩展 (允许 AI 设置定时器，在指定时间触发事件)
+  - extensions.emo # 表情包获取扩展 (允许 AI 获取表情包)
 ```
 
 2. 根据扩展需求补充相应配置项

--- a/docs/README_Extensions.md
+++ b/docs/README_Extensions.md
@@ -113,13 +113,16 @@ ADMIN_CHAT_KEY: "" # 管理会话标识，用于接收管理通知
 
 ### emo - 表情包获取
 
-提供表情包获取功能，基于 ALAPI。
+提供表情包获取功能。
 
-- **功能**: 让AI获取表情包
+- **功能**: 让 AI 获取表情包
 - **配置**:
 
 ```yaml
-ALAPI_API_TOKEN: "" # ALAPI Token密钥
+EMO_API_URL: "https://v3.alapi.cn/api/doutu" # API的URL配置可填写其他API(需更改默认API设置)
+EMO_API_API_TOKEN: "" # API Token密钥
+EMO_API_TYPE: 5 # API type配置(对表情包内容有影响)
+EMO_API_PAGE: 1 # API page配置(API分页，默认1)
 ```
 
 ## 💡 使用说明

--- a/extensions/emo.py
+++ b/extensions/emo.py
@@ -1,0 +1,72 @@
+import random  # 导入 random 模块
+import httpx
+from typing import Optional, List
+from pydantic import BaseModel, Field
+
+from nekro_agent.core import config, logger
+from nekro_agent.schemas.agent_ctx import AgentCtx
+from nekro_agent.services.chat import chat_service
+from nekro_agent.services.extension import ExtMetaData
+from nekro_agent.tools.collector import MethodType, agent_collector
+
+class ALAPIResponse(BaseModel):
+    """ALAPI 接口返回数据模型"""
+    code: int = Field(description="状态码")
+    msg: Optional[str] = Field(default="无消息", description="消息")  # 将 msg 设置为可选
+    data: Optional[List[str]] = Field(default=None, description="数据")  # 确保 data 是一个列表
+
+__meta__ = ExtMetaData(
+    name="web",
+    description="[NA] 表情包获取",
+    version="0.1.0",
+    author="wess09",
+    url="https://github.com/KroMiose/nekro-agent",
+)
+
+@core.agent_collector.mount_method(core.MethodType.AGENT)
+async def get_emoticon(keyword: str, _ctx: AgentCtx) -> str:
+    """根据关键词获取表情包 URL 列表
+
+    Args:
+        keyword (str): 搜索关键词，如 "猫咪"、"搞笑"
+
+    Returns:
+        str: 表情包URL，如果获取失败则返回错误消息
+
+    Example:
+        get_emoticon("猫咪")
+    """
+    
+    api_token = core.config.ALAPI_API_TOKEN
+    url = "https://v3.alapi.cn/api/doutu"
+    querystring = {"token": api_token, "keyword": keyword, "page": "1"}
+    headers = {'Content-Type': 'application/json'}
+    
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=headers, params=querystring, timeout=10)
+            response.raise_for_status()  # 确保抛出 HTTPStatusError
+            result = response.json()
+            core.logger.debug(f"API 返回结果: {result}")  # 添加调试日志
+            alapi_response = ALAPIResponse(**result)
+
+            if alapi_response.code == 200:
+                if alapi_response.data:
+                    # 随机选择一个 URL 并在前面加上字符串
+                    selected_url = random.choice(alapi_response.data)
+                    return f"[表情包直链需下载发送] {selected_url}"
+                else:
+                    return "未找到相关表情包，请更换关键词重试。"
+            else:
+                return f"表情包获取失败: {alapi_response.msg}"
+
+    except httpx.TimeoutException as e:
+        core.logger.error(f"请求超时: {e}")
+        return "请求超时，请稍后重试。"
+    except httpx.HTTPStatusError as e:
+        core.logger.error(f"HTTP 错误: {e}")
+        return f"服务器返回错误: {e}"
+    except Exception as e:
+        core.logger.exception(f"发生未知错误: {e}")
+        core.logger.debug(f"完整的响应内容: {response.text}")  # 添加完整响应内容的调试信息
+        return f"发生未知错误，请联系管理员。"

--- a/extensions/emo.py
+++ b/extensions/emo.py
@@ -16,61 +16,60 @@ class ALAPIResponse(BaseModel):
     data: Optional[List[str]] = Field(default=None, description="数据")  # 确保 data 是一个列表
 
 __meta__ = ExtMetaData(
-    name="web",
+    name="emo",
     description="[NA] 表情包获取",
     version="0.1.0",
     author="wess09",
     url="https://github.com/KroMiose/nekro-agent",
 )
 
-@core.agent_collector.mount_method(core.MethodType.AGENT)
-async def get_emoticon(keyword: str, _ctx: AgentCtx) -> str:
-    """根据关键词获取表情包 URL 列表
-
+@core.agent_collector.mount_method(core.MethodType.TOOL)
+async def get_emoticon(keyword: str, _ctx: AgentCtx) -> bytes:
+    """根据关键词获取表情包 URL 并返回字节流
+    **在任何表达情绪的时候使用**
     Args:
         keyword (str): 搜索关键词，如 "猫咪"、"搞笑"
 
     Returns:
-        str: 表情包URL，如果获取失败则返回错误消息
+        bytes: 表情包图片的字节流，如果获取失败则返回错误消息
 
     Example:
-        get_emoticon("猫咪")
+        get_emoticon("柴郡")
     """
-    #构建请求
-    url = "https://v3.alapi.cn/api/doutu"
-    api_token = core.config.ALAPI_API_TOKEN
-    querystring = {"token": api_token, "keyword": keyword, "page": "1"}
+    # 自定义请求方便自定义API
+    url = config.EMO_API_URL
+    api_token = config.EMO_API_API_TOKEN
+    api_type = config.EMO_API_TYPE
+    api_page = config.EMO_API_PAGE
+    
+    # 构建请求参数
+    querystring = {"keyword": keyword}
+    if api_token:
+        querystring["token"] = api_token
+    if api_page:
+        querystring["page"] = api_page
+    if api_type:
+        querystring["type"] = api_type
+
     headers = {'Content-Type': 'application/json'}
     
     try:
         async with httpx.AsyncClient() as client:
             response = await client.get(url, headers=headers, params=querystring, timeout=10)
-            response.raise_for_status()  # 确保抛出 HTTPStatusError
             result = response.json()
-            core.logger.debug(f"API 返回结果: {result}")  # 添加调试日志
             alapi_response = ALAPIResponse(**result)
-
-            if alapi_response.code == 200:
-                if alapi_response.data:
-                    # 过滤掉后缀不是 .jpg 或 .png 的 URL
-                    valid_urls = [url for url in alapi_response.data if url.endswith(('.jpg', '.png'))]
-                    if valid_urls:
-                        selected_url = random.choice(valid_urls)
-                        return f"[图片直链] {selected_url}"
-                    else:
-                        return "未找到有效的表情包链接，请更换关键词重试。"
+            if alapi_response.data:
+                # 过滤掉后缀不是 .jpg 的 URL
+                valid_urls = [url for url in alapi_response.data if url.endswith('.jpg')]
+                if valid_urls:
+                    selected_url = random.choice(valid_urls)
+                    # 下载图片并返回字节流
+                    image_response = await client.get(selected_url)
+                    image_response.raise_for_status()
+                    return image_response.content
                 else:
-                    return "未找到相关表情包，请更换关键词重试。"
+                    raise Exception("未找到有效的表情包链接，请更换关键词重试。")
             else:
-                return f"表情包获取失败: {alapi_response.msg}"
-
-    except httpx.TimeoutException as e:
-        core.logger.error(f"请求超时: {e}")
-        return "请求超时，请稍后重试。"
-    except httpx.HTTPStatusError as e:
-        core.logger.error(f"HTTP 错误: {e}")
-        return f"服务器返回错误: {e}"
+                raise Exception("未找到相关表情包，请更换关键词重试。")
     except Exception as e:
-        core.logger.exception(f"发生未知错误: {e}")
-        core.logger.debug(f"完整的响应内容: {response.text}")  # 添加完整响应内容的调试信息
-        return f"发生未知错误，请联系管理员。"
+        core.logger.exception(f"错误: {e}")

--- a/extensions/emo.py
+++ b/extensions/emo.py
@@ -36,9 +36,9 @@ async def get_emoticon(keyword: str, _ctx: AgentCtx) -> str:
     Example:
         get_emoticon("猫咪")
     """
-    
-    api_token = core.config.ALAPI_API_TOKEN
+    #构建请求
     url = "https://v3.alapi.cn/api/doutu"
+    api_token = core.config.ALAPI_API_TOKEN
     querystring = {"token": api_token, "keyword": keyword, "page": "1"}
     headers = {'Content-Type': 'application/json'}
     
@@ -52,9 +52,13 @@ async def get_emoticon(keyword: str, _ctx: AgentCtx) -> str:
 
             if alapi_response.code == 200:
                 if alapi_response.data:
-                    # 随机选择一个 URL 并在前面加上字符串
-                    selected_url = random.choice(alapi_response.data)
-                    return f"[表情包直链需下载发送] {selected_url}"
+                    # 过滤掉后缀不是 .jpg 或 .png 的 URL
+                    valid_urls = [url for url in alapi_response.data if url.endswith(('.jpg', '.png'))]
+                    if valid_urls:
+                        selected_url = random.choice(valid_urls)
+                        return f"[图片直链] {selected_url}"
+                    else:
+                        return "未找到有效的表情包链接，请更换关键词重试。"
                 else:
                     return "未找到相关表情包，请更换关键词重试。"
             else:

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -303,13 +303,20 @@ class PluginConfig(ConfigBase):
     )
     GOOGLE_SEARCH_MAX_RESULTS: int = Field(default=3, title="Google 搜索参考最大结果数")
 
-    """Alapi 配置"""
-    ALAPI_API_TOKEN: str = Field(
+    """emo表情包扩展 配置"""
+    EMO_API_URL: str = Field(
+        default="https://v3.alapi.cn/api/doutu",
+        title="API的URL配置可填写其他API(需更改默认API设置)",
+        json_schema_extra={"is_hidden": True},
+    )
+    EMO_API_API_TOKEN: str = Field(
         default="",
         title="ALAPI Token密钥",
         json_schema_extra={"is_secret": True},
         description="ALAPI Token密钥 <a href='https://www.alapi.cn/' target='_blank'>获取地址</a>",
     )
+    EMO_API_TYPE: int = Field(default=5, title="ALAPI type配置(对表情包内容有影响)")
+    EMO_API_PAGE: int = Field(default=1, title="ALAPI page配置(API分页，默认1)")
 
     """Weave 配置"""
     WEAVE_ENABLED: bool = Field(default=False, title="启用 Weave 追踪")

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -303,6 +303,14 @@ class PluginConfig(ConfigBase):
     )
     GOOGLE_SEARCH_MAX_RESULTS: int = Field(default=3, title="Google 搜索参考最大结果数")
 
+    """Alapi 配置"""
+    ALAPI_API_TOKEN: str = Field(
+        default="",
+        title="ALAPI Token密钥",
+        json_schema_extra={"is_secret": True},
+        description="ALAPI Token密钥 <a href='https://www.alapi.cn/' target='_blank'>获取地址</a>",
+    )
+
     """Weave 配置"""
     WEAVE_ENABLED: bool = Field(default=False, title="启用 Weave 追踪")
     WEAVE_PROJECT_NAME: str = Field(default="nekro-agent", title="Weave 项目名称")


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加了一个“emo”扩展，使 AI 能够根据关键词获取表情符号。它使用 ALAPI 服务，需要 API 令牌进行身份验证。该扩展提供了一种搜索表情符号的方法，并返回一个随机选择的图像的直接链接。

新功能：
- 引入了一个“emo”扩展，允许 AI 使用 ALAPI 服务根据关键词获取表情符号。

增强功能：
- 在插件配置中添加了 ALAPI API 令牌的配置选项。

文档：
- 添加了“emo”扩展的文档，包括其功能和配置详细信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds an 'emo' extension that enables the AI to fetch emoticons based on keywords. It uses the ALAPI service and requires an API token for authentication. The extension provides a method to search for emoticons and returns a direct link to a randomly selected image.

New Features:
- Introduces an 'emo' extension that allows the AI to fetch emoticons based on keywords using the ALAPI service.

Enhancements:
- Adds a configuration option for the ALAPI API token in the plugin configuration.

Documentation:
- Adds documentation for the 'emo' extension, including its functionality and configuration details.

</details>