### PR TITLE
feat: 添加禁/启用at功能;添加前缀触发对话功能

### DIFF
--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -137,11 +137,6 @@ class PluginConfig(ConfigBase):
         title="触发正则表达式",
         description="触发正则表达式，当消息匹配到正则表达式时，会触发 AI 回复",
     )
-    AI_CHAT_TRIGGER_PREFIX: List[str] = Field(
-        default=[],
-        title="触发前缀",
-        description="触发前缀，当消息匹配到前缀时，会触发 AI 回复",
-    )
     AI_CHAT_IGNORE_REGEX: List[str] = Field(
         default=[],
         title="忽略正则表达式",

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -137,6 +137,11 @@ class PluginConfig(ConfigBase):
         title="触发正则表达式",
         description="触发正则表达式，当消息匹配到正则表达式时，会触发 AI 回复",
     )
+    AI_CHAT_TRIGGER_PREFIX: List[str] = Field(
+        default=[],
+        title="触发前缀",
+        description="触发前缀，当消息匹配到前缀时，会触发 AI 回复",
+    )
     AI_CHAT_IGNORE_REGEX: List[str] = Field(
         default=[],
         title="忽略正则表达式",
@@ -214,7 +219,11 @@ class PluginConfig(ConfigBase):
         title="AI 群名片名称前缀",
         description="状态扩展修改群名片时会自动添加该前缀",
     )
-
+    SESSION_DISABLE_AT: bool = Field(
+        default=False,
+        title="关闭 at 功能",
+        description="关闭后 AI 无法发送at消息",
+    )
     """沙盒配置"""
     SANDBOX_IMAGE_NAME: str = Field(default="kromiose/nekro-agent-sandbox", title="沙盒镜像名称")
     SANDBOX_RUNNING_TIMEOUT: int = Field(

--- a/nekro_agent/services/message/convertor.py
+++ b/nekro_agent/services/message/convertor.py
@@ -146,12 +146,22 @@ async def convert_chat_message(
             else:
                 nick_name = await get_user_group_card_name(group_id=ob_event.group_id, user_id=at_qq)
             logger.info(f"OneBot at message: {at_qq=} {nick_name=}")
-            ret_list.append(
-                ChatMessageSegmentAt(
-                    type=ChatMessageSegmentType.AT,
-                    text="",
-                    target_qq=at_qq,
-                    target_nickname=nick_name,
+            if config.SESSION_DISABLE_AT:
+                logger.info(f"Session Disable At: {nick_name}")
+                ret_list.append(
+                    ChatMessageSegment(
+                        type=ChatMessageSegmentType.TEXT,
+                        text=f"@{nick_name}",
+                    ),
+                )
+            else:
+                logger.info(f"Session Allow At: {nick_name}")
+                ret_list.append(
+                    ChatMessageSegmentAt(
+                        type=ChatMessageSegmentType.AT,
+                        text="",
+                        target_qq=at_qq,
+                        target_nickname=nick_name,
                 ),
             )
 

--- a/nekro_agent/services/message/message_service.py
+++ b/nekro_agent/services/message/message_service.py
@@ -20,7 +20,6 @@ from nekro_agent.schemas.chat_message import ChatMessage, ChatType
 from nekro_agent.tools.common_util import (
     check_content_trigger,
     check_ignore_message,
-    check_prefix_trigger,
     move_to_upload_dir,
     random_chat_check,
 )
@@ -192,7 +191,6 @@ class MessageService:
             or message.is_tome
             or random_chat_check()
             or check_content_trigger(message.content_text)
-            or check_prefix_trigger(message.content_text)
         )
 
         if not should_ignore and should_trigger:

--- a/nekro_agent/services/message/message_service.py
+++ b/nekro_agent/services/message/message_service.py
@@ -20,6 +20,7 @@ from nekro_agent.schemas.chat_message import ChatMessage, ChatType
 from nekro_agent.tools.common_util import (
     check_content_trigger,
     check_ignore_message,
+    check_prefix_trigger,
     move_to_upload_dir,
     random_chat_check,
 )
@@ -161,7 +162,7 @@ class MessageService:
 
         content_data = [o.model_dump() for o in message.content_data]
         current_time: float = time.time()
-
+        
         # 添加聊天记录
         await DBChatMessage.create(
             message_id=message.message_id,
@@ -191,6 +192,7 @@ class MessageService:
             or message.is_tome
             or random_chat_check()
             or check_content_trigger(message.content_text)
+            or check_prefix_trigger(message.content_text)
         )
 
         if not should_ignore and should_trigger:

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -177,6 +177,19 @@ def check_content_trigger(content: str) -> bool:
             return True
     return False
 
+def check_prefix_trigger(content: str) -> bool:
+    """前缀触发检测
+
+    Args:
+        content (str): 内容
+
+    Returns:
+        bool: 是否触发
+    """
+    for prefix in config.AI_CHAT_TRIGGER_PREFIX:
+        if content.startswith(prefix):
+            return True
+    return False
 
 def check_ignore_message(content: str) -> bool:
     """忽略消息检测

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -177,19 +177,6 @@ def check_content_trigger(content: str) -> bool:
             return True
     return False
 
-def check_prefix_trigger(content: str) -> bool:
-    """前缀触发检测
-
-    Args:
-        content (str): 内容
-
-    Returns:
-        bool: 是否触发
-    """
-    for prefix in config.AI_CHAT_TRIGGER_PREFIX:
-        if content.startswith(prefix):
-            return True
-    return False
 
 def check_ignore_message(content: str) -> bool:
     """忽略消息检测

--- a/nekro_agent/tools/sd_util.py
+++ b/nekro_agent/tools/sd_util.py
@@ -67,7 +67,8 @@ async def text2img(positive_prompt: str, negative_prompt: str = DEFAULT_NEGATIVE
         timeout=120,
         proxy_server=PROXY,
     )
-    return res.json()["images"][0]
+    json_response = await res.json()
+    return json_response["images"][0]
 
 
 async def ai_text2img(prompt) -> str:


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增加了禁用/启用 at 功能，并为对话引入了前缀触发器。它还修改了禁用 at 功能时昵称的处理方式，并增强了配置选项，包括前缀触发器和会话级别的禁用 at 设置。

新功能：
- 为对话引入了前缀触发器，允许用户使用定义的前缀来启动与 AI 的对话。
- 增加了一个配置选项来禁用 at 功能，防止 AI 发送 at 消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds functionality to disable/enable the at function and introduces a prefix trigger for dialogues. It also modifies the way nicknames are handled when the at function is disabled, and enhances the configuration options to include prefix triggers and a session-level disable at setting.

New Features:
- Introduces a prefix trigger for dialogues, allowing users to initiate conversations with the AI using a defined prefix.
- Adds a configuration option to disable the at function, preventing the AI from sending at messages.

</details>