### PR TITLE
fix(view_image): 修正“查看图片（view_image）”插件中使用"system" role 而不是"user" role来发送包含图片的消息的问题。

### DIFF
--- a/plugins/builtin/view_image.py
+++ b/plugins/builtin/view_image.py
@@ -52,7 +52,11 @@ class ViewImageConfig(ConfigBase):
         default="default",
         title="用于查看图片的模型,如果主模型自带视觉请勿开启本插件",
         description="用于查看图片并描述内容,以文本形式返回给主模型",
-        json_schema_extra={"ref_model_groups": True, "required": True, "model_type": "chat"},
+        json_schema_extra={
+            "ref_model_groups": True,
+            "required": True,
+            "model_type": "chat",
+        },
     )
 
 
@@ -118,8 +122,10 @@ async def view_image(_ctx: AgentCtx, images: List[str]):
         raise ValueError("当前模型组不支持视觉功能")
 
     # 构造发送给视觉模型的消息
-    vision_prompt = "Describe the content shown in this images in relatively detailed language."
-    vision_msg = OpenAIChatMessage.from_text("system", vision_prompt)
+    vision_prompt = (
+        "Describe the content shown in this images in relatively detailed language."
+    )
+    vision_msg = OpenAIChatMessage.from_text("user", vision_prompt)
 
     for i, image_path in enumerate(images):
         # 判断是否为URL（简单判断是否以http开头）
@@ -127,7 +133,7 @@ async def view_image(_ctx: AgentCtx, images: List[str]):
             # 使用URL方式
             vision_msg.batch_add(
                 [
-                    ContentSegment.text_content(f"Image {i+1}: {image_path}"),
+                    ContentSegment.text_content(f"Image {i + 1}: {image_path}"),
                     ContentSegment.image_content(image_path),
                 ],
             )
@@ -138,7 +144,7 @@ async def view_image(_ctx: AgentCtx, images: List[str]):
                 raise ValueError(f"图片路径不存在: {image_path}")
             vision_msg.batch_add(
                 [
-                    ContentSegment.text_content(f"Image {i+1}: {image_path}"),
+                    ContentSegment.text_content(f"Image {i + 1}: {image_path}"),
                     ContentSegment.image_content_from_path(path),
                 ],
             )


### PR DESCRIPTION
…o user role to prevent provider 500s

# 🌟 PR 提交说明

## 📋 许可确认

- [ √] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [ √] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [ √] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [ √] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [ √] 🐛 Bug 修复 (修复一个问题)
- [ ] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

<!-- system 一般用于提供纯文本的“元指令/规则”；
user 才是承载实际“内容输入”（文本/图片等多模态）的消息角色；
将图片塞进 system 会和绝大多数模型 API 的消息结构不匹配，从而导致 4xx/5xx，使“查看图片”插件变得实际上不可用。 -->

## 🔗 相关 Issue

<!-- 如果有相关Issue，请在此处引用 (例如: Closes #123, Fixes #456) -->

## 📸 修改效果截图

<!-- 如果你的PR包含UI变更或功能改进，请提供修改前后的对比截图 -->

## 🛠️ 实现复杂度

<!-- 请选择一项 -->

- [ √] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

<!-- 如果实现方式比较复杂或特殊，可以在这里详细说明技术实现 -->

## 🧪 测试步骤 (可选)

<!-- 说明如何测试这个PR的功能，例如:
1. 进入...页面
2. 点击...按钮
3. 观察...结果
-->

## 由 Sourcery 提供的摘要

修复 `view_image` 插件，使其在发送图像提示时使用正确的用户角色，并重新格式化相关代码

Bug 修复：
- 在发送图像提示时，将 `ChatMessage` 角色从 `system` 更改为 `user`，以防止提供商返回 500 错误

改进：
- 规范 `view_image` 插件的代码格式（字典布局和 f-string 间距）

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the view_image plugin to send image prompts with the correct user role and reformat related code

Bug Fixes:
- Change the ChatMessage role from system to user when sending image prompts to prevent provider 500 errors

Enhancements:
- Standardise code formatting for the view_image plugin (dict layout and f-string spacing)

</details>