### PR TITLE
fix: replace pickle with JSON for RPC serialization (CWE-502 deserialization vulnerability)

### DIFF
--- a/nekro_agent/routers/rpc.py
+++ b/nekro_agent/routers/rpc.py
@@ -52,8 +52,14 @@ async def rpc_exec(container_key: str, from_chat_key: str, data: Request) -> Res
         await message_service.push_system_message(chat_key=from_chat_key, agent_messages=str(result))
     if method_type == SandboxMethodType.MULTIMODAL_AGENT:
         result = f"<AGENT_RESULT>{json.dumps(result, ensure_ascii=False)}</AGENT_RESULT>"
+
+    if error_message:
+        content = json.dumps({"error": error_message}, ensure_ascii=False)
+    else:
+        content = json.dumps(result, ensure_ascii=False)
+
     return Response(
-        content=error_message or json.dumps(result, ensure_ascii=False),
+        content=content,
         media_type="application/json",
         headers={"Method-Type": method_type.value, "Run-Error": "True" if error_message else "False"},
     )

--- a/nekro_agent/routers/rpc.py
+++ b/nekro_agent/routers/rpc.py
@@ -1,5 +1,4 @@
 import json
-import pickle
 
 from fastapi import APIRouter, Depends, Header, Request, Response
 
@@ -54,7 +53,7 @@ async def rpc_exec(container_key: str, from_chat_key: str, data: Request) -> Res
     if method_type == SandboxMethodType.MULTIMODAL_AGENT:
         result = f"<AGENT_RESULT>{json.dumps(result, ensure_ascii=False)}</AGENT_RESULT>"
     return Response(
-        content=error_message or pickle.dumps(result),
-        media_type="application/octet-stream",
+        content=error_message or json.dumps(result, ensure_ascii=False),
+        media_type="application/json",
         headers={"Method-Type": method_type.value, "Run-Error": "True" if error_message else "False"},
     )

--- a/nekro_agent/services/rpc_service.py
+++ b/nekro_agent/services/rpc_service.py
@@ -1,5 +1,5 @@
 import asyncio
-import pickle
+import json
 from typing import Any, Tuple
 
 from pydantic import ValidationError as PydanticValidationError
@@ -10,8 +10,8 @@ from nekro_agent.schemas.rpc import RPCRequest
 
 def decode_rpc_request(raw_body: bytes) -> RPCRequest:
     try:
-        payload = pickle.loads(raw_body)
-    except (pickle.UnpicklingError, EOFError, AttributeError, ValueError) as e:
+        payload = json.loads(raw_body)
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
         raise ValidationError(reason="RPC 请求格式错误") from e
     try:
         return RPCRequest.model_validate(payload)

--- a/nekro_agent/services/sandbox/ext_caller_code.py
+++ b/nekro_agent/services/sandbox/ext_caller_code.py
@@ -1,7 +1,7 @@
 """沙盒环境下的扩展方法调用代理"""
 
 import importlib
-import pickle as _pickle
+import json as _json
 import subprocess
 import sys
 import urllib.parse
@@ -31,12 +31,12 @@ def __extension_method_proxy(method: Callable):
         """Agent 执行沙盒扩展方法时实际调用的方法"""
 
         body = {"method": method.__name__, "args": args, "kwargs": kwargs}
-        data: bytes = _pickle.dumps(body)
+        data: str = _json.dumps(body, ensure_ascii=False)
         response = _requests.post(
             f"{CHAT_API}/ext/rpc_exec?container_key={CONTAINER_KEY}&from_chat_key={FROM_CHAT_KEY}",
-            data=data,
+            data=data.encode("utf-8"),
             headers={
-                "Content-Type": "application/octet-stream",
+                "Content-Type": "application/json",
                 "X-RPC-Token": RPC_SECRET_KEY,
             },
         )
@@ -46,7 +46,7 @@ def __extension_method_proxy(method: Callable):
                     f"The method `{method.__name__}` returned an error:\n{response.text}",
                 )
                 exit(1)
-            ret_data = _pickle.loads(response.content)
+            ret_data = _json.loads(response.content)
             if response.headers.get("Method-Type") == "agent":
                 print(
                     f"The agent method `{method.__name__}` returned:\n{ret_data}\n[result end]\nPlease continue to generate an appropriate response based on the above information.",

--- a/nekro_agent/services/sandbox/ext_caller_code.py
+++ b/nekro_agent/services/sandbox/ext_caller_code.py
@@ -42,8 +42,10 @@ def __extension_method_proxy(method: Callable):
         )
         if response.status_code == 200:
             if response.headers.get("Run-Error") and response.headers["Run-Error"].lower() == "true":
