### PR TITLE
feat: 更新mc适配器文档 修正rcon指令调用错误收集 优化mc适配器配置项

### DIFF
--- a/nekro_agent/adapters/bilibili_live/core/client.py
+++ b/nekro_agent/adapters/bilibili_live/core/client.py
@@ -31,7 +31,7 @@ class BilibiliWebSocketClient:
     def __init__(
         self,
         base_url: str,
-        danmaku_handler: Callable[[Danmaku], Coroutine[Any, Any, None]],
+        danmaku_handler: Callable[["BilibiliWebSocketClient", Danmaku], Coroutine[Any, Any, None]],
     ):
         self._base_url = base_url.rstrip("/")
         self._danmaku_handler = danmaku_handler
@@ -115,7 +115,7 @@ class BilibiliWebSocketClient:
                 try:
                     # 心跳 pong 不需要处理, aiohttp 会自动处理
                     danmaku = Danmaku.model_validate_json(msg.data)
-                    await self._danmaku_handler(danmaku)
+                    await self._danmaku_handler(self, danmaku)
                 except ValidationError as e:
                     logger.warning(f"解析弹幕消息失败: {e}, 原始数据: {msg.data}")
                 except Exception as e:

--- a/nekro_agent/adapters/minecraft/README.md
+++ b/nekro_agent/adapters/minecraft/README.md
@@ -9,99 +9,100 @@ Minecraft 适配器用于与 Minecraft 服务器进行通信，支持游戏内�
 ### 连接协议
 
 - ✅ RCON 远程控制协议
