### PR TITLE
feat: 支持bot查看自己发送的图片;优化戳一戳通知处理器相关逻辑

### DIFF
--- a/nekro_agent/matchers/notice.py
+++ b/nekro_agent/matchers/notice.py
@@ -22,19 +22,20 @@ class PokeNoticeHandler(BaseNoticeHandler):
     def match(self, event_dict: Dict[str, Any]) -> Optional[Dict[str, str]]:
         if event_dict["notice_type"] != "notify" or event_dict.get("sub_type") != "poke":
             return None
+        raw_info = event_dict.get("raw_info", [])
+        poke_style = raw_info[2].get("txt", "戳一戳") if len(raw_info) > 2 else "戳一戳"
+        poke_style_suffix = raw_info[4].get("txt", "") if len(raw_info) > 4 else ""
         return {
             "user_id": str(event_dict["user_id"]),
             "target_id": str(event_dict["target_id"]),
-            "raw_info": event_dict.get("raw_info", []),
+            "poke_style": poke_style,
+            "poke_style_suffix": poke_style_suffix,
         }
 
     def format_message(self, info: Dict[str, str]) -> str:
-        raw_info = info["raw_info"]
-        poke_style = raw_info[2].get("txt", "戳一戳") if len(raw_info) > 2 else "戳一戳"
-        poke_style_suffix = raw_info[4].get("txt", "") if len(raw_info) > 4 else ""
         if str(info["target_id"]) == str(config.BOT_QQ):
-            return f"( {poke_style} {config.AI_CHAT_PRESET_NAME} {poke_style_suffix})"
-        return f"({poke_style} {info['target_id']} {poke_style_suffix})"
+            return f"( {info['poke_style']} {config.AI_CHAT_PRESET_NAME} {info['poke_style_suffix']})"
+        return f"({info['poke_style']} {info['target_id']} {info['poke_style_suffix']})"
 
 
 class GroupIncreaseNoticeHandler(BaseNoticeHandler):

--- a/nekro_agent/services/chat.py
+++ b/nekro_agent/services/chat.py
@@ -53,6 +53,7 @@ class ChatService:
 
         file_message: List[Path] = []
         if file_mode:
+            #发送文件
             for agent_message in messages:
                 if agent_message.type != AgentMessageSegmentType.FILE.value:
                     raise ValueError("File mode only support file message")
@@ -88,6 +89,7 @@ class ChatService:
                 message.append(MessageSegment.text(f"Invalid file path: {content}"))
 
         else:
+            #发送图片
             for agent_message in messages:
                 content = agent_message.content
                 if agent_message.type == AgentMessageSegmentType.TEXT.value:
@@ -111,6 +113,7 @@ class ChatService:
                     if content.startswith("uploads/"):
                         real_path = Path(USER_UPLOAD_DIR) / chat_key / content[len("uploads/") :]
                         logger.info(f"Sending agent file: {real_path}")
+                        agent_message.content = str(real_path)
                         message.append(MessageSegment.image(file=real_path.read_bytes(), type_="image"))
                         continue
 
@@ -126,10 +129,12 @@ class ChatService:
                     if content.startswith("shared/"):
                         real_path = Path(SANDBOX_SHARED_HOST_DIR) / ctx.container_key / content[len("shared/") :]
                         logger.info(f"Sending agent file: {real_path}")
+                        agent_message.content = str(real_path)
                         message.append(MessageSegment.image(file=real_path.read_bytes(), type_="image"))
                         continue
                     if content.startswith(("http://", "https://")):
                         file_path, _ = await download_file(content, from_chat_key=chat_key)
+                        agent_message.content = file_path
                         message.append(MessageSegment.image(file=Path(file_path).read_bytes()))
                         continue
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

实现让机器人查看自己发送的图片的功能，并优化了戳（poke）通知处理器的逻辑。现在，机器人会将其发送的图片存储在一个专门的目录中，从而可以查看这些图片。戳通知处理器得到了增强，可以提取和利用戳的样式和后缀信息。

新功能：
- 使机器人能够查看自己发送的图片，通过将图片存储在专用目录中并在发送消息时引用它们来实现。

增强功能：
- 改进戳通知处理，通过提取戳的样式和后缀信息以提供更多上下文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement the ability for the bot to view its own sent images and optimize the poke notification processor logic. The bot now stores images it sends in a dedicated directory, allowing it to view them. The poke notification processor is enhanced to extract and utilize poke style and suffix information.

New Features:
- Enable the bot to view images sent by itself by storing images in a dedicated directory and referencing them when sending messages.

Enhancements:
- Improve poke notification handling by extracting poke style and suffix information for more context.

</details>