### PR TITLE
修复了当API返回"reasoning_content": null时出现的none问题

### DIFF
--- a/nekro_agent/adapters/onebot_v11/matchers/command.py
+++ b/nekro_agent/adapters/onebot_v11/matchers/command.py
@@ -26,7 +26,7 @@ from nekro_agent.models.db_chat_channel import DBChatChannel
 from nekro_agent.models.db_chat_message import DBChatMessage
 from nekro_agent.models.db_exec_code import DBExecCode
 from nekro_agent.schemas.chat_message import ChatType
-from nekro_agent.services.agent.openai import OpenAIResponse, gen_openai_chat_response, parse_extra_body
+from nekro_agent.services.agent.openai import OpenAIResponse, gen_openai_chat_response
 from nekro_agent.services.agent.resolver import ParsedCodeRunData
 from nekro_agent.services.message_service import message_service
 from nekro_agent.services.plugin.collector import plugin_collector
@@ -49,7 +49,7 @@ def _build_chat_params(model_group: ModelConfigGroup, stream_mode: bool, max_wai
         "top_k": model_group.TOP_K,
         "frequency_penalty": model_group.FREQUENCY_PENALTY,
         "presence_penalty": model_group.PRESENCE_PENALTY,
-        "extra_body": parse_extra_body(model_group.EXTRA_BODY, source_hint=f"ModelGroup: {model_group.CHAT_MODEL}"),
+        "extra_body": model_group.EXTRA_BODY,
         "base_url": model_group.BASE_URL,
         "api_key": model_group.API_KEY,
         "stream_mode": stream_mode,

--- a/nekro_agent/services/agent/openai.py
+++ b/nekro_agent/services/agent/openai.py
@@ -353,7 +353,7 @@ async def gen_openai_chat_response(
     top_p: Optional[float] = None,
     stop_words: Optional[List[str]] = None,
     max_tokens: Optional[int] = None,
-    extra_body: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Union[Dict[str, Any], str]] = None,
     top_k: Optional[int] = None,
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
@@ -372,6 +372,10 @@ async def gen_openai_chat_response(
 
     # messages 处理
     messages = [msg.to_dict() if isinstance(msg, OpenAIChatMessage) else msg for msg in messages]
+
+    # Parse extra_body if it is a string
+    if isinstance(extra_body, str):
+        extra_body = parse_extra_body(extra_body, source_hint=f"Model: {model}")
 
     gen_kwargs = {
         "temperature": temperature,
@@ -568,7 +572,7 @@ async def gen_openai_chat_stream(
     top_p: Optional[float] = None,
     stop_words: Optional[List[str]] = None,
     max_tokens: Optional[int] = None,
-    extra_body: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Union[Dict[str, Any], str]] = None,
     top_k: Optional[int] = None,
 ) -> AsyncGenerator[str, None]:
     """简化的OpenAI流式生成器，直接产生文本片段
@@ -592,6 +596,10 @@ async def gen_openai_chat_stream(
         生成的文本片段
     """
     logger.info(f"启动简化的流式生成，使用模型: {model}")
+
+    # Parse extra_body if it is a string
+    if isinstance(extra_body, str):
+        extra_body = parse_extra_body(extra_body, source_hint=f"Model: {model}")
 
     # 创建参数字典，移除None值
     # 创建参数字典，移除None值

--- a/nekro_agent/services/agent/run_agent.py
+++ b/nekro_agent/services/agent/run_agent.py
@@ -21,7 +21,7 @@ from nekro_agent.services.sandbox.runner import limited_run_code
 
 from ..config_resolver import config_resolver
 from .creator import OpenAIChatMessage
-from .openai import OpenAIResponse, gen_openai_chat_response, parse_extra_body
+from .openai import OpenAIResponse, gen_openai_chat_response
 from .resolver import ParsedCodeRunData, parse_chat_response
 from .templates.base import env as default_env
 from .templates.history import HistoryFirstStart, render_history_data
@@ -295,11 +295,6 @@ async def send_agent_request(
         use_model_group: ModelConfigGroup = model_group if i < config.AI_CHAT_LLM_API_MAX_RETRIES - 1 else fallback_model_group
 
         try:
-            extra_body_dict = parse_extra_body(
-                use_model_group.EXTRA_BODY,
-                source_hint=f"ModelGroup: {use_model_group.CHAT_MODEL}",
-            )
-
             llm_response: OpenAIResponse = await gen_openai_chat_response(
                 model=use_model_group.CHAT_MODEL,
                 messages=messages,
@@ -308,7 +303,7 @@ async def send_agent_request(
                 top_k=use_model_group.TOP_K,
                 frequency_penalty=use_model_group.FREQUENCY_PENALTY,
                 presence_penalty=use_model_group.PRESENCE_PENALTY,
-                extra_body=extra_body_dict,
+                extra_body=use_model_group.EXTRA_BODY,
                 base_url=use_model_group.BASE_URL,
                 api_key=use_model_group.API_KEY,
                 stream_mode=config.AI_REQUEST_STREAM_MODE,

--- a/nekro_agent/services/plugin/generator.py
+++ b/nekro_agent/services/plugin/generator.py
@@ -14,7 +14,6 @@ from nekro_agent.services.agent.openai import (
     OpenAIStreamChunk,
     gen_openai_chat_response,
     gen_openai_chat_stream,
-    parse_extra_body,
 )
 from nekro_agent.services.agent.templates.generator import (
     ApplySystemPrompt,
@@ -41,7 +40,7 @@ def _build_model_params(model_group: str) -> dict:
         "top_k": model_config.TOP_K,
         "frequency_penalty": model_config.FREQUENCY_PENALTY,
         "presence_penalty": model_config.PRESENCE_PENALTY,
-        "extra_body": parse_extra_body(model_config.EXTRA_BODY, source_hint=f"ModelGroup: {model_group}"),
+        "extra_body": model_config.EXTRA_BODY,
         "base_url": model_config.BASE_URL,
         "api_key": model_config.API_KEY,
     }


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [ ] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [x] 🐛 Bug 修复 (修复一个问题)
- [ ] ✨ 新功能 (添加新功能)
- [x] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

修复了当API返回"reasoning_content": null时出现的none问题

## 🔗 相关 Issue

#167 

## 📸 修改效果截图



## 🛠️ 实现复杂度

<!-- 请选择一项 -->

- [*] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## Summary by Sourcery

错误修复：
- 当 OpenAI API 返回的 reasoning/chain-of-thought 字段为 null 时，通过在流式和非流式响应中将其规范化为空字符串，避免产生错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent errors when the OpenAI API returns a null reasoning/chain-of-thought field by normalizing it to an empty string in both streaming and non-streaming responses.

</details>

## Summary by Sourcery

规范 OpenAI 的 reasoning/chain-of-thought 字段，并在 agent、plugin 和 OneBot 集成中统一模型参数处理。

Bug 修复：
- 当 OpenAI 流式和非流式响应中缺失或返回空的 reasoning/chain-of-thought 字段时，通过将其规范化为空字符串，防止运行时错误。

增强：
- 为所有 OpenAI 聊天与流式调用增加对模型分组采样参数以及结构化 `extra_body`（包括 `top_k`）的支持。
- 引入共享辅助方法，为插件、OneBot 命令处理器和 agent 请求构建 OpenAI 模型/聊天参数字典，以减少重复并确保配置一致性。
- 为 `EXTRA_BODY` 配置实现健壮的 JSON 解析和日志记录，使格式错误的负载被安全忽略而不会导致请求失败。
- 在发送请求前，将 OpenAI 聊天消息统一规范为字典形式，以提高输入的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize OpenAI reasoning/chain-of-thought fields and centralize model parameter handling across agent, plugin, and OneBot integrations.

Bug Fixes:
- Prevent runtime errors when OpenAI streaming and non-streaming responses return missing or null reasoning/chain-of-thought fields by normalizing them to empty strings.

Enhancements:
- Add support for passing model-group sampling parameters and structured extra_body (including top_k) into all OpenAI chat and streaming calls.
- Introduce shared helpers to build OpenAI model/chat parameter dictionaries for plugins, OneBot command handlers, and agent requests, reducing duplication and ensuring consistent configuration.
- Implement robust JSON parsing and logging for EXTRA_BODY configuration so malformed payloads are safely ignored without failing requests.
- Normalize OpenAI chat messages to dict form before sending requests to improve input consistency.

</details>

Bug 修复：
- 当 OpenAI 的 reasoning/chain-of-thought 字段缺失或为 null 时，通过在流式和非流式响应中将其规范化为空字符串来避免运行时错误。

增强功能：
- 引入辅助函数，用于构建 OpenAI 聊天与流式调用所需的模型参数字典（包括采样设置和已解析的 `EXTRA_BODY`）。
- 将模型组采样参数（`temperature`、`top_p`、`top_k`、`frequency_penalty`、`presence_penalty`）以及结构化的 `extra_body` 传递到所有 OpenAI 聊天和流式调用中，包括插件生成和 OneBot 命令处理器。
- 为 `EXTRA_BODY` 配置添加健壮的 JSON 解析和日志记录，使格式错误的负载在被安全忽略的同时不会导致请求失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

规范 OpenAI 的 reasoning/chain-of-thought 字段，并在 agent、plugin 和 OneBot 集成中统一模型参数处理。

Bug 修复：
- 当 OpenAI 流式和非流式响应中缺失或返回空的 reasoning/chain-of-thought 字段时，通过将其规范化为空字符串，防止运行时错误。

增强：
- 为所有 OpenAI 聊天与流式调用增加对模型分组采样参数以及结构化 `extra_body`（包括 `top_k`）的支持。
- 引入共享辅助方法，为插件、OneBot 命令处理器和 agent 请求构建 OpenAI 模型/聊天参数字典，以减少重复并确保配置一致性。
- 为 `EXTRA_BODY` 配置实现健壮的 JSON 解析和日志记录，使格式错误的负载被安全忽略而不会导致请求失败。
- 在发送请求前，将 OpenAI 聊天消息统一规范为字典形式，以提高输入的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize OpenAI reasoning/chain-of-thought fields and centralize model parameter handling across agent, plugin, and OneBot integrations.

Bug Fixes:
- Prevent runtime errors when OpenAI streaming and non-streaming responses return missing or null reasoning/chain-of-thought fields by normalizing them to empty strings.

Enhancements:
- Add support for passing model-group sampling parameters and structured extra_body (including top_k) into all OpenAI chat and streaming calls.
- Introduce shared helpers to build OpenAI model/chat parameter dictionaries for plugins, OneBot command handlers, and agent requests, reducing duplication and ensuring consistent configuration.
- Implement robust JSON parsing and logging for EXTRA_BODY configuration so malformed payloads are safely ignored without failing requests.
- Normalize OpenAI chat messages to dict form before sending requests to improve input consistency.

</details>

</details>

Bug 修复：
- 在流式和非流式的 OpenAI 响应中统一规范处理缺失或为 null 的 reasoning/chain-of-thought 字段，以避免运行时错误。

增强功能：
- 将模型组采样参数（temperature、top_p、top_k、frequency_penalty、presence_penalty）传递到所有 OpenAI 的聊天和流式调用中。
- 通过 JSON 配置为每个模型添加对额外请求负载（EXTRA_BODY）的支持，并在解析失败时进行友好的错误日志记录。
- 扩展 OpenAI 聊天辅助函数，使其接受 top_k 和结构化的 extra_body，并在同步和流式路径中将这些参数一致地合并到请求负载中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

规范 OpenAI 的 reasoning/chain-of-thought 字段，并在 agent、plugin 和 OneBot 集成中统一模型参数处理。

Bug 修复：
- 当 OpenAI 流式和非流式响应中缺失或返回空的 reasoning/chain-of-thought 字段时，通过将其规范化为空字符串，防止运行时错误。

增强：
- 为所有 OpenAI 聊天与流式调用增加对模型分组采样参数以及结构化 `extra_body`（包括 `top_k`）的支持。
- 引入共享辅助方法，为插件、OneBot 命令处理器和 agent 请求构建 OpenAI 模型/聊天参数字典，以减少重复并确保配置一致性。
- 为 `EXTRA_BODY` 配置实现健壮的 JSON 解析和日志记录，使格式错误的负载被安全忽略而不会导致请求失败。
- 在发送请求前，将 OpenAI 聊天消息统一规范为字典形式，以提高输入的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize OpenAI reasoning/chain-of-thought fields and centralize model parameter handling across agent, plugin, and OneBot integrations.

Bug Fixes:
- Prevent runtime errors when OpenAI streaming and non-streaming responses return missing or null reasoning/chain-of-thought fields by normalizing them to empty strings.

Enhancements:
- Add support for passing model-group sampling parameters and structured extra_body (including top_k) into all OpenAI chat and streaming calls.
- Introduce shared helpers to build OpenAI model/chat parameter dictionaries for plugins, OneBot command handlers, and agent requests, reducing duplication and ensuring consistent configuration.
- Implement robust JSON parsing and logging for EXTRA_BODY configuration so malformed payloads are safely ignored without failing requests.
- Normalize OpenAI chat messages to dict form before sending requests to improve input consistency.

</details>

Bug 修复：
- 当 OpenAI 的 reasoning/chain-of-thought 字段缺失或为 null 时，通过在流式和非流式响应中将其规范化为空字符串来避免运行时错误。

增强功能：
- 引入辅助函数，用于构建 OpenAI 聊天与流式调用所需的模型参数字典（包括采样设置和已解析的 `EXTRA_BODY`）。
- 将模型组采样参数（`temperature`、`top_p`、`top_k`、`frequency_penalty`、`presence_penalty`）以及结构化的 `extra_body` 传递到所有 OpenAI 聊天和流式调用中，包括插件生成和 OneBot 命令处理器。
- 为 `EXTRA_BODY` 配置添加健壮的 JSON 解析和日志记录，使格式错误的负载在被安全忽略的同时不会导致请求失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

规范 OpenAI 的 reasoning/chain-of-thought 字段，并在 agent、plugin 和 OneBot 集成中统一模型参数处理。

Bug 修复：
- 当 OpenAI 流式和非流式响应中缺失或返回空的 reasoning/chain-of-thought 字段时，通过将其规范化为空字符串，防止运行时错误。

增强：
- 为所有 OpenAI 聊天与流式调用增加对模型分组采样参数以及结构化 `extra_body`（包括 `top_k`）的支持。
- 引入共享辅助方法，为插件、OneBot 命令处理器和 agent 请求构建 OpenAI 模型/聊天参数字典，以减少重复并确保配置一致性。
- 为 `EXTRA_BODY` 配置实现健壮的 JSON 解析和日志记录，使格式错误的负载被安全忽略而不会导致请求失败。
- 在发送请求前，将 OpenAI 聊天消息统一规范为字典形式，以提高输入的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize OpenAI reasoning/chain-of-thought fields and centralize model parameter handling across agent, plugin, and OneBot integrations.

Bug Fixes:
- Prevent runtime errors when OpenAI streaming and non-streaming responses return missing or null reasoning/chain-of-thought fields by normalizing them to empty strings.

Enhancements:
- Add support for passing model-group sampling parameters and structured extra_body (including top_k) into all OpenAI chat and streaming calls.
- Introduce shared helpers to build OpenAI model/chat parameter dictionaries for plugins, OneBot command handlers, and agent requests, reducing duplication and ensuring consistent configuration.
- Implement robust JSON parsing and logging for EXTRA_BODY configuration so malformed payloads are safely ignored without failing requests.
- Normalize OpenAI chat messages to dict form before sending requests to improve input consistency.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

规范 OpenAI 的 reasoning/chain-of-thought 字段，并在 agent、plugin 和 OneBot 集成中统一模型参数处理。

Bug 修复：
- 当 OpenAI 流式和非流式响应中缺失或返回空的 reasoning/chain-of-thought 字段时，通过将其规范化为空字符串，防止运行时错误。

增强：
- 为所有 OpenAI 聊天与流式调用增加对模型分组采样参数以及结构化 `extra_body`（包括 `top_k`）的支持。
- 引入共享辅助方法，为插件、OneBot 命令处理器和 agent 请求构建 OpenAI 模型/聊天参数字典，以减少重复并确保配置一致性。
- 为 `EXTRA_BODY` 配置实现健壮的 JSON 解析和日志记录，使格式错误的负载被安全忽略而不会导致请求失败。
- 在发送请求前，将 OpenAI 聊天消息统一规范为字典形式，以提高输入的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize OpenAI reasoning/chain-of-thought fields and centralize model parameter handling across agent, plugin, and OneBot integrations.

Bug Fixes:
- Prevent runtime errors when OpenAI streaming and non-streaming responses return missing or null reasoning/chain-of-thought fields by normalizing them to empty strings.

Enhancements:
- Add support for passing model-group sampling parameters and structured extra_body (including top_k) into all OpenAI chat and streaming calls.
- Introduce shared helpers to build OpenAI model/chat parameter dictionaries for plugins, OneBot command handlers, and agent requests, reducing duplication and ensuring consistent configuration.
- Implement robust JSON parsing and logging for EXTRA_BODY configuration so malformed payloads are safely ignored without failing requests.
- Normalize OpenAI chat messages to dict form before sending requests to improve input consistency.

</details>

Bug 修复：
- 当 OpenAI 的 reasoning/chain-of-thought 字段缺失或为 null 时，通过在流式和非流式响应中将其规范化为空字符串来避免运行时错误。

增强功能：
- 引入辅助函数，用于构建 OpenAI 聊天与流式调用所需的模型参数字典（包括采样设置和已解析的 `EXTRA_BODY`）。
- 将模型组采样参数（`temperature`、`top_p`、`top_k`、`frequency_penalty`、`presence_penalty`）以及结构化的 `extra_body` 传递到所有 OpenAI 聊天和流式调用中，包括插件生成和 OneBot 命令处理器。
- 为 `EXTRA_BODY` 配置添加健壮的 JSON 解析和日志记录，使格式错误的负载在被安全忽略的同时不会导致请求失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

规范 OpenAI 的 reasoning/chain-of-thought 字段，并在 agent、plugin 和 OneBot 集成中统一模型参数处理。

Bug 修复：
- 当 OpenAI 流式和非流式响应中缺失或返回空的 reasoning/chain-of-thought 字段时，通过将其规范化为空字符串，防止运行时错误。

增强：
- 为所有 OpenAI 聊天与流式调用增加对模型分组采样参数以及结构化 `extra_body`（包括 `top_k`）的支持。
- 引入共享辅助方法，为插件、OneBot 命令处理器和 agent 请求构建 OpenAI 模型/聊天参数字典，以减少重复并确保配置一致性。
- 为 `EXTRA_BODY` 配置实现健壮的 JSON 解析和日志记录，使格式错误的负载被安全忽略而不会导致请求失败。
- 在发送请求前，将 OpenAI 聊天消息统一规范为字典形式，以提高输入的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize OpenAI reasoning/chain-of-thought fields and centralize model parameter handling across agent, plugin, and OneBot integrations.

Bug Fixes:
- Prevent runtime errors when OpenAI streaming and non-streaming responses return missing or null reasoning/chain-of-thought fields by normalizing them to empty strings.

Enhancements:
- Add support for passing model-group sampling parameters and structured extra_body (including top_k) into all OpenAI chat and streaming calls.
- Introduce shared helpers to build OpenAI model/chat parameter dictionaries for plugins, OneBot command handlers, and agent requests, reducing duplication and ensuring consistent configuration.
- Implement robust JSON parsing and logging for EXTRA_BODY configuration so malformed payloads are safely ignored without failing requests.
- Normalize OpenAI chat messages to dict form before sending requests to improve input consistency.

</details>

</details>

Bug 修复：
- 在流式和非流式的 OpenAI 响应中统一规范处理缺失或为 null 的 reasoning/chain-of-thought 字段，以避免运行时错误。

增强功能：
- 将模型组采样参数（temperature、top_p、top_k、frequency_penalty、presence_penalty）传递到所有 OpenAI 的聊天和流式调用中。
- 通过 JSON 配置为每个模型添加对额外请求负载（EXTRA_BODY）的支持，并在解析失败时进行友好的错误日志记录。
- 扩展 OpenAI 聊天辅助函数，使其接受 top_k 和结构化的 extra_body，并在同步和流式路径中将这些参数一致地合并到请求负载中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

规范 OpenAI 的 reasoning/chain-of-thought 字段，并在 agent、plugin 和 OneBot 集成中统一模型参数处理。

Bug 修复：
- 当 OpenAI 流式和非流式响应中缺失或返回空的 reasoning/chain-of-thought 字段时，通过将其规范化为空字符串，防止运行时错误。

增强：
- 为所有 OpenAI 聊天与流式调用增加对模型分组采样参数以及结构化 `extra_body`（包括 `top_k`）的支持。
- 引入共享辅助方法，为插件、OneBot 命令处理器和 agent 请求构建 OpenAI 模型/聊天参数字典，以减少重复并确保配置一致性。
- 为 `EXTRA_BODY` 配置实现健壮的 JSON 解析和日志记录，使格式错误的负载被安全忽略而不会导致请求失败。
- 在发送请求前，将 OpenAI 聊天消息统一规范为字典形式，以提高输入的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize OpenAI reasoning/chain-of-thought fields and centralize model parameter handling across agent, plugin, and OneBot integrations.

Bug Fixes:
- Prevent runtime errors when OpenAI streaming and non-streaming responses return missing or null reasoning/chain-of-thought fields by normalizing them to empty strings.

Enhancements:
- Add support for passing model-group sampling parameters and structured extra_body (including top_k) into all OpenAI chat and streaming calls.
- Introduce shared helpers to build OpenAI model/chat parameter dictionaries for plugins, OneBot command handlers, and agent requests, reducing duplication and ensuring consistent configuration.
- Implement robust JSON parsing and logging for EXTRA_BODY configuration so malformed payloads are safely ignored without failing requests.
- Normalize OpenAI chat messages to dict form before sending requests to improve input consistency.

</details>

Bug 修复：
- 当 OpenAI 的 reasoning/chain-of-thought 字段缺失或为 null 时，通过在流式和非流式响应中将其规范化为空字符串来避免运行时错误。

增强功能：
- 引入辅助函数，用于构建 OpenAI 聊天与流式调用所需的模型参数字典（包括采样设置和已解析的 `EXTRA_BODY`）。
- 将模型组采样参数（`temperature`、`top_p`、`top_k`、`frequency_penalty`、`presence_penalty`）以及结构化的 `extra_body` 传递到所有 OpenAI 聊天和流式调用中，包括插件生成和 OneBot 命令处理器。
- 为 `EXTRA_BODY` 配置添加健壮的 JSON 解析和日志记录，使格式错误的负载在被安全忽略的同时不会导致请求失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

规范 OpenAI 的 reasoning/chain-of-thought 字段，并在 agent、plugin 和 OneBot 集成中统一模型参数处理。

Bug 修复：
- 当 OpenAI 流式和非流式响应中缺失或返回空的 reasoning/chain-of-thought 字段时，通过将其规范化为空字符串，防止运行时错误。

增强：
- 为所有 OpenAI 聊天与流式调用增加对模型分组采样参数以及结构化 `extra_body`（包括 `top_k`）的支持。
- 引入共享辅助方法，为插件、OneBot 命令处理器和 agent 请求构建 OpenAI 模型/聊天参数字典，以减少重复并确保配置一致性。
- 为 `EXTRA_BODY` 配置实现健壮的 JSON 解析和日志记录，使格式错误的负载被安全忽略而不会导致请求失败。
- 在发送请求前，将 OpenAI 聊天消息统一规范为字典形式，以提高输入的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize OpenAI reasoning/chain-of-thought fields and centralize model parameter handling across agent, plugin, and OneBot integrations.

Bug Fixes:
- Prevent runtime errors when OpenAI streaming and non-streaming responses return missing or null reasoning/chain-of-thought fields by normalizing them to empty strings.

Enhancements:
- Add support for passing model-group sampling parameters and structured extra_body (including top_k) into all OpenAI chat and streaming calls.
- Introduce shared helpers to build OpenAI model/chat parameter dictionaries for plugins, OneBot command handlers, and agent requests, reducing duplication and ensuring consistent configuration.
- Implement robust JSON parsing and logging for EXTRA_BODY configuration so malformed payloads are safely ignored without failing requests.
- Normalize OpenAI chat messages to dict form before sending requests to improve input consistency.

</details>

</details>

</details>

</details>