### PR TITLE
feat: 支持命令中心修改命令权限并增强 na_info 状态显示

### DIFF
--- a/frontend/src/components/common/FilterSelect.tsx
+++ b/frontend/src/components/common/FilterSelect.tsx
@@ -6,7 +6,7 @@ export interface FilterSelectOption {
 }
 
 interface FilterSelectProps extends Omit<FormControlProps, 'onChange'> {
-  label: string
+  label?: string
   value: string
   options: FilterSelectOption[]
   onChange: (value: string) => void
@@ -23,10 +23,10 @@ export default function FilterSelect({
 }: FilterSelectProps) {
   return (
     <FormControl {...props} size={size} fullWidth={fullWidth}>
-      <InputLabel>{label}</InputLabel>
+      {label ? <InputLabel>{label}</InputLabel> : null}
       <Select
         value={value}
-        label={label}
+        label={label || undefined}
         onChange={event => onChange(String(event.target.value))}
       >
         {options.map(option => (

--- a/frontend/src/locales/en-US/settings.json
+++ b/frontend/src/locales/en-US/settings.json
@@ -385,17 +385,26 @@
       "aliases": "Aliases",
       "category": "Category",
       "source": "Source",
-      "permission": "Permission",
+      "permission": "Effective Permission",
       "params": "Parameters",
       "noParams": "No additional parameter notes",
       "required": "Required",
       "defaultValue": "Default",
       "allowedValues": "Allowed values"
     },
+    "permissionEditor": {
+      "label": "Permission Override",
+      "systemOverrideHint": "The system permission currently overrides the command's registered default permission.",
+      "systemDefaultHint": "The system permission currently follows the command's registered default permission.",
+      "channelOverrideHint": "This channel has its own permission override and does not follow the system permission.",
+      "channelInheritedHint": "This channel has no custom permission and follows the effective system permission."
+    },
     "actions": {
       "reset": "Reset to default",
       "enable": "Enable Command",
-      "disable": "Disable Command"
+      "disable": "Disable Command",
+      "resetPermissionDefault": "Restore Default",
+      "resetPermissionInherited": "Restore Inherited Permission"
     },
     "permissions": {
       "public": "Public",
@@ -408,6 +417,10 @@
       "toggleFailed": "Update failed",
       "resetSuccess": "Command state reset",
       "resetFailed": "Reset failed",
+      "permissionUpdateSuccess": "Command permission updated",
+      "permissionUpdateFailed": "Permission update failed",
+      "permissionResetSuccess": "Command permission reset",
+      "permissionResetFailed": "Permission reset failed",
       "executeSent": "Command sent, waiting for output",
       "executeFailed": "Command execution failed"
     },

--- a/frontend/src/locales/zh-CN/settings.json
+++ b/frontend/src/locales/zh-CN/settings.json
@@ -385,17 +385,26 @@
       "aliases": "别名",
       "category": "分类",
       "source": "来源",
-      "permission": "权限",
+      "permission": "生效权限",
       "params": "参数",
       "noParams": "此命令没有额外参数说明",
       "required": "必填",
       "defaultValue": "默认值",
       "allowedValues": "可选值"
     },
+    "permissionEditor": {
+      "label": "权限覆盖",
+      "systemOverrideHint": "当前系统权限已覆盖命令注册时的默认权限。",
+      "systemDefaultHint": "当前系统权限沿用命令注册时的默认权限。",
+      "channelOverrideHint": "当前频道已单独覆盖权限，不受系统权限影响。",
+      "channelInheritedHint": "当前频道未单独设置权限，沿用系统生效权限。"
+    },
     "actions": {
       "reset": "重置为默认",
       "enable": "启用命令",
-      "disable": "禁用命令"
+      "disable": "禁用命令",
+      "resetPermissionDefault": "恢复默认权限",
+      "resetPermissionInherited": "恢复继承权限"
     },
     "permissions": {
       "public": "公开",
@@ -408,6 +417,10 @@
       "toggleFailed": "更新失败",
       "resetSuccess": "已重置命令状态",
       "resetFailed": "重置失败",
+      "permissionUpdateSuccess": "已更新命令权限",
+      "permissionUpdateFailed": "权限更新失败",
+      "permissionResetSuccess": "已重置命令权限",
+      "permissionResetFailed": "权限重置失败",
       "executeSent": "命令已发送，等待输出",
       "executeFailed": "命令执行失败"
     },

--- a/frontend/src/pages/settings/commands.tsx
+++ b/frontend/src/pages/settings/commands.tsx
@@ -36,7 +36,6 @@ import { useChannelDirectoryContext } from '../../contexts/ChannelDirectoryConte
 import type { ChannelDirectoryEntry } from '../../hooks/useChannelDirectory'
 
 type ManageScope = 'system' | 'channel'
-type CommandPermissionValue = 'public' | 'user' | 'advanced' | 'super_user'
 type ManageTargetOption =
   | { type: 'system'; value: 'system'; label: string }
   | { type: 'channel'; value: string; channel: ChannelDirectoryEntry }
@@ -49,8 +48,6 @@ type ParamSchemaItem = {
   enumValues: string[]
 }
 
-const COMMAND_PERMISSION_VALUES: CommandPermissionValue[] = ['public', 'user', 'advanced', 'super_user']
-
 function getCommandDescription(cmd: CommandState, lang: string) {
   return getLocalizedText(cmd.i18n_description, cmd.description, lang)
 }
@@ -61,10 +58,6 @@ function getCommandUsage(cmd: CommandState, lang: string) {
 
 function getCommandCategory(cmd: CommandState, lang: string) {
   return getLocalizedText(cmd.i18n_category, cmd.category, lang)
-}
-
-function isCommandPermissionValue(value: string | null | undefined): value is CommandPermissionValue {
-  return COMMAND_PERMISSION_VALUES.includes(value as CommandPermissionValue)
 }
 
 function getSourceLabel(
@@ -377,14 +370,17 @@ export default function CommandCenterPage() {
       categorySet.set(cmd.category, getCommandCategory(cmd, i18n.language))
       sourceSet.add(cmd.source)
       permissionSet.add(cmd.permission)
+      permissionSet.add(cmd.default_permission)
     })
 
     return {
       categories: Array.from(categorySet.entries()).sort((a, b) => a[1].localeCompare(b[1])),
       sources: Array.from(sourceSet).sort(),
-      permissions: Array.from(permissionSet).sort(),
+      permissions: Array.from(permissionSet).sort((a, b) =>
+        t(`commands.permissions.${a}`, a).localeCompare(t(`commands.permissions.${b}`, b), i18n.language),
+      ),
     }
-  }, [commands, i18n.language])
+  }, [commands, i18n.language, t])
 
   const filteredCommands = useMemo(() => {
     const keyword = deferredSearchInput.trim().toLowerCase()
@@ -457,7 +453,7 @@ export default function CommandCenterPage() {
   })
 
   const setPermissionMutation = useMutation({
-    mutationFn: ({ name, permission }: { name: string; permission: CommandPermissionValue }) =>
+    mutationFn: ({ name, permission }: { name: string; permission: string }) =>
       commandsApi.setCommandPermission(name, permission, managementQueryChatKey),
     onSuccess: () => {
       invalidateCommandQueries()
@@ -543,11 +539,11 @@ export default function CommandCenterPage() {
     [permissions, t],
   )
   const permissionEditorOptions = useMemo(
-    () => COMMAND_PERMISSION_VALUES.map(permission => ({
+    () => permissions.map(permission => ({
       value: permission,
       label: t(`commands.permissions.${permission}`, permission),
     })),
-    [t],
+    [permissions, t],
   )
 
   const manageTargetValue = getManageTargetValue(scope, managementChatKey)
@@ -905,7 +901,7 @@ export default function CommandCenterPage() {
                                 onChange={value => {
                                   if (
                                     !selectedCommand ||
-                                    !isCommandPermissionValue(value) ||
+                                    !value ||
                                     value === selectedCommand.permission
                                   ) {
                                     return

--- a/frontend/src/pages/settings/commands.tsx
+++ b/frontend/src/pages/settings/commands.tsx
@@ -36,6 +36,7 @@ import { useChannelDirectoryContext } from '../../contexts/ChannelDirectoryConte
 import type { ChannelDirectoryEntry } from '../../hooks/useChannelDirectory'
 
 type ManageScope = 'system' | 'channel'
+type CommandPermissionValue = 'public' | 'user' | 'advanced' | 'super_user'
 type ManageTargetOption =
   | { type: 'system'; value: 'system'; label: string }
   | { type: 'channel'; value: string; channel: ChannelDirectoryEntry }
@@ -48,6 +49,8 @@ type ParamSchemaItem = {
   enumValues: string[]
 }
 
+const COMMAND_PERMISSION_VALUES: CommandPermissionValue[] = ['public', 'user', 'advanced', 'super_user']
+
 function getCommandDescription(cmd: CommandState, lang: string) {
   return getLocalizedText(cmd.i18n_description, cmd.description, lang)
 }
@@ -58,6 +61,10 @@ function getCommandUsage(cmd: CommandState, lang: string) {
 
 function getCommandCategory(cmd: CommandState, lang: string) {
   return getLocalizedText(cmd.i18n_category, cmd.category, lang)
+}
+
+function isCommandPermissionValue(value: string | null | undefined): value is CommandPermissionValue {
+  return COMMAND_PERMISSION_VALUES.includes(value as CommandPermissionValue)
 }
 
 function getSourceLabel(
@@ -155,6 +162,34 @@ function getEffectiveStateDescription(
     : t(
         'commands.stateDescription.inheritedDisabled',
         '该频道没有单独设置，当前沿用系统默认停用状态。',
+      )
+}
+
+function getPermissionOverrideDescription(
+  cmd: CommandState,
+  scope: ManageScope,
+  t: TFunction<'settings'>,
+) {
+  if (scope === 'system') {
+    return cmd.has_permission_override
+      ? t(
+          'commands.permissionEditor.systemOverrideHint',
+          '当前系统权限已覆盖命令注册时的默认权限。',
+        )
+      : t(
+          'commands.permissionEditor.systemDefaultHint',
+          '当前系统权限沿用命令注册时的默认权限。',
+        )
+  }
+
+  return cmd.has_permission_override
+    ? t(
+        'commands.permissionEditor.channelOverrideHint',
+        '当前频道已单独覆盖权限，不受系统权限影响。',
+      )
+    : t(
+        'commands.permissionEditor.channelInheritedHint',
+        '当前频道未单独设置权限，沿用系统生效权限。',
       )
 }
 
@@ -265,6 +300,10 @@ export default function CommandCenterPage() {
   const deferredSearchInput = useDeferredValue(searchInput)
   const [commandLine, setCommandLine] = useState('')
   const executePanelRef = useRef<HTMLDivElement | null>(null)
+  const invalidateCommandQueries = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['command-center', 'commands'] })
+    queryClient.invalidateQueries({ queryKey: ['command-center', 'execute-commands'] })
+  }, [queryClient])
 
   const updateParams = useCallback(
     (updates: Record<string, string | null>, replace = true) => {
@@ -398,8 +437,7 @@ export default function CommandCenterPage() {
     mutationFn: ({ name, enabled }: { name: string; enabled: boolean }) =>
       commandsApi.setCommandState(name, enabled, managementQueryChatKey),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['command-center', 'commands'] })
-      queryClient.invalidateQueries({ queryKey: ['command-center', 'execute-commands'] })
+      invalidateCommandQueries()
       notification.success(t('commands.messages.toggleSuccess', '已更新命令状态'))
     },
     onError: () => {
@@ -410,12 +448,34 @@ export default function CommandCenterPage() {
   const resetMutation = useMutation({
     mutationFn: (name: string) => commandsApi.resetCommandState(name, managementQueryChatKey),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['command-center', 'commands'] })
-      queryClient.invalidateQueries({ queryKey: ['command-center', 'execute-commands'] })
+      invalidateCommandQueries()
       notification.success(t('commands.messages.resetSuccess', '已重置命令状态'))
     },
     onError: () => {
       notification.error(t('commands.messages.resetFailed', '重置失败'))
+    },
+  })
+
+  const setPermissionMutation = useMutation({
+    mutationFn: ({ name, permission }: { name: string; permission: CommandPermissionValue }) =>
+      commandsApi.setCommandPermission(name, permission, managementQueryChatKey),
+    onSuccess: () => {
+      invalidateCommandQueries()
+      notification.success(t('commands.messages.permissionUpdateSuccess', '已更新命令权限'))
+    },
+    onError: () => {
+      notification.error(t('commands.messages.permissionUpdateFailed', '权限更新失败'))
+    },
+  })
+
+  const resetPermissionMutation = useMutation({
+    mutationFn: (name: string) => commandsApi.resetCommandPermission(name, managementQueryChatKey),
+    onSuccess: () => {
+      invalidateCommandQueries()
+      notification.success(t('commands.messages.permissionResetSuccess', '已重置命令权限'))
+    },
+    onError: () => {
+      notification.error(t('commands.messages.permissionResetFailed', '权限重置失败'))
     },
   })
 
@@ -481,6 +541,13 @@ export default function CommandCenterPage() {
       })),
     ],
     [permissions, t],
+  )
+  const permissionEditorOptions = useMemo(
+    () => COMMAND_PERMISSION_VALUES.map(permission => ({
+      value: permission,
+      label: t(`commands.permissions.${permission}`, permission),
+    })),
+    [t],
   )
 
   const manageTargetValue = getManageTargetValue(scope, managementChatKey)
@@ -821,8 +888,51 @@ export default function CommandCenterPage() {
                       value={getSourceDetailLabel(selectedCommand, t)}
                     />
                     <DetailRow
-                      label={t('commands.detail.permission', '权限')}
-                      value={t(`commands.permissions.${selectedCommand.permission}`, selectedCommand.permission)}
+                      label={t('commands.detail.permission', '生效权限')}
+                      value=""
+                      content={
+                        <Stack spacing={0.75}>
+                          <Stack
+                            direction={{ xs: 'column', sm: 'row' }}
+                            spacing={1}
+                            alignItems={{ xs: 'stretch', sm: 'center' }}
+                          >
+                            <Box sx={{ flex: 1, minWidth: { xs: '100%', sm: 220 } }}>
+                              <FilterSelect
+                                label=""
+                                value={selectedCommand.permission}
+                                options={permissionEditorOptions}
+                                onChange={value => {
+                                  if (
+                                    !selectedCommand ||
+                                    !isCommandPermissionValue(value) ||
+                                    value === selectedCommand.permission
+                                  ) {
+                                    return
+                                  }
+                                  setPermissionMutation.mutate({
+                                    name: selectedCommand.name,
+                                    permission: value,
+                                  })
+                                }}
+                                disabled={setPermissionMutation.isPending || resetPermissionMutation.isPending}
+                              />
+                            </Box>
+                            <ActionButton
+                              tone="secondary"
+                              onClick={() => resetPermissionMutation.mutate(selectedCommand.name)}
+                              disabled={!selectedCommand.has_permission_override || resetPermissionMutation.isPending}
+                            >
+                              {scope === 'system'
+                                ? t('commands.actions.resetPermissionDefault', '恢复默认权限')
+                                : t('commands.actions.resetPermissionInherited', '恢复继承权限')}
+                            </ActionButton>
+                          </Stack>
+                          <Typography variant="caption" color="text.secondary">
+                            {getPermissionOverrideDescription(selectedCommand, scope, t)}
+                          </Typography>
+                        </Stack>
+                      }
                     />
                   </Box>
                 </Box>

--- a/frontend/src/services/api/commands.ts
+++ b/frontend/src/services/api/commands.ts
@@ -18,11 +18,13 @@ export interface CommandState {
   description: string
   usage: string
   permission: string
+  default_permission: string
   category: string
   source: string
   source_display_name: string
   enabled: boolean
   has_channel_override: boolean
+  has_permission_override: boolean
   params_schema?: Record<string, unknown>
   i18n_description?: I18nDict
   i18n_usage?: I18nDict
@@ -63,6 +65,27 @@ export const commandsApi = {
 
   resetCommandState: async (commandName: string, chatKey?: string): Promise<boolean> => {
     const response = await axios.post<{ ok: boolean }>('/commands/reset-state', {
+      command_name: commandName,
+      chat_key: chatKey || undefined,
+    })
+    return response.data.ok
+  },
+
+  setCommandPermission: async (
+    commandName: string,
+    permission: 'public' | 'user' | 'advanced' | 'super_user',
+    chatKey?: string,
+  ): Promise<boolean> => {
+    const response = await axios.post<{ ok: boolean }>('/commands/set-permission', {
+      command_name: commandName,
+      permission,
+      chat_key: chatKey || undefined,
+    })
+    return response.data.ok
+  },
+
+  resetCommandPermission: async (commandName: string, chatKey?: string): Promise<boolean> => {
+    const response = await axios.post<{ ok: boolean }>('/commands/reset-permission', {
       command_name: commandName,
       chat_key: chatKey || undefined,
     })

--- a/frontend/src/services/api/commands.ts
+++ b/frontend/src/services/api/commands.ts
@@ -73,7 +73,7 @@ export const commandsApi = {
 
   setCommandPermission: async (
     commandName: string,
-    permission: 'public' | 'user' | 'advanced' | 'super_user',
+    permission: string,
     chatKey?: string,
   ): Promise<boolean> => {
     const response = await axios.post<{ ok: boolean }>('/commands/set-permission', {

--- a/nekro_agent/core/os_env.py
+++ b/nekro_agent/core/os_env.py
@@ -96,6 +96,15 @@ TIMER_ONE_SHOT_PERSIST_PATH: str = TIMER_SYSTEM_DIR + "/one_shot_timers.json"
 CALENDAR_SYSTEM_DIR: str = APP_SYSTEM_DIR + "/calendar"
 CALENDAR_CN_HOLIDAY_DIR: str = CALENDAR_SYSTEM_DIR + "/cn_holidays"
 
+# =============================================================================
+# Command data paths (under DATA_DIR/configs)
+# =============================================================================
+COMMAND_STATE_DIR: str = OsEnv.DATA_DIR + "/configs/command_states"
+COMMAND_SYSTEM_STATE_FILE: str = COMMAND_STATE_DIR + "/system.json"
+COMMAND_CHANNEL_STATE_DIR: str = COMMAND_STATE_DIR + "/channels"
+COMMAND_SYSTEM_PERMISSION_FILE: str = COMMAND_STATE_DIR + "/system_permissions.json"
+COMMAND_CHANNEL_PERMISSION_DIR: str = COMMAND_STATE_DIR + "/channel_permissions"
+
 
 # 设置上传目录及其子目录权限
 with contextlib.suppress(Exception):

--- a/nekro_agent/routers/commands.py
+++ b/nekro_agent/routers/commands.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
 
 from nekro_agent.models.db_user import DBUser
+from nekro_agent.services.command.base import CommandPermission
 from nekro_agent.services.command.schemas import CommandOutputSegment
 from nekro_agent.services.user.deps import get_current_active_user
 from nekro_agent.services.user.perm import Role, require_role
@@ -25,11 +26,13 @@ class CommandStateResponse(BaseModel):
     description: str
     usage: str
     permission: str
+    default_permission: str
     category: str
     source: str  # "built_in" | 插件 key
     source_display_name: str
     enabled: bool
     has_channel_override: bool
+    has_permission_override: bool
     params_schema: Optional[dict] = None
     i18n_description: Optional[dict[str, str]] = None
     i18n_usage: Optional[dict[str, str]] = None
@@ -88,6 +91,43 @@ async def reset_command_state(
     from nekro_agent.services.command.manager import command_manager
 
     await command_manager.reset_command_state(req.command_name, req.chat_key)
+    return {"ok": True}
+
+
+class SetCommandPermissionRequest(BaseModel):
+    command_name: str
+    permission: CommandPermission
+    chat_key: Optional[str] = None
+
+
+@router.post("/set-permission", summary="设置命令权限")
+@require_role(Role.Admin)
+async def set_command_permission(
+    req: SetCommandPermissionRequest,
+    _current_user: DBUser = Depends(get_current_active_user),
+):
+    """设置命令权限覆盖"""
+    from nekro_agent.services.command.manager import command_manager
+
+    await command_manager.set_command_permission(req.command_name, req.permission, req.chat_key)
+    return {"ok": True}
+
+
+class ResetCommandPermissionRequest(BaseModel):
+    command_name: str
+    chat_key: Optional[str] = None
+
+
+@router.post("/reset-permission", summary="重置命令权限")
+@require_role(Role.Admin)
+async def reset_command_permission(
+    req: ResetCommandPermissionRequest,
+    _current_user: DBUser = Depends(get_current_active_user),
+):
+    """重置命令权限覆盖（回退到上级）"""
+    from nekro_agent.services.command.manager import command_manager
+
+    await command_manager.reset_command_permission(req.command_name, req.chat_key)
     return {"ok": True}
 
 

--- a/nekro_agent/services/command/base.py
+++ b/nekro_agent/services/command/base.py
@@ -85,7 +85,10 @@ class BaseCommand(ABC):
         context: CommandExecutionContext,
     ) -> tuple[bool, Optional[str]]:
         """默认权限检查，子类可覆盖"""
-        perm = self.metadata.permission
+        from nekro_agent.services.command.manager import command_manager
+
+        meta = self.metadata
+        perm = command_manager.get_command_permission(meta.name, meta.permission, context.chat_key)
         if perm == CommandPermission.PUBLIC:
             return True, None
         if perm == CommandPermission.SUPER_USER:

--- a/nekro_agent/services/command/built_in/info.py
+++ b/nekro_agent/services/command/built_in/info.py
@@ -43,7 +43,7 @@ def _resolve_channel_agent_runtime_status(chat_key: str) -> tuple[str, str]:
     if active_status is not None:
         return t(zh_CN="LLM 生成中", en_US="LLM generating"), "llm_generating"
 
-    return t(zh_CN="无", en_US="None"), "none"
+    return t(zh_CN="闲置中", en_US="Idle"), "none"
 
 
 class NaInfoCommand(BaseCommand):

--- a/nekro_agent/services/command/built_in/info.py
+++ b/nekro_agent/services/command/built_in/info.py
@@ -8,6 +8,15 @@ from nekro_agent.services.command.ctl import CmdCtl
 from nekro_agent.services.command.schemas import CommandExecutionContext, CommandResponse
 
 
+def _format_channel_status(status: str) -> str:
+    status_labels = {
+        "active": t(zh_CN="启用", en_US="Enabled"),
+        "disabled": t(zh_CN="停用", en_US="Disabled"),
+        "observe": t(zh_CN="旁观", en_US="Observe"),
+    }
+    return status_labels.get(status, t(zh_CN="未知", en_US="Unknown"))
+
+
 def _format_agent_runtime_phase(phase: str | None) -> str:
     phase_labels = {
         "llm_generating": t(zh_CN="LLM 生成中", en_US="LLM generating"),
@@ -60,13 +69,16 @@ class NaInfoCommand(BaseCommand):
         db_chat_channel = await DBChatChannel.get_channel(chat_key=context.chat_key)
         preset = await db_chat_channel.get_preset()
         version = get_app_version()
+        channel_status = db_chat_channel.channel_status.value
+        channel_status_label = _format_channel_status(channel_status)
         runtime_status_label, runtime_status_phase = _resolve_channel_agent_runtime_status(context.chat_key)
 
         title = t(zh_CN="[Nekro-Agent 信息]", en_US="[Nekro-Agent Info]")
         subtitle = t(zh_CN="> 更智能、更优雅的代理执行 AI", en_US="> Smarter, more elegant agent execution AI")
         chat_settings = t(zh_CN="========聊天设定========", en_US="========Chat Settings========")
         preset_label = t(zh_CN="人设", en_US="Preset")
-        runtime_status_label_title = t(zh_CN="当前频道机器人运行状态", en_US="Current Channel Agent Runtime Status")
+        channel_status_label_title = t(zh_CN="频道状态", en_US="Channel Status")
+        runtime_status_label_title = t(zh_CN="Agent状态", en_US="Agent Status")
 
         message = (
             f"{title}\n"
@@ -77,6 +89,7 @@ class NaInfoCommand(BaseCommand):
             f"In-Docker: {OsEnv.RUN_IN_DOCKER}\n"
             f"{chat_settings}\n"
             f"{preset_label}: {preset.name}\n"
+            f"{channel_status_label_title}: {channel_status_label}\n"
             f"{runtime_status_label_title}: {runtime_status_label}"
         )
 
@@ -86,6 +99,8 @@ class NaInfoCommand(BaseCommand):
                 "version": version,
                 "in_docker": OsEnv.RUN_IN_DOCKER,
                 "preset": preset.name,
+                "channel_status": channel_status_label,
+                "channel_status_value": channel_status,
                 "agent_runtime_status": runtime_status_label,
                 "agent_runtime_phase": runtime_status_phase,
             },

--- a/nekro_agent/services/command/built_in/info.py
+++ b/nekro_agent/services/command/built_in/info.py
@@ -1,9 +1,40 @@
 """内置命令 - 信息类: na_info, na_help"""
 
+from typing import Any
+
 from nekro_agent.schemas.i18n import i18n_text, t
 from nekro_agent.services.command.base import BaseCommand, CommandMetadata, CommandPermission
 from nekro_agent.services.command.ctl import CmdCtl
 from nekro_agent.services.command.schemas import CommandExecutionContext, CommandResponse
+
+
+def _format_agent_runtime_phase(phase: str | None) -> str:
+    phase_labels = {
+        "llm_generating": t(zh_CN="LLM 生成中", en_US="LLM generating"),
+        "llm_retrying": t(zh_CN="LLM 重试中", en_US="LLM retrying"),
+        "sandbox_running": t(zh_CN="沙盒执行中", en_US="Sandbox running"),
+        "sandbox_stopped": t(zh_CN="沙盒结束", en_US="Sandbox stopped"),
+        "iterating": t(zh_CN="进入迭代", en_US="Iterating"),
+        "completed": t(zh_CN="已完成", en_US="Completed"),
+        "failed": t(zh_CN="生成失败", en_US="Generation failed"),
+    }
+    return phase_labels.get(phase or "", t(zh_CN="未知", en_US="Unknown"))
+
+
+def _resolve_channel_agent_runtime_status(chat_key: str) -> tuple[str, str]:
+    from nekro_agent.services.system_broadcast import get_state_snapshot
+
+    snapshot = get_state_snapshot()
+    runtime_status: dict[str, Any] | None = snapshot.get("agent_runtime_status", {}).get(chat_key)
+    if runtime_status is not None:
+        phase = str(runtime_status.get("phase") or "")
+        return _format_agent_runtime_phase(phase), phase
+
+    active_status = snapshot.get("agent_active", {}).get(chat_key)
+    if active_status is not None:
+        return t(zh_CN="LLM 生成中", en_US="LLM generating"), "llm_generating"
+
+    return t(zh_CN="无", en_US="None"), "none"
 
 
 class NaInfoCommand(BaseCommand):
@@ -16,7 +47,7 @@ class NaInfoCommand(BaseCommand):
             aliases=[],
             description="查看系统信息",
             i18n_description=i18n_text(zh_CN="查看系统信息", en_US="View system information"),
-            permission=CommandPermission.SUPER_USER,
+            permission=CommandPermission.USER,
             category="信息",
             i18n_category=i18n_text(zh_CN="信息", en_US="Information"),
         )
@@ -30,12 +61,14 @@ class NaInfoCommand(BaseCommand):
         effective_config = await db_chat_channel.get_effective_config()
         preset = await db_chat_channel.get_preset()
         version = get_app_version()
+        runtime_status_label, runtime_status_phase = _resolve_channel_agent_runtime_status(context.chat_key)
 
         title = t(zh_CN="[Nekro-Agent 信息]", en_US="[Nekro-Agent Info]")
         subtitle = t(zh_CN="> 更智能、更优雅的代理执行 AI", en_US="> Smarter, more elegant agent execution AI")
         chat_settings = t(zh_CN="========聊天设定========", en_US="========Chat Settings========")
         preset_label = t(zh_CN="人设", en_US="Preset")
         model_group_label = t(zh_CN="当前模型组", en_US="Current Model Group")
+        runtime_status_label_title = t(zh_CN="当前频道机器人运行状态", en_US="Current Channel Agent Runtime Status")
 
         message = (
             f"{title}\n"
@@ -46,7 +79,8 @@ class NaInfoCommand(BaseCommand):
             f"In-Docker: {OsEnv.RUN_IN_DOCKER}\n"
             f"{chat_settings}\n"
             f"{preset_label}: {preset.name}\n"
-            f"{model_group_label}: {effective_config.USE_MODEL_GROUP}"
+            f"{model_group_label}: {effective_config.USE_MODEL_GROUP}\n"
+            f"{runtime_status_label_title}: {runtime_status_label}"
         )
 
         return CmdCtl.success(
@@ -56,6 +90,8 @@ class NaInfoCommand(BaseCommand):
                 "in_docker": OsEnv.RUN_IN_DOCKER,
                 "preset": preset.name,
                 "model_group": effective_config.USE_MODEL_GROUP,
+                "agent_runtime_status": runtime_status_label,
+                "agent_runtime_phase": runtime_status_phase,
             },
         )
 

--- a/nekro_agent/services/command/built_in/info.py
+++ b/nekro_agent/services/command/built_in/info.py
@@ -58,7 +58,6 @@ class NaInfoCommand(BaseCommand):
         from nekro_agent.tools.common_util import get_app_version
 
         db_chat_channel = await DBChatChannel.get_channel(chat_key=context.chat_key)
-        effective_config = await db_chat_channel.get_effective_config()
         preset = await db_chat_channel.get_preset()
         version = get_app_version()
         runtime_status_label, runtime_status_phase = _resolve_channel_agent_runtime_status(context.chat_key)
@@ -67,7 +66,6 @@ class NaInfoCommand(BaseCommand):
         subtitle = t(zh_CN="> 更智能、更优雅的代理执行 AI", en_US="> Smarter, more elegant agent execution AI")
         chat_settings = t(zh_CN="========聊天设定========", en_US="========Chat Settings========")
         preset_label = t(zh_CN="人设", en_US="Preset")
-        model_group_label = t(zh_CN="当前模型组", en_US="Current Model Group")
         runtime_status_label_title = t(zh_CN="当前频道机器人运行状态", en_US="Current Channel Agent Runtime Status")
 
         message = (
@@ -79,7 +77,6 @@ class NaInfoCommand(BaseCommand):
             f"In-Docker: {OsEnv.RUN_IN_DOCKER}\n"
             f"{chat_settings}\n"
             f"{preset_label}: {preset.name}\n"
-            f"{model_group_label}: {effective_config.USE_MODEL_GROUP}\n"
             f"{runtime_status_label_title}: {runtime_status_label}"
         )
 
@@ -89,7 +86,6 @@ class NaInfoCommand(BaseCommand):
                 "version": version,
                 "in_docker": OsEnv.RUN_IN_DOCKER,
                 "preset": preset.name,
-                "model_group": effective_config.USE_MODEL_GROUP,
                 "agent_runtime_status": runtime_status_label,
                 "agent_runtime_phase": runtime_status_phase,
             },

--- a/nekro_agent/services/command/completion.py
+++ b/nekro_agent/services/command/completion.py
@@ -35,13 +35,14 @@ class CommandCompletionProvider:
         for meta in command_registry.list_all_commands():
             if not command_manager.is_command_enabled(meta.name, chat_key):
                 continue
+            effective_permission = command_manager.get_command_permission(meta.name, meta.permission, chat_key)
             entries.append(
                 CommandCompletionEntry(
                     name=meta.name,
                     description=meta.get_description(lang)[:100],
                     usage=meta.get_usage(lang),
                     category=meta.get_category(lang),
-                    permission=meta.permission,
+                    permission=effective_permission,
                     params_schema=meta.params_schema,
                 )
             )

--- a/nekro_agent/services/command/manager.py
+++ b/nekro_agent/services/command/manager.py
@@ -7,6 +7,7 @@ from typing import Optional
 from nonebot import logger
 
 from nekro_agent.core.os_env import OsEnv
+from nekro_agent.schemas.errors import ValidationError
 from nekro_agent.services.command.base import CommandPermission
 
 COMMAND_STATE_DIR = Path(OsEnv.DATA_DIR) / "configs" / "command_states"
@@ -75,7 +76,10 @@ class CommandManager:
         return normalized
 
     def _load_system_permission_state(self) -> dict[str, CommandPermission]:
-        """加载系统级权限覆盖（带缓存）"""
+        """加载系统级权限覆盖（带缓存）。
+
+        返回内部共享缓存，调用方仅应在 setter 流程中原地修改并立即持久化。
+        """
         if self._system_permission_cache is None:
             if SYSTEM_PERMISSION_FILE.exists():
                 try:
@@ -90,7 +94,10 @@ class CommandManager:
         return self._system_permission_cache
 
     def _load_channel_permission_state(self, chat_key: str) -> dict[str, CommandPermission]:
-        """加载频道级权限覆盖（带缓存）"""
+        """加载频道级权限覆盖（带缓存）。
+
+        返回内部共享缓存，调用方仅应在 setter 流程中原地修改并立即持久化。
+        """
         if chat_key not in self._channel_permission_cache:
             path = CHANNEL_PERMISSION_DIR / f"{chat_key}.json"
             if path.exists():
@@ -181,7 +188,7 @@ class CommandManager:
 
         command = command_registry.resolve(command_name)
         if command is None:
-            raise ValueError(f"命令不存在: {command_name}")
+            raise ValidationError(reason=f"命令不存在: {command_name}")
         return command.metadata.permission
 
     async def set_command_enabled(
@@ -191,6 +198,7 @@ class CommandManager:
         chat_key: Optional[str] = None,
     ) -> None:
         """设置命令启用状态"""
+        self._get_command_default_permission(command_name)
         if chat_key:
             state = self._load_channel_state(chat_key)
             state[command_name] = enabled

--- a/nekro_agent/services/command/manager.py
+++ b/nekro_agent/services/command/manager.py
@@ -7,10 +7,13 @@ from typing import Optional
 from nonebot import logger
 
 from nekro_agent.core.os_env import OsEnv
+from nekro_agent.services.command.base import CommandPermission
 
 COMMAND_STATE_DIR = Path(OsEnv.DATA_DIR) / "configs" / "command_states"
 SYSTEM_STATE_FILE = COMMAND_STATE_DIR / "system.json"
 CHANNEL_STATE_DIR = COMMAND_STATE_DIR / "channels"
+SYSTEM_PERMISSION_FILE = COMMAND_STATE_DIR / "system_permissions.json"
+CHANNEL_PERMISSION_DIR = COMMAND_STATE_DIR / "channel_permissions"
 
 
 class CommandManager:
@@ -22,8 +25,11 @@ class CommandManager:
     def __init__(self):
         COMMAND_STATE_DIR.mkdir(parents=True, exist_ok=True)
         CHANNEL_STATE_DIR.mkdir(parents=True, exist_ok=True)
+        CHANNEL_PERMISSION_DIR.mkdir(parents=True, exist_ok=True)
         self._system_cache: Optional[dict[str, bool]] = None
         self._channel_cache: dict[str, dict[str, bool]] = {}
+        self._system_permission_cache: Optional[dict[str, CommandPermission]] = None
+        self._channel_permission_cache: dict[str, dict[str, CommandPermission]] = {}
 
     def _load_system_state(self) -> dict[str, bool]:
         """加载系统级状态（带缓存）"""
@@ -53,6 +59,51 @@ class CommandManager:
                 self._channel_cache[chat_key] = {}
         return self._channel_cache[chat_key]
 
+    @staticmethod
+    def _normalize_permission_state(raw_state: object) -> dict[str, CommandPermission]:
+        if not isinstance(raw_state, dict):
+            return {}
+
+        normalized: dict[str, CommandPermission] = {}
+        for command_name, permission in raw_state.items():
+            if not isinstance(command_name, str) or not isinstance(permission, str):
+                continue
+            try:
+                normalized[command_name] = CommandPermission(permission)
+            except ValueError:
+                logger.warning(f"检测到无效命令权限配置，已忽略: {command_name}={permission}")
+        return normalized
+
+    def _load_system_permission_state(self) -> dict[str, CommandPermission]:
+        """加载系统级权限覆盖（带缓存）"""
+        if self._system_permission_cache is None:
+            if SYSTEM_PERMISSION_FILE.exists():
+                try:
+                    raw_state = json.loads(SYSTEM_PERMISSION_FILE.read_text(encoding="utf-8"))
+                    self._system_permission_cache = self._normalize_permission_state(raw_state)
+                except (json.JSONDecodeError, OSError) as e:
+                    logger.warning(f"加载系统级命令权限失败: {e}")
+                    self._system_permission_cache = {}
+            else:
+                self._system_permission_cache = {}
+        assert self._system_permission_cache is not None
+        return self._system_permission_cache
+
+    def _load_channel_permission_state(self, chat_key: str) -> dict[str, CommandPermission]:
+        """加载频道级权限覆盖（带缓存）"""
+        if chat_key not in self._channel_permission_cache:
+            path = CHANNEL_PERMISSION_DIR / f"{chat_key}.json"
+            if path.exists():
+                try:
+                    raw_state = json.loads(path.read_text(encoding="utf-8"))
+                    self._channel_permission_cache[chat_key] = self._normalize_permission_state(raw_state)
+                except (json.JSONDecodeError, OSError) as e:
+                    logger.warning(f"加载频道 {chat_key} 命令权限失败: {e}")
+                    self._channel_permission_cache[chat_key] = {}
+            else:
+                self._channel_permission_cache[chat_key] = {}
+        return self._channel_permission_cache[chat_key]
+
     def _save_system_state(self, state: dict[str, bool]) -> None:
         SYSTEM_STATE_FILE.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
         self._system_cache = state
@@ -64,6 +115,24 @@ class CommandManager:
         else:
             path.unlink(missing_ok=True)  # 空状态则删除文件
         self._channel_cache[chat_key] = state
+
+    def _save_system_permission_state(self, state: dict[str, CommandPermission]) -> None:
+        SYSTEM_PERMISSION_FILE.write_text(
+            json.dumps({key: value.value for key, value in state.items()}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        self._system_permission_cache = state
+
+    def _save_channel_permission_state(self, chat_key: str, state: dict[str, CommandPermission]) -> None:
+        path = CHANNEL_PERMISSION_DIR / f"{chat_key}.json"
+        if state:
+            path.write_text(
+                json.dumps({key: value.value for key, value in state.items()}, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        else:
+            path.unlink(missing_ok=True)
+        self._channel_permission_cache[chat_key] = state
 
     def is_command_enabled(self, command_name: str, chat_key: Optional[str] = None) -> bool:
         """查询命令是否启用（频道级 > 系统级 > 默认）"""
@@ -77,6 +146,43 @@ class CommandManager:
             return system_state[command_name]
 
         return True  # 默认启用
+
+    def get_command_permission(
+        self,
+        command_name: str,
+        default_permission: CommandPermission,
+        chat_key: Optional[str] = None,
+    ) -> CommandPermission:
+        """查询命令生效权限（频道级 > 系统级 > 注册默认）"""
+        if chat_key:
+            channel_state = self._load_channel_permission_state(chat_key)
+            if command_name in channel_state:
+                return channel_state[command_name]
+
+        system_state = self._load_system_permission_state()
+        if command_name in system_state:
+            return system_state[command_name]
+
+        return default_permission
+
+    def has_permission_override(
+        self,
+        command_name: str,
+        chat_key: Optional[str] = None,
+    ) -> bool:
+        """当前作用域下是否存在权限覆盖"""
+        if chat_key:
+            return command_name in self._load_channel_permission_state(chat_key)
+        return command_name in self._load_system_permission_state()
+
+    @staticmethod
+    def _get_command_default_permission(command_name: str) -> CommandPermission:
+        from nekro_agent.services.command.registry import command_registry
+
+        command = command_registry.resolve(command_name)
+        if command is None:
+            raise ValueError(f"命令不存在: {command_name}")
+        return command.metadata.permission
 
     async def set_command_enabled(
         self,
@@ -95,6 +201,34 @@ class CommandManager:
             self._save_system_state(state)
         await self.notify_commands_changed(chat_key)
 
+    async def set_command_permission(
+        self,
+        command_name: str,
+        permission: CommandPermission | str,
+        chat_key: Optional[str] = None,
+    ) -> None:
+        """设置命令权限覆盖"""
+        normalized_permission = (
+            permission if isinstance(permission, CommandPermission) else CommandPermission(permission)
+        )
+        default_permission = self._get_command_default_permission(command_name)
+        if chat_key:
+            state = self._load_channel_permission_state(chat_key)
+            inherited_permission = self.get_command_permission(command_name, default_permission, None)
+            if normalized_permission == inherited_permission:
+                state.pop(command_name, None)
+            else:
+                state[command_name] = normalized_permission
+            self._save_channel_permission_state(chat_key, state)
+        else:
+            state = self._load_system_permission_state()
+            if normalized_permission == default_permission:
+                state.pop(command_name, None)
+            else:
+                state[command_name] = normalized_permission
+            self._save_system_permission_state(state)
+        await self.notify_commands_changed(chat_key)
+
     async def reset_command_state(
         self,
         command_name: str,
@@ -109,6 +243,23 @@ class CommandManager:
             state = self._load_system_state()
             state.pop(command_name, None)
             self._save_system_state(state)
+        await self.notify_commands_changed(chat_key)
+
+    async def reset_command_permission(
+        self,
+        command_name: str,
+        chat_key: Optional[str] = None,
+    ) -> None:
+        """重置命令权限覆盖（删除覆盖，回退到上级）"""
+        if chat_key:
+            state = self._load_channel_permission_state(chat_key)
+            state.pop(command_name, None)
+            self._save_channel_permission_state(chat_key, state)
+        else:
+            state = self._load_system_permission_state()
+            state.pop(command_name, None)
+            self._save_system_permission_state(state)
+        await self.notify_commands_changed(chat_key)
 
     async def get_all_command_states(
         self,
@@ -123,7 +274,9 @@ class CommandManager:
         result = []
         for meta in commands:
             enabled = self.is_command_enabled(meta.name, chat_key)
+            permission = self.get_command_permission(meta.name, meta.permission, chat_key)
             has_channel_override = chat_key is not None and meta.name in channel_state
+            has_permission_override = self.has_permission_override(meta.name, chat_key)
             source_display_name = "内置" if meta.source == "built_in" else meta.source
             if meta.source != "built_in":
                 plugin = plugin_collector.get_plugin(meta.source)
@@ -136,12 +289,14 @@ class CommandManager:
                 "aliases": meta.aliases,
                 "description": meta.description,
                 "usage": meta.usage,
-                "permission": meta.permission.value,
+                "permission": permission.value,
+                "default_permission": meta.permission.value,
                 "category": meta.category,
                 "source": meta.source,
                 "source_display_name": source_display_name,
                 "enabled": enabled,
                 "has_channel_override": has_channel_override,
+                "has_permission_override": has_permission_override,
                 "params_schema": meta.params_schema,
                 "i18n_description": meta.i18n_description,
                 "i18n_usage": meta.i18n_usage,
@@ -164,6 +319,8 @@ class CommandManager:
         """清除缓存（配置文件外部修改后调用）"""
         self._system_cache = None
         self._channel_cache.clear()
+        self._system_permission_cache = None
+        self._channel_permission_cache.clear()
 
 
 command_manager = CommandManager()

--- a/nekro_agent/services/command/manager.py
+++ b/nekro_agent/services/command/manager.py
@@ -6,15 +6,15 @@ from typing import Optional
 
 from nonebot import logger
 
-from nekro_agent.core.os_env import OsEnv
+from nekro_agent.core.os_env import (
+    COMMAND_CHANNEL_PERMISSION_DIR,
+    COMMAND_CHANNEL_STATE_DIR,
+    COMMAND_STATE_DIR,
+    COMMAND_SYSTEM_PERMISSION_FILE,
+    COMMAND_SYSTEM_STATE_FILE,
+)
 from nekro_agent.schemas.errors import ValidationError
 from nekro_agent.services.command.base import CommandPermission
-
-COMMAND_STATE_DIR = Path(OsEnv.DATA_DIR) / "configs" / "command_states"
-SYSTEM_STATE_FILE = COMMAND_STATE_DIR / "system.json"
-CHANNEL_STATE_DIR = COMMAND_STATE_DIR / "channels"
-SYSTEM_PERMISSION_FILE = COMMAND_STATE_DIR / "system_permissions.json"
-CHANNEL_PERMISSION_DIR = COMMAND_STATE_DIR / "channel_permissions"
 
 
 class CommandManager:
@@ -24,9 +24,9 @@ class CommandManager:
     """
 
     def __init__(self):
-        COMMAND_STATE_DIR.mkdir(parents=True, exist_ok=True)
-        CHANNEL_STATE_DIR.mkdir(parents=True, exist_ok=True)
-        CHANNEL_PERMISSION_DIR.mkdir(parents=True, exist_ok=True)
+        Path(COMMAND_STATE_DIR).mkdir(parents=True, exist_ok=True)
+        Path(COMMAND_CHANNEL_STATE_DIR).mkdir(parents=True, exist_ok=True)
+        Path(COMMAND_CHANNEL_PERMISSION_DIR).mkdir(parents=True, exist_ok=True)
         self._system_cache: Optional[dict[str, bool]] = None
         self._channel_cache: dict[str, dict[str, bool]] = {}
         self._system_permission_cache: Optional[dict[str, CommandPermission]] = None
@@ -35,9 +35,10 @@ class CommandManager:
     def _load_system_state(self) -> dict[str, bool]:
         """加载系统级状态（带缓存）"""
         if self._system_cache is None:
-            if SYSTEM_STATE_FILE.exists():
+            system_state_file = Path(COMMAND_SYSTEM_STATE_FILE)
+            if system_state_file.exists():
                 try:
-                    self._system_cache = json.loads(SYSTEM_STATE_FILE.read_text(encoding="utf-8"))
+                    self._system_cache = json.loads(system_state_file.read_text(encoding="utf-8"))
                 except (json.JSONDecodeError, OSError) as e:
                     logger.warning(f"加载系统级命令状态失败: {e}")
                     self._system_cache = {}
@@ -49,7 +50,7 @@ class CommandManager:
     def _load_channel_state(self, chat_key: str) -> dict[str, bool]:
         """加载频道级状态（带缓存）"""
         if chat_key not in self._channel_cache:
-            path = CHANNEL_STATE_DIR / f"{chat_key}.json"
+            path = Path(COMMAND_CHANNEL_STATE_DIR) / f"{chat_key}.json"
             if path.exists():
                 try:
                     self._channel_cache[chat_key] = json.loads(path.read_text(encoding="utf-8"))
@@ -81,9 +82,10 @@ class CommandManager:
         返回内部共享缓存，调用方仅应在 setter 流程中原地修改并立即持久化。
         """
         if self._system_permission_cache is None:
-            if SYSTEM_PERMISSION_FILE.exists():
+            system_permission_file = Path(COMMAND_SYSTEM_PERMISSION_FILE)
+            if system_permission_file.exists():
                 try:
-                    raw_state = json.loads(SYSTEM_PERMISSION_FILE.read_text(encoding="utf-8"))
+                    raw_state = json.loads(system_permission_file.read_text(encoding="utf-8"))
                     self._system_permission_cache = self._normalize_permission_state(raw_state)
                 except (json.JSONDecodeError, OSError) as e:
                     logger.warning(f"加载系统级命令权限失败: {e}")
@@ -99,7 +101,7 @@ class CommandManager:
         返回内部共享缓存，调用方仅应在 setter 流程中原地修改并立即持久化。
         """
         if chat_key not in self._channel_permission_cache:
-            path = CHANNEL_PERMISSION_DIR / f"{chat_key}.json"
+            path = Path(COMMAND_CHANNEL_PERMISSION_DIR) / f"{chat_key}.json"
             if path.exists():
                 try:
                     raw_state = json.loads(path.read_text(encoding="utf-8"))
@@ -112,26 +114,26 @@ class CommandManager:
         return self._channel_permission_cache[chat_key]
 
     def _save_system_state(self, state: dict[str, bool]) -> None:
-        SYSTEM_STATE_FILE.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+        Path(COMMAND_SYSTEM_STATE_FILE).write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
         self._system_cache = state
 
     def _save_channel_state(self, chat_key: str, state: dict[str, bool]) -> None:
-        path = CHANNEL_STATE_DIR / f"{chat_key}.json"
+        path = Path(COMMAND_CHANNEL_STATE_DIR) / f"{chat_key}.json"
         if state:
             path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
         else:
-            path.unlink(missing_ok=True)  # 空状态则删除文件
+            path.unlink(missing_ok=True)
         self._channel_cache[chat_key] = state
 
     def _save_system_permission_state(self, state: dict[str, CommandPermission]) -> None:
-        SYSTEM_PERMISSION_FILE.write_text(
+        Path(COMMAND_SYSTEM_PERMISSION_FILE).write_text(
             json.dumps({key: value.value for key, value in state.items()}, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
         self._system_permission_cache = state
 
     def _save_channel_permission_state(self, chat_key: str, state: dict[str, CommandPermission]) -> None:
-        path = CHANNEL_PERMISSION_DIR / f"{chat_key}.json"
+        path = Path(COMMAND_CHANNEL_PERMISSION_DIR) / f"{chat_key}.json"
         if state:
             path.write_text(
                 json.dumps({key: value.value for key, value in state.items()}, ensure_ascii=False, indent=2),
@@ -152,7 +154,7 @@ class CommandManager:
         if command_name in system_state:
             return system_state[command_name]
 
-        return True  # 默认启用
+        return True
 
     def get_command_permission(
         self,


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [√] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [√] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [√] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [ ] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [ ] 🐛 Bug 修复 (修复一个问题)
- [√] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

<!-- 请详细描述你的PR解决了什么问题，为什么这个变更是必要的 -->

## 🔗 相关 Issue

<!-- 如果有相关Issue，请在此处引用 (例如: Closes #123, Fixes #456) -->

## 📸 修改效果截图

<!-- 如果你的PR包含UI变更或功能改进，请提供修改前后的对比截图 -->

## 🛠️ 实现复杂度

<!-- 请选择一项 -->

- [√] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

<!-- 如果实现方式比较复杂或特殊，可以在这里详细说明技术实现 -->

## 🧪 测试步骤 (可选)

<!-- 说明如何测试这个PR的功能，例如:
1. 进入...页面
2. 点击...按钮
3. 观察...结果
-->

## Summary by Sourcery

在系统和频道范围内新增可配置的命令权限覆盖，并通过指令中心（command center）UI 对其进行管理，同时增强 `na_info` 命令以报告代理（agent）的运行时状态。

**新功能：**
- 持久化系统级与频道级的命令权限覆盖，并在执行或列出命令时计算生效的综合权限。
- 在指令中心中提供 API 和前端控件，用于查看和修改命令权限，包括将权限重置为默认值或继承值。
- 扩展内置命令 `na_info`，以展示当前频道的代理运行时状态，并放宽其默认权限到普通用户可用。

**增强改进：**
- 在命令状态响应和 UI 中包含权限覆盖的元数据以及默认权限，并重构选择组件，使其支持无标签的使用场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable command permission overrides at system and channel scope and expose them through the command center UI, while enhancing the na_info command to report agent runtime status.

New Features:
- Persist system- and channel-level command permission overrides and compute effective permissions when executing or listing commands.
- Expose APIs and frontend controls in the command center to view and modify command permissions, including resetting to defaults or inherited values.
- Extend the na_info built-in command to surface current agent runtime status for the active channel and relax its default permission to regular users.

Enhancements:
- Include permission override metadata and default permission in command state responses and UI, and refactor select component to support unlabeled usage.

</details>