+                error_data = _json.loads(response.content)
+                error_msg = error_data.get("error", response.text) if isinstance(error_data, dict) else response.text
                 print(
-                    f"The method `{method.__name__}` returned an error:\n{response.text}",
+                    f"The method `{method.__name__}` returned an error:\n{error_msg}",
                 )
                 exit(1)
             ret_data = _json.loads(response.content)


### PR DESCRIPTION
## Vulnerability Summary

**CWE-502 — Deserialization of Untrusted Data**
**Severity:** High (container escape → host RCE)

### Data Flow

1. **Source:** HTTP request body arriving at `POST /api/ext/rpc_exec` (`nekro_agent/routers/rpc.py`)
2. **Sink:** `pickle.loads(raw_body)` in `decode_rpc_request()` (`nekro_agent/services/rpc_service.py:13`)
3. **Response path:** `pickle.dumps(result)` sent back to the caller, deserialized with `pickle.loads(response.content)` in the sandbox client (`nekro_agent/services/sandbox/ext_caller_code.py`)

Python `pickle.loads()` on attacker-controlled input executes arbitrary code during deserialization — this is [well-documented](https://docs.python.org/3/library/pickle.html) in Python's own security warnings.

### Threat Model

The nekro-agent architecture runs LLM-generated Python code inside Docker sandbox containers. These sandbox containers:
- Have the `RPC_SECRET_KEY` token (embedded in `api_caller.py` mounted into every container)
- Have network access to the host via `host.docker.internal` (Docker bridge networking)
- Can therefore reach the `/api/ext/rpc_exec` endpoint and pass token authentication

The host process has `/var/run/docker.sock` mounted, database credentials, JWT secrets, and full filesystem access. A crafted pickle payload sent from a sandbox container to the host's RPC endpoint achieves **container escape to full host compromise**.

### Exploit Sketch

An attacker sends a prompt injection via a chat message. The LLM generates code that runs in the sandbox. That code crafts a pickle payload with a `__reduce__` method that calls `os.system()`, and sends it to the host's RPC endpoint using the embedded `RPC_SECRET_KEY`. The host's `pickle.loads()` executes the payload in the host process context — which has docker.sock access, enabling full host takeover.

```python
# Inside sandbox — has RPC_SECRET_KEY and network access to host
import pickle, os, requests
from api_caller import RPC_SECRET_KEY, CHAT_API, CONTAINER_KEY, FROM_CHAT_KEY

class RCE:
    def __reduce__(self):
        return (os.system, ("curl -s --unix-socket /var/run/docker.sock ...",))

requests.post(
    f"{CHAT_API}/ext/rpc_exec?container_key={CONTAINER_KEY}&from_chat_key={FROM_CHAT_KEY}",
    data=pickle.dumps(RCE()),
    headers={"X-RPC-Token": RPC_SECRET_KEY, "Content-Type": "application/octet-stream"},
)
```

---

## Fix Description

Replace `pickle` serialization with `json` across the entire RPC request/response path:

| File | Change |
|------|--------|
| `nekro_agent/services/rpc_service.py` | `pickle.loads()` → `json.loads()` in `decode_rpc_request()` |
| `nekro_agent/routers/rpc.py` | `pickle.dumps()` → `json.dumps()` for response serialization |
| `nekro_agent/services/sandbox/ext_caller_code.py` | `pickle.dumps()` → `json.dumps()` for request serialization, `pickle.loads()` → `json.loads()` for response deserialization |

### Rationale

- `json.loads()` is safe — it **cannot** execute arbitrary code during parsing
- All RPC payloads are simple JSON-serializable dicts (`{"method": str, "args": list, "kwargs": dict}`)
- All RPC responses are JSON-serializable values (dicts, strings, None, bools, ints)
- No functionality is lost — pickle was never needed here since only standard JSON types are exchanged
- Content-Type headers updated from `application/octet-stream` to `application/json` for correctness

**Changes: 3 files, +10 −11 lines**

---

## Test Results

17 tests all passing:

```
tests/test_rpc_serialization.py::TestPickleRejection::test_pickle_payload_rejected PASSED
tests/test_rpc_serialization.py::TestPickleRejection::test_pickle_rce_payload_rejected PASSED
tests/test_rpc_serialization.py::TestValidRequests::test_basic_request PASSED
tests/test_rpc_serialization.py::TestValidRequests::test_unicode_args PASSED
tests/test_rpc_serialization.py::TestValidRequests::test_empty_args_kwargs PASSED
tests/test_rpc_serialization.py::TestValidRequests::test_nested_structures PASSED
tests/test_rpc_serialization.py::TestValidRequests::test_none_in_args PASSED
tests/test_rpc_serialization.py::TestInvalidRequests::test_empty_body PASSED
tests/test_rpc_serialization.py::TestInvalidRequests::test_invalid_json PASSED
tests/test_rpc_serialization.py::TestInvalidRequests::test_missing_method_field PASSED
tests/test_rpc_serialization.py::TestInvalidRequests::test_binary_garbage PASSED
tests/test_rpc_serialization.py::TestResponseSerialization::test_dict_result PASSED
tests/test_rpc_serialization.py::TestResponseSerialization::test_string_result PASSED
tests/test_rpc_serialization.py::TestResponseSerialization::test_none_result PASSED
tests/test_rpc_serialization.py::TestResponseSerialization::test_bool_result PASSED
tests/test_rpc_serialization.py::TestResponseSerialization::test_int_result PASSED
tests/test_rpc_serialization.py::TestResponseSerialization::test_multimodal_agent_double_encoding PASSED

17 passed in 0.03s
```

Test categories:
- **Security (2 tests):** Confirm pickle payloads (including RCE-crafted payloads with `__reduce__`) are rejected
- **Functional (5 tests):** Valid JSON requests with basic types, unicode, nested structures, None values
- **Error handling (4 tests):** Empty body, invalid JSON, missing required fields, binary garbage
- **Response serialization (6 tests):** Dict, string, None, bool, int results, and multimodal agent double-encoding path

---

## Disprove Analysis

We performed a thorough adversarial review attempting to invalidate this finding:

| Check | Result |
|-------|--------|
| **Auth present?** | Yes — `X-RPC-Token` required (validated against `OsEnv.RPC_SECRET_KEY`). However, the token is embedded in every sandbox container, so sandboxed code can authenticate. |
| **Network reachable?** | Yes — Port 8021 exposed in docker-compose. Sandbox containers have bridge networking with `host.docker.internal` access to host. CORS is `allow_origins=["*"]`. |
| **Deployment isolation?** | Docker containers, but sandbox containers have network access to host. Host process has `/var/run/docker.sock` mounted. No reverse proxy or VPN documented. |
| **Caller trace** | `decode_rpc_request()` called once at `rpc.py:30`. Input is raw HTTP body bytes, no preprocessing or sanitization before `pickle.loads()`. |
| **Input validation?** | None before deserialization. Pydantic `model_validate` runs after, but pickle code execution happens during `pickle.loads()` — before validation. |
| **Prior reports?** | None found via `gh issue list`. |
| **Security policy?** | No SECURITY.md present. |
| **Fix cosmetic?** | **No.** The fix eliminates a container escape vector. No parallel path gives sandbox code equivalent host-level access. Docker isolation is the security boundary, and this pickle endpoint was the deserialization-based escape. |
| **Similar vulns in codebase?** | No other `pickle.loads()` on untrusted input found. No `marshal`, `shelve`, or unsafe `yaml.load`. |

### Existing Mitigations (insufficient)

1. **RPC_SECRET_KEY** — blocks external attackers without the token, but every sandbox container has it
2. **Docker isolation** — sandbox runs in separate containers, but this vulnerability is specifically a container escape
3. **Token checked before body parsing** — unauthenticated requests are rejected before deserialization, but sandbox code passes auth

### Verdict

**CONFIRMED VALID** — High confidence. The fix eliminates a genuine container escape vulnerability via pickle deserialization in the RPC endpoint. The change is minimal, preserves all functionality, and the test suite validates both security and correctness.

---

*

## Summary by Sourcery

在整个沙盒的 RPC 请求/响应路径中，用 JSON 替换不安全的基于 pickle 的 RPC 序列化方式，从而消除远程代码执行风险。

Bug 修复：
- 在 `/api/ext/rpc_exec` 端点中使用 `json` 而不是 `pickle` 来解码 RPC 请求，消除反序列化不受信任数据的风险。
- 将 RPC 响应以 JSON 序列化的负载形式返回，而不是使用 pickle 对象，以防止客户端中任意代码执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace unsafe pickle-based RPC serialization with JSON across the sandbox RPC request/response path to remove a remote code execution vector.

Bug Fixes:
- Eliminate deserialization-of-untrusted-data risk in the /api/ext/rpc_exec endpoint by decoding RPC requests with json instead of pickle.
- Return RPC responses as JSON-serialized payloads instead of pickled objects to prevent arbitrary code execution in clients.

</details>