### PR TITLE
feat:迁移各适配器配置项至对应适配器下

### DIFF
--- a/nekro_agent/adapters/minecraft/adapter.py
+++ b/nekro_agent/adapters/minecraft/adapter.py
@@ -21,13 +21,42 @@ from nekro_agent.adapters.interface.schemas.platform import (
     PlatformUser,
 )
 from nekro_agent.core import logger
+from nekro_agent.core.config import ExtraField
 from nekro_agent.models.db_chat_channel import DBChatChannel
 from nekro_agent.schemas.chat_message import ChatType
 
 
 class MinecraftConfig(BaseAdapterConfig):
     """Minecraft 适配器配置"""
-
+    MINECRAFT_WS_URLS: str = Field(
+        default="{}",
+        title="Minecraft 服务器 WebSocket 地址",
+        description="Minecraft 服务器 WebSocket 地址，可配置多个服务器",
+        json_schema_extra=ExtraField(
+            load_to_nonebot_env=True,
+            load_nbenv_as="minecraft_ws_urls",
+            is_textarea=True,
+        ).model_dump(),
+    )
+    MINECRAFT_ACCESS_TOKEN: str = Field(
+        default="",
+        title="Minecraft 服务器 WebSocket 认证密钥",
+        description="用于验证连接",
+        json_schema_extra=ExtraField(
+            load_to_nonebot_env=True,
+            load_nbenv_as="minecraft_access_token",
+        ).model_dump(),
+    )
+    MINECRAFT_SERVER_RCON: str = Field(
+        default="{}",
+        title="Minecraft 服务器 RCON 地址",
+        description="Minecraft 服务器 RCON 地址，用于远程执行指令",
+        json_schema_extra=ExtraField(
+            load_to_nonebot_env=True,
+            load_nbenv_as="minecraft_server_rcon",
+            is_textarea=True,
+        ).model_dump(),
+    )
 
 class MinecraftAdapter(BaseAdapter[MinecraftConfig]):
     """Minecraft 适配器"""


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff
  - 前端：TypeScript 严格模式
- [x] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
  <!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [ ] 🐛 Bug 修复 (修复一个问题)
- [ ] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [x] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

<!-- 请详细描述你的PR解决了什么问题，为什么这个变更是必要的 -->

## 🔗 相关 Issue

<!-- 如果有相关Issue，请在此处引用 (例如: Closes #123, Fixes #456) -->

## 📸 修改效果截图

<!-- 如果你的PR包含UI变更或功能改进，请提供修改前后的对比截图 -->

## 🛠️ 实现复杂度

<!-- 请选择一项 -->
- [x] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

<!-- 如果实现方式比较复杂或特殊，可以在这里详细说明技术实现 -->

## 🧪 测试步骤 (可选)

<!-- 说明如何测试这个PR的功能，例如:
1. 进入...页面
2. 点击...按钮
3. 观察...结果
-->

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将特定于适配器的配置选项迁移到它们各自的适配器配置类中，并将环境变量加载逻辑集中到核心实用程序中。

增强功能：
- 从全局 PluginConfig 中删除 Minecraft 和 Bilibili Live 设置，并将它们重新引入到它们各自的适配器特定配置类下
- 将环境变量加载重构为 core_utils 中的共享 load_config_to_env 方法，并在加载配置后调用它
- 更新适配器实现，以通过 self.config 而不是全局配置来引用其重新定位的配置字段

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate adapter-specific configuration options into their respective adapter config classes and centralize environment variable loading logic to the core utilities.

Enhancements:
- Remove Minecraft and Bilibili Live settings from the global PluginConfig and reintroduce them under their adapter-specific config classes
- Refactor environment variable loading into a shared load_config_to_env method in core_utils and invoke it after configuration is loaded
- Update adapter implementations to reference their relocated config fields via self.config instead of the global config

</details>