### PR TITLE
fix: 修复下载云端插件时模块名重复检查无效的问题

### DIFF
--- a/nekro_agent/routers/cloud/plugins_market.py
+++ b/nekro_agent/routers/cloud/plugins_market.py
@@ -225,8 +225,9 @@ async def download_plugin(
     _current_user: DBUser = Depends(get_current_active_user),
 ) -> ActionResponse:
     """下载云端插件到本地"""
-    local_plugins = plugin_collector.package_data.get_remote_ids()
-    if module_name in local_plugins:
+    # 检查本地是否已存在同模块名的插件（排除已下架的）
+    existing_package = plugin_collector.package_data.get_package_by_module(module_name)
+    if existing_package:
         raise ConflictError(resource="插件")
 
     response = await get_plugin(module_name)


### PR DESCRIPTION
## Summary

- 修复 `download_plugin` 函数中模块名重复检查无效的问题
- **根因**: `get_remote_ids()` 返回 `remote_id`（UUID 列表），而 `module_name` 是字符串（如 `"emotion"`），两者类型不匹配导致 `in` 检查永远返回 `False`
- **修复**: 改用 `get_package_by_module(module_name)` 按模块名精确查找

## Test plan

- [ ] 下载一个云端插件（例如 `emotion`）
- [ ] 再次尝试下载同名插件，确认返回冲突错误
- [ ] 确认已下架后重新上架的插件可以正常下载

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

错误修复：
- 修正重复云插件下载检查机制，改为使用基于模块的包查找方式，并在本地已存在同名模块插件时正确触发冲突提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct duplicate cloud plugin download check to use module-based package lookup and properly raise a conflict when a plugin with the same module name already exists locally.

</details>