### PR TITLE
feat: 在插件和设置页面中添加模型组配置按钮，支持导航到模型组设置

### DIFF
--- a/frontend/src/pages/plugins/management.tsx
+++ b/frontend/src/pages/plugins/management.tsx
@@ -61,6 +61,7 @@ import {
   KeyboardArrowUp as KeyboardArrowUpIcon,
   KeyboardArrowDown as KeyboardArrowDownIcon,
   Storage as StorageIcon,
+  Launch as LaunchIcon,
 } from '@mui/icons-material'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Method, Plugin, PluginConfig, pluginsApi, MethodType } from '../../services/api/plugins'
@@ -998,14 +999,23 @@ function PluginDetails({ plugin, onBack, onToggleEnabled }: PluginDetailProps) {
                               <TableCell>
                                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                                   {renderConfigInput(item)}
-                                  {item.ref_model_groups && (
-                                    <Chip
-                                      label={modelTypeMap[item.model_type as string]?.label || '模型组'}
-                                      size="small"
-                                      color={(modelTypeMap[item.model_type as string]?.color as any) || 'primary'}
-                                      variant="outlined"
-                                    />
-                                  )}
+                                  {item.ref_model_groups && (() => {
+                                    const typeOption = modelTypeMap[item.model_type as string];
+                                    const chipLabel = typeOption
+                                      ?`${typeOption.label}模型组`
+                                      : '模型组';
+                                    const chipColor = (typeOption?.color as any) || 'primary';
+                                    return (
+                                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                                        <Chip label={chipLabel} size="small" color={chipColor} variant="outlined" />
+                                        <Tooltip title="配置模型组">
+                                          <IconButton size="small" onClick={() => navigate('/settings/model-groups')}>
+                                            <LaunchIcon fontSize="inherit" />
+                                          </IconButton>
+                                        </Tooltip>
+                                      </Box>
+                                    );
+                                  })()}
                                 </Box>
                               </TableCell>
                             </TableRow>

--- a/frontend/src/pages/settings/index.tsx
+++ b/frontend/src/pages/settings/index.tsx
@@ -43,8 +43,10 @@ import {
   Tune as TuneIcon,
   HelpOutline as HelpOutlineIcon,
   Search as SearchIcon,
+  Launch as LaunchIcon,
 } from '@mui/icons-material'
 import { styled } from '@mui/material/styles'
+import { useNavigate } from 'react-router-dom'
 
 // 添加自定义 Tooltip 样式
 const HtmlTooltip = styled(({ className, ...props }: TooltipProps) => (
@@ -180,6 +182,7 @@ const getTypeColor = (type: string) => {
 }
 
 export default function SettingsPage() {
+  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [message, setMessage] = useState<string>('')
   const [editingValues, setEditingValues] = useState<Record<string, string>>({})
@@ -651,14 +654,23 @@ export default function SettingsPage() {
                     <TableCell>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         {renderConfigInput(config)}
-                        {config.ref_model_groups && (
-                          <Chip
-                            label={modelTypeMap[config.model_type as string]?.label || '模型组'}
-                            size="small"
-                            color={(modelTypeMap[config.model_type as string]?.color as any) || 'primary'}
-                            variant="outlined"
-                          />
-                        )}
+                        {config.ref_model_groups && (() => {
+                          const typeOption = modelTypeMap[config.model_type as string];
+                          const chipLabel = typeOption
+                            ? `${typeOption.label}模型组`
+                            : '模型组';
+                          const chipColor = (typeOption?.color as any) || 'primary';
+                          return (
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                              <Chip label={chipLabel} size="small" color={chipColor} variant="outlined" />
+                              <Tooltip title="配置模型组">
+                                <IconButton size="small" onClick={() => navigate('/settings/model-groups')}>
+                                  <LaunchIcon fontSize="inherit" />
+                                </IconButton>
+                              </Tooltip>
+                            </Box>
+                          );
+                        })()}
                       </Box>
                     </TableCell>
                   </TableRow>

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -311,13 +311,13 @@ class PluginConfig(ConfigBase):
     PLUGIN_GENERATE_MODEL_GROUP: str = Field(
         default="default",
         title="插件代码生成模型组",
-        json_schema_extra={"ref_model_groups": True},
+        json_schema_extra={"ref_model_groups": True, "model_type": "chat"},
         description="用于生成插件代码的模型组，建议使用上下文长，逻辑推理能力强的模型",
     )
     PLUGIN_APPLY_MODEL_GROUP: str = Field(
         default="default",
         title="插件代码应用模型组",
-        json_schema_extra={"ref_model_groups": True},
+        json_schema_extra={"ref_model_groups": True, "model_type": "chat"},
         description="用于应用插件代码的模型组，建议使用上下文长，响应速度快的模型",
     )
     PLUGIN_UPDATE_USE_PROXY: bool = Field(


### PR DESCRIPTION
# PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 🔍 变更类型

- [ ] 🐛 Bug 修复 (修复一个问题)
- [x] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [x] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

<!-- 请详细描述你的PR解决了什么问题，为什么这个变更是必要的 -->

## 🔗 相关 Issue

<!-- 如果有相关Issue，请在此处引用 (例如: Closes #123, Fixes #456) -->

## 📸 截图 (如适用)

<!-- 如果你的PR包含UI变更或功能改进，添加截图会很有帮助 -->

## 📋 实现细节 (可选)

<!-- 如果实现方式比较复杂或特殊，可以在这里详细说明技术实现 -->

## 🧪 测试步骤 (可选)

<!-- 说明如何测试这个PR的功能 -->

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在插件和设置页面中，向模型组设置添加导航按钮

新特性：
- 添加了启动图标按钮，可以直接从插件和设置配置页面导航到模型组设置

增强功能：
- 改进了模型组芯片的显示，使用更具描述性的标签
- 为模型组配置按钮添加了工具提示

杂务：
- 更新了插件配置，以明确指定模型组的模型类型

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add navigation buttons to model group settings in plugin and settings pages

New Features:
- Added launch icon button to navigate directly to model group settings from plugin and settings configuration pages

Enhancements:
- Improved model group chip display with more descriptive labels
- Added tooltip for model group configuration button

Chores:
- Updated plugin configuration to explicitly specify model type for model groups

</details>