-- ✅ 支持 Minecraft 1.16+
-- ✅ UTF-8 编码支持
-- ✅ 安全的身份验证
+- ✅ Websocket 协议 (基于 [nonebot-adapter-minecraft](https://github.com/17TheWord/nonebot-adapter-minecraft) 适配器)
 
 ### 聊天功能
 
 - ✅ 游戏内聊天消息双向同步
 - ✅ 玩家消息接收
 - ✅ 系统消息推送
-- ✅ 自定义消息格式
+- ✅ 富文本消息发送
 
-### 服务器管理
+## 配套插件/模组
 
-- ✅ 实时服务器状态监控
-- ✅ 在线玩家查看
-- ✅ 服务器事件监听
-- ✅ RCON 命令执行
+此适配器需要配合在 Minecraft 服务端上安装 [QueQiao](https://github.com/17TheWord/QueQiao) 插件/模组才能使用 WebSocket 相关功能。
+
+- **下载地址**:
+  - [CurseForge](https://www.curseforge.com/minecraft/mc-mods/queqiao)
+  - [Modrinth](https://modrinth.com/plugin/queqiao)
+
+- **配置文档**:
+  - [部署指南](https://github.com/17TheWord/QueQiao/wiki/1.-部署)
+  - [配置文件说明](https://github.com/17TheWord/QueQiao/wiki/2.-配置文件)
 
 ## 配置说明
 
-### 必需配置
+您需要在 Nekro Agent 的 Web UI 中配置此适配器。
 
-- 服务器地址和端口
-- RCON 密码
-- 连接超时设置
+### `MINECRAFT_ACCESS_TOKEN`
 
-### 可选配置
+全局的 WebSocket 连接认证密钥，用于验证与所有配置的 Minecraft 服务器的连接。
 
-- 消息格式模板
-- 事件过滤规则
-- 重连策略
+### `SERVERS`
+
+一个服务器列表，您可以在其中配置一个或多个 Minecraft 服务器。每个服务器配置包含以下字段：
+
+- **`SERVER_NAME`**: 服务器的唯一名称，将用于生成聊天标识。**（必填）**
+- **`SERVER_WS_URL`**: 服务器的 WebSocket 地址 (例如 `ws://127.0.0.1:8089`)。需要配合 Minecraft 服务端插件使用。
+- **`IS_SERVER_RCON`**: 是否为此服务器启用 RCON。
+- **`SERVER_RCON_PORT`**: RCON 端口，默认为 `25575`。
+- **`SERVER_RCON_PASSWORD`**: RCON 密码。
 
 ## 聊天标识规则
 
 Minecraft 适配器使用以下格式标识聊天频道：
 
-- **服务器聊天**: `minecraft-server_服务器ID`
-- **玩家私聊**: `minecraft-player_玩家UUID`
-
-## 依赖要求
-
-- Minecraft 服务器 (1.16+)
-- 启用 RCON 功能
-- 网络连接稳定
-- 正确的防火墙配置
+- **服务器聊天**: `minecraft-<SERVER_NAME>` (其中 `SERVER_NAME` 是您在服务器配置中填写的服务器名称)
 
 ## 配置示例
 
-### server.properties 配置
+### QueQiao 配置文件示例
+
+以下是 QueQiao 插件/模组的配置文件示例 (配置文件实际路径请参考上文的 [部署指南](https://github.com/17TheWord/QueQiao/wiki/1.-部署)):
+
+```yaml
+enable: true # 是否启用插件/模组
+
+debug: false # DEBUG，开启后会打印所有日志
+
+server_name: "Server" # 服务器名称，对应上文中的SERVER_NAME
+
+access_token: "" # 用于连接时进行验证
+
+# 消息前缀
+# 消息前面添加的前缀（不包含Title、ActionBar）
+# 设置为空时，不会在消息前面添加前缀
+message_prefix: "" #建议留空，此内容可不用修改
+
+# WebSocket Server配置项
+websocket_server:
+  enable: true          # 是否启用
+  host: "127.0.0.1"     # WebSocket Server 地址 如果是公网建议改为0.0.0.0
+  port: 8080            # WebSocket Server 端口 按需修改
+
+# WebSocket Client配置项，此配置项不需要修改
+websocket_client:
+  enable: false                 # 是否启用
+  reconnect_interval: 5         # 重连间隔（秒）
+  reconnect_max_times: 5        # 最大重连次数
+  url_list:
+    - "ws://127.0.0.1:8080/minecraft/ws"
+
+# 订阅事件配置项
+subscribe_event:
+  player_chat: true       # 玩家聊天事件监听
+  player_death: true      # 玩家死亡事件监听
+  player_join: true       # 玩家登录事件监听
+  player_quit: true       # 玩家退出事件监听
+  player_command: true    # 玩家命令事件监听
+```
+
+### Minecraft `server.properties` 配置
+
+如果启用了 RCON，请确保您的 `server.properties` 文件中有如下配置：
 
 ```properties
 enable-rcon=true
-rcon.password=your_password_here
+rcon.password=your_rcon_password
 rcon.port=25575
 ```
-
-## 支持的命令
-
-### 基础命令
-
-- `/list` - 查看在线玩家
-- `/say <message>` - 发送服务器消息
-- `/tellraw <player> <json>` - 发送富文本消息
-
-### 管理命令
-
-- `/kick <player>` - 踢出玩家
-- `/ban <player>` - 封禁玩家
-- `/whitelist add <player>` - 添加白名单
-
-## 常见问题
-
-### Q: 无法连接到服务器？
-
-A: 请检查：
-
-1. 服务器是否启用 RCON
-2. 端口是否正确开放
-3. 密码是否正确
-4. 防火墙设置
-
-### Q: 收不到聊天消息？
-
-A: 确认：
-
-1. 服务器版本兼容性
-2. 消息格式配置
-3. 权限设置
-
-### Q: 命令执行失败？
-
-A: 检查：
-
-1. RCON 连接状态
-2. 命令格式正确性
-3. 服务器权限配置

--- a/plugins/builtin/bilibili_live_utils.py
+++ b/plugins/builtin/bilibili_live_utils.py
@@ -1,30 +1,30 @@
 """
 # Bilibili 直播工具 (Bilibili Live Utils)
 
-为 `Bilibili 直播` 适配器提供一系列专属的增强功能，核心是控制 Live2D 模型进行表演。
+为 `Bilibili 直播` 适配器提供一系列专属的增强功能,核心是控制 Live2D 模型进行表演.
 
-## 设计理念：动画任务队列
+## 设计理念:动画任务队列
 
-本插件的核心是一个**动画任务队列**系统。AI 的所有操作（如说话、做表情、播放动画）都不会立即执行，而是被添加到一个待办列表（队列）中。然后，通过一个统一的"执行"指令，才能让模型按照队列中的顺序开始表演。
+本插件的核心是一个**动画任务队列**系统.AI 的所有操作(如说话、做表情、播放动画)都不会立即执行,而是被添加到一个待办列表(队列)中.然后,通过一个统一的"执行"指令,才能让模型按照队列中的顺序开始表演.
 
-这种设计允许 AI 精心编排复杂的、包含延迟和同步的连续动作，实现更生动、更具表现力的虚拟主播互动效果。
+这种设计允许 AI 精心编排复杂的、包含延迟和同步的连续动作,实现更生动、更具表现力的虚拟主播互动效果.
 
 ## 主要功能
 
-- **发送弹幕**: 以虚拟主播的身份在直播间发送弹幕消息。
-- **Live2D 表情控制**: 控制模型的面部表情，并可以指定表情的持续时间。
-- **Live2D 动作播放**: 播放预设的复杂动画，例如挥手、大笑等。
-- **音效播放**: 在直播中播放各种音效，增强节目效果。
-- **队列控制**: 提供了发送执行指令的能力，这是启动所有表演的关键。
+- **发送弹幕**: 以虚拟主播的身份在直播间发送弹幕消息.
+- **Live2D 表情控制**: 控制模型的面部表情,并可以指定表情的持续时间.
+- **Live2D 动作播放**: 播放预设的复杂动画,例如挥手、大笑等.
+- **音效播放**: 在直播中播放各种音效,增强节目效果.
+- **队列控制**: 提供了发送执行指令的能力,这是启动所有表演的关键.
 
 ## 使用方法
 
-AI 会像导演一样，通过组合使用各种工具来编排一场表演：
-1.  调用 `send_text_message`、`set_expression` 等工具，把想让模型做的动作一个个地加入到任务队列中。
-2.  在所有动作都安排好后，调用 `send_execute` 工具。
-3.  此时，模型才会开始按照队列中的顺序，生动地表演出来。
+AI 会像导演一样,通过组合使用各种工具来编排一场表演:
+1.  调用 `send_text_message`、`set_expression` 等工具,把想让模型做的动作一个个地加入到任务队列中.
+2.  在所有动作都安排好后,调用 `send_execute` 工具.
+3.  此时,模型才会开始按照队列中的顺序,生动地表演出来.
 
-这个插件的所有工具都是为 AI 自动调用而设计的，用户无需手动操作。
+这个插件的所有工具都是为 AI 自动调用而设计的,用户无需手动操作.
 """
 
 import json
@@ -64,17 +64,17 @@ class BasicConfig(ConfigBase):
     STRICT_MESSAGE_FILTER: bool = Field(
         default=False,
         title="启用严格重复消息过滤",
-        description="启用后，完全重复的消息将直接抛出异常，否则仅过滤并提示",
+        description="启用后,完全重复的消息将直接抛出异常,否则仅过滤并提示",
     )
     SIMILARITY_THRESHOLD: float = Field(
         default=0.7,
         title="消息相似度警告阈值",
-        description="当消息相似度超过该阈值时，将触发系统警告提示引导 AI 调整生成策略",
+        description="当消息相似度超过该阈值时,将触发系统警告提示引导 AI 调整生成策略",
     )
     SIMILARITY_CHECK_LENGTH: int = Field(
         default=12,
         title="启用消息相似度检查阈值",
-        description="当消息长度超过该阈值时，将进行相似度检查",
+        description="当消息长度超过该阈值时,将进行相似度检查",
     )
 
 
@@ -86,24 +86,24 @@ SEND_MSG_CACHE: Dict[str, List[str]] = {}
 
 def extract_expressions(json_data: Dict) -> str:
     """
-    从 JSON 数据中提取并格式化表情详情（名称、文件、激活状态）。
+    从 JSON 数据中提取并格式化表情详情(名称、文件、激活状态).
 
-    此函数在内部用于为 LLM 准备可用表情的列表。
+    此函数在内部用于为 LLM 准备可用表情的列表.
 
     参数:
-        json_data (Dict): 从 JSON 解析的字典，包含表情数据，通常来自 API 响应。期望的结构类似：`{"data": {"expressions": [{"name": "str", "file": "str", "active": bool}, ...]}}`。
+        json_data (Dict): 从 JSON 解析的字典,包含表情数据,通常来自 API 响应.期望的结构类似:`{"data": {"expressions": [{"name": "str", "file": "str", "active": bool}, ...]}}`.
 
     返回:
-        str: 一个字符串，包含每个表情的名称、文件和激活状态，格式化以便于阅读（例如："开心 happy.exp3.json 激活\n伤心 sad.exp3.json 未激活"）。
-        如果 'expressions' 数组缺失或为空，则返回 "未找到表情数据。"。
-        如果 JSON 处理失败，则返回错误消息。
+        str: 一个字符串,包含每个表情的名称、文件和激活状态,格式化以便于阅读(例如:"开心 happy.exp3.json 激活\n伤心 sad.exp3.json 未激活").
+        如果 'expressions' 数组缺失或为空,则返回 "未找到表情数据.".
+        如果 JSON 处理失败,则返回错误消息.
     """
     try:
         # 提取expressions数组
         expressions = json_data.get("data", {}).get("expressions", [])
 
         if not expressions:
-            return "未找到表情数据。"
+            return "未找到表情数据."
 
         result = []
 
@@ -118,36 +118,50 @@ def extract_expressions(json_data: Dict) -> str:
         return "\n".join(result)
 
     except json.JSONDecodeError:
-        return "JSON 格式错误，请检查输入数据。"
+        return "JSON 格式错误,请检查输入数据."
     except Exception as e:
-        return f"处理数据时出错：{e!s}"
+        return f"处理数据时出错:{e!s}"
 
 
-def extract_sound_effects(json_data: Dict) -> str:
+def extract_sound_effects(data: List[Dict[str, str]]) -> str:
     """
-    从 JSON 数据中提取并格式化音效列表。
+    从数据中提取并格式化音效列表.
 
-    此函数在内部用于为 LLM 准备可用音效的列表。
+    此函数在内部用于为 LLM 准备可用音效的列表.
 
     参数:
-        json_data (Dict): 从 JSON 解析的字典，包含音效数据，通常来自 API 响应。期望的结构类似：`{"data": {"sounds": ["sound1.wav", "sound2.wav", ...]}}`。
+        data (List[Dict[str, str]]): 包含音效数据的列表.
+            期望的结构为: `[{"name": "sound1.wav", "description": "desc1"}, ...]`.
 
     返回:
-        str: 一个字符串，包含每个音效名称，每行一个。如果 'sounds' 数组缺失或为空，则返回 "未找到音效。".如果 JSON 处理失败，则返回错误消息。
+        str: 一个字符串,包含每个音效及其描述,格式为 "音效名称: 描述",每行一个.
+             如果音效列表为空,则返回 "未找到音效.".
+             如果处理失败,则返回错误消息.
     """
     try:
-        # 提取sounds数组
-        sounds = json_data.get("data", {}).get("sounds", [])
+        if not data:
+            return "未找到音效."
 
-        if not sounds:
-            return "未找到音效。"
+        formatted_sounds = []
+        for sound in data:
+            name = sound.get("name")
+            description = sound.get("description")
 
-        return "\n".join(sounds)
+            if not name:
+                continue
 
-    except json.JSONDecodeError:
-        return "JSON 格式错误，请检查输入数据。"
+            if description:
+                formatted_sounds.append(f"{name}: {description}")
+            else:
+                formatted_sounds.append(name)
+
+        if not formatted_sounds:
+            return "未找到音效."
+
+        return "\n".join(formatted_sounds)
+
     except Exception as e:
-        return f"处理数据时出错：{e!s}"
+        return f"处理数据时出错:{e!s}"
 
 
 def extract_preformed_animations(json_data: Dict) -> str:
@@ -160,20 +174,20 @@ def extract_preformed_animations(json_data: Dict) -> str:
         for animation in animations:
             name = animation.get("name", "未知")
             description = animation.get("description", "未知")
-            result.append(f"动画名称: {name}，描述: {description}")
+            result.append(f"动画名称: {name},描述: {description}")
 
             params = animation.get("params", [])
             for param in params:
                 p_name = param.get("name", "未知")
                 p_desc = param.get("description", "未知")
                 p_type = param.get("type", "unknown")
-                p_default = param.get("default", "无默认值，必填")
-                result.append(f"    - 参数: {p_name}，描述: {p_desc}，类型: {p_type}，默认值: {p_default}")
+                p_default = param.get("default", "无默认值,必填")
+                result.append(f"    - 参数: {p_name},描述: {p_desc},类型: {p_type},默认值: {p_default}")
 
         return "\n".join(result)
 
     except Exception as e:
-        return f"处理数据时出错：{e}"
+        return f"处理数据时出错:{e}"
 
 
 def extract_estimated_completion_time(json_data: Dict) -> float:
@@ -182,21 +196,21 @@ def extract_estimated_completion_time(json_data: Dict) -> float:
         return json_data.get("data", {}).get("estimated_completion_time", 0.0)
 
     except json.JSONDecodeError:
-        logger.warning("JSON 格式错误，请检查输入数据。")
+        logger.warning("JSON 格式错误,请检查输入数据.")
         return 0.0
     except Exception as e:
-        logger.warning(f"处理数据时出错：{e!s}")
+        logger.warning(f"处理数据时出错:{e!s}")
         return 0.0
 
 
 @plugin.mount_prompt_inject_method(name="basic_prompt_inject")
 async def basic_prompt_inject(_ctx: AgentCtx):
     """
-    将关于可用 Live2D 表情和音效的动态信息注入到代理的提示中。
+    将关于可用 Live2D 表情和音效的动态信息注入到提示词中.
 
-    此方法从 Bilibili Live websocket 客户端获取当前可用的表情和音效列表，
-    并将其格式化为提示字符串。这有助于 LLM 理解它可以使用哪些表情和音效
-    以及对应的工具。
+    此方法从 Bilibili Live websocket 客户端获取当前可用的表情和音效列表,
+    并将其格式化为提示字符串.这有助于 LLM 理解它可以使用哪些表情和音效
+    以及对应的工具.
     """
     chat_key = _ctx.chat_key
     room_id = chat_key.replace("bilibili_live-", "")
@@ -228,34 +242,34 @@ async def basic_prompt_inject(_ctx: AgentCtx):
         available_preformed_animations = await ws_client.send_animate_command(preformed_msg)
         available_preformed_animations = extract_preformed_animations(available_preformed_animations)
     basic_prompt = f"""
-    Live2D 模型控制重要说明：
-    1.像 `send_text_message`、`set_expression` 和 `play_preformed_animation` 这样的操作并不会立即执行。相反，它们会将任务添加到一个动画队列中，并会返回一个float，代表此任务从delay到执行结束后的总时间，你可以使用此值来精确控制动画的顺序。
-    2.必须使用 `send_execute` 命令来执行队列中当前的所有任务。
-    3.动画队列（由一系列任务后跟 `send_execute` 定义）会一个接一个地处理。只有在前一个队列完全完成后，新的队列才会开始。
-    4.实现延迟和复杂序列：** 您可以通过以下方式创建复杂的动画序列：
-        - 在单个任务函数（例如 `set_expression`、`play_preformed_animation`）中使用 `delay` 参数。
-        - 策略性地放置 `send_execute` 调用来定义动画的各个片段。`send_execute` 调用之间的延迟实际上是前一个队列中任务的持续时间和延迟的总和。
+    Live2D 模型控制重要说明:
+    1.像 `send_text_message`、`set_expression` 和 `play_preformed_animation` 这样的操作并不会立即执行.相反,它们会将任务添加到一个动画队列中,并会返回一个float,代表此任务从delay到执行结束后的总时间,你可以使用此值来精确控制动画的顺序.
+    2.必须使用 `send_execute` 命令来执行队列中当前的所有任务.
+    3.动画队列(由一系列任务后跟 `send_execute` 定义)会一个接一个地处理.只有在前一个队列完全完成后,新的队列才会开始.
+    4.实现延迟和复杂序列:您可以通过以下方式创建复杂的动画序列:
+        - 在单个任务函数(例如 `set_expression`、`play_preformed_animation`)中使用 `delay` 参数.
+        - 策略性地放置 `send_execute` 调用来定义动画的各个片段.`send_execute` 调用之间的延迟实际上是前一个队列中任务的持续时间和延迟的总和.
 
     可用的预制动画:
     {available_preformed_animations}
 
-    可用表情（格式：名称 文件 状态）：
+    可用表情(格式:名称 文件 状态):
     {avilable_expressions}
 
-    要使用表情，请调用 `set_expression(_ck, "expression_file_name.exp3.json", duration, delay)`。
-    示例：`set_expression(_ck, "Happy.exp3.json", 2.0, 0)` 将"开心"表情设置为持续 2 秒，无初始延迟。
+    要使用表情,请调用 `set_expression(_ck, "expression_file_name.exp3.json", duration, delay)`.
+    示例:`set_expression(_ck, "Happy.exp3.json", 2.0, 0)` 将"开心"表情设置为持续 2 秒,无初始延迟.
 
-    注意：上面列出的"表情"可能不仅仅包括面部表情。
-    它们可以控制模型的其他部分，如道具（例如，枕头）或头发。
-    你需要将表情与预制动画结合起来使用，以达到更好的效果。
-    请参考列表以了解所有可用的可控表情资源。
+    注意:上面列出的"表情"不仅仅包括面部表情.
+    它们可以控制模型的其他部件(如模型自带的道具,墨镜,帽子等)或模型形态(如头发).
+    你需要将表情与预制动画结合起来使用,以达到更好的效果.
+    请参考以下列表以了解所有可用的可控表情资源
 
-    可用meme音效（用于创造节目效果）：
+    可用meme音效(用于创造节目效果):
     {available_sound_effects}
 
-    要播放音效，请调用 `play_sound(_ck, "sound_file_name.wav", volume, speed, delay)`。
-    音效可以在直播期间创造更好的节目效果。
-    但是您不能频繁使用它们，否则会影响直播。
+    要播放音效,请调用 `play_sound(_ck, "sound_file_name.wav", volume, speed, delay)`.
+    音效可以在直播期间创造更好的节目效果.
+    但是您不能频繁使用它们,否则会影响直播.
     """
     return basic_prompt  # noqa: RET504
 
@@ -263,22 +277,22 @@ async def basic_prompt_inject(_ctx: AgentCtx):
 @plugin.mount_sandbox_method(
     SandboxMethodType.TOOL,
     name="发送文本消息",
-    description="发送聊天消息文本，附带缓存消息重复检查",
+    description="发送聊天消息文本,附带缓存消息重复检查",
 )
 async def send_text_message(_ctx: AgentCtx, chat_key: str, message_text: str, tts_text: str):
     """
-    为 Live2D 模型发送文本消息。
+    Live2D 模型将说出这些文字并伴随文本转语音生成的音频.
 
-    此函数将 'say' 任务添加到动画队列中。当通过 `send_execute` 执行队列时，Live2D 模型将按说出这些文字并伴随文本转语音生成的音频。
+    当通过 `send_execute` 执行队列时,Live2D 模型将按照队列中的顺序说出这些文字并伴随文本转语音生成的音频.
 
-    注意：
-        - 此函数将任务添加到队列中。请调用 `send_execute` 来触发执行。
+    注意:
+        - 此函数将任务添加到队列中.请调用 `send_execute` 来触发执行.
         - 此函数不会返回任何值
 
     参数:
-        chat_key (str): 聊天的会话标识符，例如 "bilibili_live-ROOM_ID"。
-        message_text (str): 字符串，用于展示字幕的文字，语言要求为中文，不能为空。
-        tts_text (str): 字符串，用于文本转语音的文字，语言要求为日语，字符串中只能出现片假名和其他标点符号，不允许使用日文汉字，不能为空。
+        chat_key (str): 聊天的会话标识符,例如 "bilibili_live-ROOM_ID".
+        message_text (str): 字符串,用于展示字幕的文字,语言要求为中文,不能为空.
+        tts_text (str): 字符串,用于文本转语音的文字,语言要求为日语,字符串中只能出现片假名和其他标点符号,不允许使用日文汉字,不能为空.
 
     返回:
         无
@@ -287,18 +301,18 @@ async def send_text_message(_ctx: AgentCtx, chat_key: str, message_text: str, tt
 
     # 检查消息列表是否为空或者长度不匹配
     if not message_text:
-        raise Exception("错误：消息列表不能为空。")
+        raise Exception("错误:消息列表不能为空.")
 
     if not message_text.strip():
-        raise Exception("错误：消息内容不能为空。")
+        raise Exception("错误:消息内容不能为空.")
 
     if not tts_text.strip():
-        raise Exception("错误：文本转语音内容不能为空。")
+        raise Exception("错误:文本转语音内容不能为空.")
 
     # 拒绝包含 [image:xxx...] 的图片消息
     if re.match(r"^.*\[image:.*\]$", message_text):
         raise Exception(
-            "错误：不能直接发送图片消息，请使用 send_msg_file 方法发送图片/文件资源。",
+            "错误:不能直接发送图片消息,请使用 send_msg_file 方法发送图片/文件资源.",
         )
 
     # 初始化消息缓存
@@ -313,16 +327,16 @@ async def send_text_message(_ctx: AgentCtx, chat_key: str, message_text: str, tt
         SEND_MSG_CACHE[chat_key] = []
         if config.STRICT_MESSAGE_FILTER:
             raise Exception(
-                "错误：最近已发送过相同的消息。请仔细阅读最近的聊天记录，检查是否发送了重复消息。请生成更有趣的回复。如果你完全确定有必要，可以重新发送。禁止刷屏！",
+                "错误:最近已发送过相同的消息.请仔细阅读最近的聊天记录,检查是否发送了重复消息.请生成更有趣的回复.如果你完全确定有必要,可以重新发送.禁止刷屏!",
             )
         await message_service.push_system_message(
             chat_key=chat_key,
-            agent_messages="系统提示：最近已发送过相同的消息。自动跳过此消息。请仔细阅读最近的聊天记录，检查是否发送了重复消息。如果你完全确定有必要，可以重新发送。禁止刷屏！",
+            agent_messages="系统提示:最近已发送过相同的消息.自动跳过此消息.请仔细阅读最近的聊天记录,检查是否发送了重复消息.如果你完全确定有必要,可以重新发送.禁止刷屏!",
             trigger_agent=False,
         )
         return
 
-    # 检查相似度（仅对超过限定字符的消息进行检查）
+    # 检查相似度(仅对超过限定字符的消息进行检查)
     for recent_msg in recent_messages:
         similarity = calculate_text_similarity(message_text, recent_msg, min_length=config.SIMILARITY_CHECK_LENGTH)
         if similarity > config.SIMILARITY_THRESHOLD:
@@ -330,7 +344,7 @@ async def send_text_message(_ctx: AgentCtx, chat_key: str, message_text: str, tt
             logger.warning(f"[{chat_key}] 检测到相似度过高的消息: {similarity:.2f}")
             await message_service.push_system_message(
                 chat_key=chat_key,
-                agent_messages="系统提示：您发送的消息与最近发送的消息过于相似！您的回复应当保持有效性，而不是冗余和繁琐！",
+                agent_messages="系统提示:您发送的消息与最近发送的消息过于相似!您的回复应当保持有效性,而不是冗余和繁琐!",
                 trigger_agent=False,
             )
             break
@@ -367,24 +381,21 @@ async def send_text_message(_ctx: AgentCtx, chat_key: str, message_text: str, tt
 )
 async def set_expression(_ctx: AgentCtx, chat_key: str, expression: str, duration: float, delay: float) -> float:
     """
-    设置特定的 Live2D 模型表情。
-
-    此函数将 'emotion' 任务添加到动画队列中。当通过 `send_execute` 执行队列时，
-    该表情将应用于 Live2D 模型。
-
-    注意：
-        - 此函数将任务添加到队列中。请调用 `send_execute` 来触发执行。
+    设置特定的 Live2D 模型表情.
+    此函数可搭配`play_preformed_animation`使用,以实现更好的展示效果.
+    注意:
+        - 此函数将任务添加到队列中.请调用 `send_execute` 来触发执行.
 
     参数:
-        chat_key (str): 会话标识符，例如 "bilibili_live-ROOM_ID"。
-        expression (str): 要设置的表情文件名（例如 "happy.exp3.json"）。请参考提示中提供的可用表情列表。
-        duration (float): 表情应保持激活的持续时间（秒）。
-        - 如果 `duration < 0`，表情将无限期持续。
-        - 要关闭一个持续的表情，可以用 `duration = 0` 设置。
-        delay (float): 在 `send_execute` 命令（或队列中的前一个任务）开始后，此表情任务开始前的延迟时间（秒）。
+        chat_key (str): 会话标识符,例如 "bilibili_live-ROOM_ID".
+        expression (str): 要设置的表情文件名(例如 "happy.exp3.json").请参考提示中提供的可用表情列表.
+        duration (float): 表情应保持激活的持续时间(秒).
+        - 如果 `duration < 0`,表情将无限期持续.
+        - 要关闭一个持续的表情,可以用 `duration = 0` 设置.
+        delay (float): 在 `send_execute` 命令(或队列中的前一个任务)开始后,此表情任务开始前的延迟时间(秒).
 
     返回:
-        一个float值,代表设置的表情从delay到duration结束后持续的总时间，你可以使用此返回值来精确控制动画的顺序
+        一个float值,代表设置的表情从delay到duration结束后持续的总时间,你可以使用此返回值来精确控制动画的顺序
     """
 
     room_id = chat_key.replace("bilibili_live-", "")
@@ -418,48 +429,48 @@ async def set_expression(_ctx: AgentCtx, chat_key: str, expression: str, duratio
 #     easing: str,
 # ) -> float:
 #     """
-#     设置或动画化特定的 Live2D 模型面部参数。
+#     设置或动画化特定的 Live2D 模型面部参数.
 
-#     此函数将 'animation' 任务添加到动画队列中，以控制单个面部参数，
-#     如嘴巴开合、眼睛眨动或头部角度。当通过 `send_execute` 执行队列时，
-#     该参数将被动画化。
+#     此函数将 'animation' 任务添加到动画队列中,以控制单个面部参数,
+#     如嘴巴开合、眼睛眨动或头部角度.当通过 `send_execute` 执行队列时,
+#     该参数将被动画化.
 
-#     注意：
-#         - 此函数将任务添加到队列中。请调用 `send_execute` 来触发执行。
+#     注意:
+#         - 此函数将任务添加到队列中.请调用 `send_execute` 来触发执行.
 
 #     参数:
-#         chat_key (str): 会话标识符，例如 "bilibili_live-ROOM_ID"。
-#         parameter (str): 要动画化的面部参数名称。请参见下方的"可用面部参数"。
-#         target (float): 参数的目标值。有效范围取决于参数。
-#         duration (float): 参数从当前值动画到 `target` 值所需的时间（秒）。
-#         delay (float): 在 `send_execute` 命令（或队列中的前一个任务）开始后，此动画任务开始前的延迟时间（秒）。
-#         easing (str): 用于动画的缓动函数。请参见下方的"可用缓动函数"。
+#         chat_key (str): 会话标识符,例如 "bilibili_live-ROOM_ID".
+#         parameter (str): 要动画化的面部参数名称.请参见下方的"可用面部参数".
+#         target (float): 参数的目标值.有效范围取决于参数.
+#         duration (float): 参数从当前值动画到 `target` 值所需的时间(秒).
+#         delay (float): 在 `send_execute` 命令(或队列中的前一个任务)开始后,此动画任务开始前的延迟时间(秒).
+#         easing (str): 用于动画的缓动函数.请参见下方的"可用缓动函数".
 
-#     可用缓动函数：
+#     可用缓动函数:
 #         'linear', 'in_sine', 'out_sine', 'in_out_sine', 'in_back', 'out_back',
 #         'in_out_back', 'in_elastic', 'out_elastic', 'in_out_elastic'
 
-#     可用面部参数（及其典型范围）：
-#         - 'MouthSmile': 0.0（嘴角向下）到 1.0（嘴角向上）
-#         - 'MouthOpen': 0.0（闭合）到 1.0（完全张开）
-#         - 'EyeOpenLeft': 0.0（完全睁开）到 1.0（完全闭合）
-#         - 'EyeOpenRight': 0.0（完全睁开）到 1.0（完全闭合）
-#         - 'Brows': 0.0（皱眉）到 1.0（扬眉）
-#         - 'FaceAngleY': -30.0（向下看）到 30.0（向上看）
-#         - 'FaceAngleX': -30.0（面向模型右侧）到 30.0（面向模型左侧）
-#         - 'FaceAngleZ': -90.0（向模型右侧倾斜）到 90.0（向模型左侧倾斜）
+#     可用面部参数(及其典型范围):
+#         - 'MouthSmile': 0.0(嘴角向下)到 1.0(嘴角向上)
+#         - 'MouthOpen': 0.0(闭合)到 1.0(完全张开)
+#         - 'EyeOpenLeft': 0.0(完全睁开)到 1.0(完全闭合)
+#         - 'EyeOpenRight': 0.0(完全睁开)到 1.0(完全闭合)
+#         - 'Brows': 0.0(皱眉)到 1.0(扬眉)
+#         - 'FaceAngleY': -30.0(向下看)到 30.0(向上看)
+#         - 'FaceAngleX': -30.0(面向模型右侧)到 30.0(面向模型左侧)
+#         - 'FaceAngleZ': -90.0(向模型右侧倾斜)到 90.0(向模型左侧倾斜)
 
-#     您可以在一次 `send_execute` 之前组合多个 `set_model_face_params` 调用（以及其他任务）
-#     来创建复杂的面部动画。
+#     您可以在一次 `send_execute` 之前组合多个 `set_model_face_params` 调用(以及其他任务)
+#     来创建复杂的面部动画.
 
-#     示例（先眨眼后微笑）：
-#         # 阶段 1：眨左眼（持续0.3秒），然后微笑（持续0.3秒，在眨眼结束后开始）
+#     示例(先眨眼后微笑):
+#         # 阶段 1:眨左眼(持续0.3秒),然后微笑(持续0.3秒,在眨眼结束后开始)
 #         set_model_face_params(_ck, "EyeOpenLeft", 1.0, 0.3, 0.0, "in_sine")  # 眨眼立即开始
 #         set_model_face_params(_ck, "MouthSmile", 1.0, 0.3, 0.3, "in_sine") # 微笑在0.3秒后开始
 #         send_execute(_ck, 1) # 执行此序列一次
 
 #     返回:
-#         一个float值,代表设置的参数动作从delay到duration结束后持续的总时间，你可以使用此返回值来精确控制动画的顺序
+#         一个float值,代表设置的参数动作从delay到duration结束后持续的总时间,你可以使用此返回值来精确控制动画的顺序
 #     """
 #     room_id = chat_key.replace("bilibili_live-", "")
 #     ws_client = _ctx.adapter.get_ws_client_by_room_id(room_id)  # type: ignore
@@ -486,18 +497,18 @@ async def set_expression(_ctx: AgentCtx, chat_key: str, expression: str, duratio
 )
 async def play_sound(_ctx: AgentCtx, chat_key: str, sound_name: str, volume: float, speed: float, delay: float) -> float:
     """
-    播放一个音效。
-    注意：
-        - 此函数将任务添加到队列中。请调用 `send_execute` 来触发执行。
+    播放一个音效.
+    注意:
+        - 此函数将任务添加到队列中.请调用 `send_execute` 来触发执行.
     参数:
-        chat_key (str): 会话标识符，例如 "bilibili_live-ROOM_ID"。
-        sound_name (str): 要播放的声音的路径。
-        volume (float): 声音的音量（0.0-1.0）。
-        speed (float): 声音的速度（0.0-1.0）。
-        delay (float): 在 `send_execute` 命令（或队列中的前一个任务）开始后，此声音任务开始前的延迟时间（秒）。
+        chat_key (str): 会话标识符,例如 "bilibili_live-ROOM_ID".
+        sound_name (str): 要播放的声音的路径.
+        volume (float): 声音的音量(0.0-1.0).
+        speed (float): 声音的速度(0.0-1.0).
+        delay (float): 在 `send_execute` 命令(或队列中的前一个任务)开始后,此声音任务开始前的延迟时间(秒).
 
     返回:
-        一个float值,代表播放的音频从delay到结束持续的总时间，你可以使用此返回值来精确控制动画的顺序
+        一个float值,代表播放的音频从delay到结束持续的总时间,你可以使用此返回值来精确控制动画的顺序
     """
     room_id = chat_key.replace("bilibili_live-", "")
     ws_client = _ctx.adapter.get_ws_client_by_room_id(room_id)  # type: ignore
@@ -523,18 +534,18 @@ async def play_sound(_ctx: AgentCtx, chat_key: str, sound_name: str, volume: flo
 )
 async def play_preformed_animation(_ctx: AgentCtx, chat_key: str, animation_name: str, params: Dict, delay: float) -> float:
     """
-    播放一个预制动画。
-    注意：
-        - 此函数将任务添加到队列中。请调用 `send_execute` 来触发执行。
-        - 此函数只作用于面部参数等，若要实现更好展示效果请搭配`set_model_face_params`使用
+    播放一个预制动画.
+    注意:
+        - 此函数将任务添加到队列中.请调用 `send_execute` 来触发执行.
+        - 此函数只作用于面部参数等,若要实现更好展示效果请搭配`set_expression`使用
     参数:
-        chat_key (str): 会话标识符，例如 "bilibili_live-ROOM_ID"。
-        animation_name (str): 要播放的预制动画的名称。
-        params (Dict): 预制动画的参数。dict的key为参数名称，value为参数值。
-        delay (float): 在 `send_execute` 命令（或队列中的前一个任务）开始后，此预制动画任务开始前的延迟时间（秒）。
+        chat_key (str): 会话标识符,例如 "bilibili_live-ROOM_ID".
+        animation_name (str): 要播放的预制动画的名称.
+        params (Dict): 预制动画的参数.dict的key为参数名称,value为参数值.
+        delay (float): 在 `send_execute` 命令(或队列中的前一个任务)开始后,此预制动画任务开始前的延迟时间(秒).
 
     返回:
-        一个float值,代表播放的预制动画从开始到结束持续的总时间，你可以使用此返回值来精确控制动画的顺序
+        一个float值,代表播放的预制动画从开始到结束持续的总时间,你可以使用此返回值来精确控制动画的顺序
 
     示例:
         play_preformed_animation(
@@ -569,21 +580,21 @@ async def play_preformed_animation(_ctx: AgentCtx, chat_key: str, animation_name
 )
 async def send_execute(_ctx: AgentCtx, chat_key: str, loop: int):
     """
-    执行所有已排队的 Live2D 动画任务。
+    执行所有已排队的 Live2D 动画任务.
 
-    此函数触发执行自上次 `send_execute` 调用以来（或者如果从未调用过 `send_execute`，
-    则从开始以来）已添加到动画队列中的所有 'say'、'emotion' 和 'animation' 任务。
+    此函数触发执行自上次 `send_execute` 调用以来(或者如果从未调用过 `send_execute`,
+    则从开始以来)已添加到动画队列中的所有 'send_text_message'、'set_expression' 、 'play_preformed_animation' 和 'play_sound' 任务.
 
-    注意：
-        - 此函数执行当前队列中的所有任务。
+    注意:
+        - 此函数执行当前队列中的所有任务.
 
     参数:
-        chat_key (str): 会话标识符，例如 "bilibili_live-ROOM_ID"。
-        loop (int): 重复执行当前队列中整个任务序列的次数。例如，`loop=1` 将执行当前队列，然后再次执行它。值为 `0` 表示执行一次。
+        chat_key (str): 会话标识符,例如 "bilibili_live-ROOM_ID".
+        loop (int): 重复执行当前队列中整个任务序列的次数.例如,`loop=1` 将执行当前队列,然后再次执行它.值为 `0` 表示执行一次.
 
-    行为：
-        - 系统会等待上一个 `send_execute` 队列完全完成后才开始下一个队列。这允许创建不同的动画片段。
-        - 如果 `loop` 大于 0，在此 `send_execute` 之前定义的所有任务集将重复 `loop` 次。
+    行为:
+        - 系统会等待上一个 `send_execute` 队列完全完成后才开始下一个队列.这允许创建不同的动画片段.
+        - 如果 `loop` 大于 0,在此 `send_execute` 之前定义的所有任务集将重复 `loop` 次.
 
     返回:
         无
@@ -603,10 +614,10 @@ async def send_execute(_ctx: AgentCtx, chat_key: str, loop: int):
 @plugin.mount_cleanup_method()
 async def clean_up():
     """
-    清理插件资源，特别是清除消息缓存。
+    清理插件资源,特别是清除消息缓存.
 
-    此函数通常在插件卸载或应用程序关闭时调用。
-    它将 `SEND_MSG_CACHE` 重置为空字典。
+    此函数通常在插件卸载或应用程序关闭时调用.
+    它将 `SEND_MSG_CACHE` 重置为空字典.
     """
     global SEND_MSG_CACHE
     SEND_MSG_CACHE = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/KroMiose/nekro-agent"
 [tool.poetry.scripts]
 publish = "scripts.run_publish:main"
 bot = "run_bot:main"
-dev = "nb-cli run --reload --reload-excludes plugins/workdir"
+# dev = "nb-cli run --reload --reload-excludes plugins/workdir"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff
  - 前端：TypeScript 严格模式
- [x] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
  <!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [x] 🐛 Bug 修复 (修复一个问题)
- [ ] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [x] 📝 文档更新
- [x] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

<!-- 请详细描述你的PR解决了什么问题，为什么这个变更是必要的 -->

## 🔗 相关 Issue

<!-- 如果有相关Issue，请在此处引用 (例如: Closes #123, Fixes #456) -->

## 📸 修改效果截图

<!-- 如果你的PR包含UI变更或功能改进，请提供修改前后的对比截图 -->

## 🛠️ 实现复杂度

<!-- 请选择一项 -->
- [x] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

<!-- 如果实现方式比较复杂或特殊，可以在这里详细说明技术实现 -->

## 🧪 测试步骤 (可选)

<!-- 说明如何测试这个PR的功能，例如:
1. 进入...页面
2. 点击...按钮
3. 观察...结果
-->

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新 Minecraft 适配器配置、文档和错误处理，以支持 Bilibili 直播和 Minecraft 集成

**新特性:**

- 为 Minecraft 适配器添加结构化的多服务器配置支持，并提供旧配置转换功能
- 在 Minecraft 适配器中通过 QueQiao 插件引入 WebSocket 协议支持
- 在直播适配器中启用 Bilibili 直播房间 ID 到 WebSocket 客户端的动态映射

**Bug 修复:**

- 增强 RCON 命令执行，以检测和收集错误响应，并提供可选的遇错继续执行行为

**增强:**

- 通过移除显式的房间 ID 列表要求，简化 Bilibili 直播适配器的初始化
- 规范化 Bilibili 直播实用函数和提示中的标点符号和格式
- 在 Minecraft 适配器中，将旧的 WebSocket 和 RCON 配置字段隐藏在新 SERVERS 模式之后

**构建:**

- 注释掉 pyproject.toml 中的开发重新加载脚本

**文档:**

- 修订 Minecraft 适配器 README，更新 WebSocket 设置、配置示例和事件订阅详细信息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Minecraft adapter configuration, documentation, and error handling for Bilibili Live and Minecraft integrations

New Features:
- Add structured multi-server configuration support for the Minecraft adapter with legacy conversion
- Introduce WebSocket protocol support in the Minecraft adapter via the QueQiao plugin
- Enable dynamic mapping of Bilibili Live room IDs to WebSocket clients in the live adapter

Bug Fixes:
- Enhance RCON command execution to detect and collect error responses with optional continue-on-error behavior

Enhancements:
- Streamline Bilibili Live adapter initialization by removing explicit room ID list requirement
- Normalize punctuation and formatting across Bilibili Live utility functions and prompts
- Hide legacy WebSocket and RCON config fields behind new SERVERS schema in Minecraft adapter

Build:
- Comment out the development reload script in pyproject.toml

Documentation:
- Revise Minecraft adapter README with updated WebSocket setup, configuration examples, and event subscription details

</details>