### PR TITLE
feat(plugin): 添加插件启用和禁用的生命周期回调支持

### DIFF
--- a/nekro_agent/services/plugin/base.py
+++ b/nekro_agent/services/plugin/base.py
@@ -535,11 +535,31 @@ class NekroPlugin:
     def is_enabled(self) -> bool:
         return self._is_enabled
 
-    def enable(self) -> None:
+    async def enable(self) -> None:
+        """启用插件并触发相应的回调函数
+        
+        此方法是启用插件的统一入口，确保无论从何处调用，
+        都会自动执行状态变更和触发回调事件。
+        """
+        if self._is_enabled:
+            return  # 已经启用，无需重复操作
+        
         self._is_enabled = True
+        # 自动触发启用回调
+        await self.trigger_callbacks("enabled")
 
-    def disable(self) -> None:
+    async def disable(self) -> None:
+        """禁用插件并触发相应的回调函数
+        
+        此方法是禁用插件的统一入口，确保无论从何处调用，
+        都会自动执行状态变更和触发回调事件。
+        """
+        if not self._is_enabled:
+            return  # 已经禁用，无需重复操作
+        
         self._is_enabled = False
+        # 自动触发禁用回调
+        await self.trigger_callbacks("disabled")
 
     @property
     def key(self) -> str:

--- a/nekro_agent/services/plugin/collector.py
+++ b/nekro_agent/services/plugin/collector.py
@@ -448,7 +448,8 @@ class PluginCollector:
             )
             plugin._update_plugin_type(is_builtin, is_package)  # noqa: SLF001
             if plugin.key not in config.PLUGIN_ENABLED:
-                plugin.disable()
+                # 直接设置状态为禁用，不触发回调（因为插件刚加载，没有从启用变为禁用）
+                plugin._is_enabled = False  # noqa: SLF001
             else:
                 # 插件已启用，触发 enabled 回调
                 await plugin.trigger_callbacks("enabled")

--- a/nekro_agent/services/plugin/manager.py
+++ b/nekro_agent/services/plugin/manager.py
@@ -129,11 +129,8 @@ async def enable_plugin(plugin_id: str) -> bool:
         return True  # 已经启用，直接返回成功
 
     try:
-        # 启用插件
-        plugin.enable()
-        
-        # 触发回调
-        await plugin.trigger_callbacks("enabled")
+        # 启用插件 - enable() 方法内部会自动触发回调
+        await plugin.enable()
         
         if plugin.key not in config.PLUGIN_ENABLED:
             config.PLUGIN_ENABLED.append(plugin.key)
@@ -180,11 +177,8 @@ async def disable_plugin(plugin_id: str) -> bool:
             logger.exception(f"插件 {plugin.name} 路由卸载失败: {router_error}")
             # 路由卸载失败不影响插件禁用
 
-        # 禁用插件
-        plugin.disable()
-        
-        # 触发回调
-        await plugin.trigger_callbacks("disabled")
+        # 禁用插件 - disable() 方法内部会自动触发回调
+        await plugin.disable()
         
         if plugin.key in config.PLUGIN_ENABLED:
             config.PLUGIN_ENABLED.remove(plugin.key)


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [x] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [ ] 🐛 Bug 修复 (修复一个问题)
- [x] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [x] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述
- 在 NekroPlugin 类中添加 _on_enabled_callbacks 和 _on_disabled_callbacks 两个回调列表
- 实现@on_enabled 和 @on_disabled 装饰器，用于注册插件启用和禁用时的异步回调
- 新增 trigger_callbacks 异步方法，用于同时并行触发对应事件的所有回调并记录异常
- 在 PluginCollector 中，当插件已启用时自动触发 enabled 回调
- 在插件管理器 enable_plugin 和 disable_plugin 方法中，插件启用/禁用后触发对应的生命周期回调

## 🛠️ 实现复杂度

- [x] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 由 Sourcery 提供的摘要

为插件启用/禁用事件添加生命周期回调支持，并确保在插件被切换或以启用状态加载时正确调用这些回调。

新功能：
- 在插件上引入 `on_enabled` 和 `on_disabled` 装饰器，用于为启用/禁用生命周期事件注册异步回调。
- 新增异步 `trigger_callbacks`，在插件状态变化时并行执行已注册的生命周期回调，并记录错误日志。

增强点：
- 当通过管理器启用插件，或插件收集器加载时已处于启用状态时，调用对应的启用生命周期回调。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add lifecycle callback support for plugin enable/disable events and ensure they are invoked when plugins are toggled or loaded in an enabled state.

New Features:
- Introduce on_enabled and on_disabled decorators on plugins to register async callbacks for enable/disable lifecycle events.
- Add async trigger_callbacks to execute registered lifecycle callbacks in parallel with error logging during plugin state changes.

Enhancements:
- Invoke enabled lifecycle callbacks when plugins are enabled via the manager or loaded already enabled through the plugin collector.

</details>