### PR TITLE
修正 na_info 的 CC 沙盒状态显示

### DIFF
--- a/nekro_agent/routers/workspaces.py
+++ b/nekro_agent/routers/workspaces.py
@@ -66,6 +66,7 @@ from nekro_agent.services.memory.semantic_writer import persist_cc_task_memory
 from nekro_agent.services.runtime_state import is_shutting_down
 from nekro_agent.services.system_broadcast import (
     WorkspaceCcActiveEvent,
+    WorkspaceCcRuntimePhase,
     WorkspaceCcRuntimeStatusEvent,
     WorkspaceStatusEvent,
     publish_system_event,
@@ -3217,7 +3218,7 @@ async def user_send_to_cc(
 
         async def _runtime_status(
             *,
-            phase: Literal["queued", "running", "responding", "completed", "failed", "cancelled"],
+            phase: WorkspaceCcRuntimePhase,
             current_tool: Optional[str] = None,
             queue_length: int = 0,
             last_block_kind: Optional[Literal["tool_call", "tool_result", "text_chunk"]] = None,

--- a/nekro_agent/services/command/built_in/info.py
+++ b/nekro_agent/services/command/built_in/info.py
@@ -1,6 +1,7 @@
 """内置命令 - 信息类: na_info, na_help"""
 
-from typing import Any, Literal
+from enum import StrEnum
+from typing import Any
 
 from pydantic import ValidationError
 
@@ -9,18 +10,6 @@ from nekro_agent.services.command.base import BaseCommand, CommandMetadata, Comm
 from nekro_agent.services.command.ctl import CmdCtl
 from nekro_agent.services.command.schemas import CommandExecutionContext, CommandResponse
 from nekro_agent.services.system_broadcast import (
-    WORKSPACE_CC_PHASE_CANCELLED,
-    WORKSPACE_CC_PHASE_COMPLETED,
-    WORKSPACE_CC_PHASE_FAILED,
-    WORKSPACE_CC_PHASE_QUEUED,
-    WORKSPACE_CC_PHASE_RESPONDING,
-    WORKSPACE_CC_PHASE_RUNNING,
-    WORKSPACE_CC_RUNTIME_PHASE_VALUES,
-    WORKSPACE_STATUS_ACTIVE,
-    WORKSPACE_STATUS_DELETING,
-    WORKSPACE_STATUS_FAILED,
-    WORKSPACE_STATUS_STOPPED,
-    WORKSPACE_STATUS_VALUES,
     WorkspaceCcActiveState,
     WorkspaceCcRuntimePhase,
     WorkspaceCcRuntimeStatusState,
@@ -28,11 +17,59 @@ from nekro_agent.services.system_broadcast import (
     WorkspaceStatusValue,
 )
 
-WORKSPACE_SANDBOX_STATUS_IDLE = "idle"
-WORKSPACE_SANDBOX_STATUS_UNBOUND = "unbound"
-WORKSPACE_SANDBOX_STATUS_UNKNOWN = "unknown"
 
-WorkspaceSandboxDisplayStatus = WorkspaceStatusValue | WorkspaceCcRuntimePhase | Literal["idle", "unbound", "unknown"]
+class WorkspaceSandboxDisplayStatus(StrEnum):
+    IDLE = "idle"
+    UNBOUND = "unbound"
+    UNKNOWN = "unknown"
+
+    ACTIVE = "active"
+    STOPPED = "stopped"
+    FAILED = "failed"
+    DELETING = "deleting"
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    RESPONDING = "responding"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+    @classmethod
+    def from_workspace_status(cls, status: WorkspaceStatusValue | str) -> "WorkspaceSandboxDisplayStatus | None":
+        parsed = cls._try_parse(status)
+        if parsed in {cls.ACTIVE, cls.STOPPED, cls.FAILED, cls.DELETING}:
+            return parsed
+        return None
+
+    @classmethod
+    def from_cc_phase(cls, phase: WorkspaceCcRuntimePhase | str) -> "WorkspaceSandboxDisplayStatus | None":
+        parsed = cls._try_parse(phase)
+        if parsed in {cls.QUEUED, cls.RUNNING, cls.RESPONDING, cls.COMPLETED, cls.FAILED, cls.CANCELLED}:
+            return parsed
+        return None
+
+    @classmethod
+    def _try_parse(cls, value: str) -> "WorkspaceSandboxDisplayStatus | None":
+        try:
+            return cls(value)
+        except ValueError:
+            return None
+
+    def to_label(self) -> str:
+        labels = {
+            WorkspaceSandboxDisplayStatus.IDLE: t(zh_CN="闲置中", en_US="Idle"),
+            WorkspaceSandboxDisplayStatus.UNBOUND: t(zh_CN="未绑定", en_US="Unbound"),
+            WorkspaceSandboxDisplayStatus.ACTIVE: t(zh_CN="闲置中", en_US="Idle"),
+            WorkspaceSandboxDisplayStatus.STOPPED: t(zh_CN="已停止", en_US="Stopped"),
+            WorkspaceSandboxDisplayStatus.FAILED: t(zh_CN="执行失败", en_US="Failed"),
+            WorkspaceSandboxDisplayStatus.DELETING: t(zh_CN="删除中", en_US="Deleting"),
+            WorkspaceSandboxDisplayStatus.QUEUED: t(zh_CN="排队中", en_US="Queued"),
+            WorkspaceSandboxDisplayStatus.RUNNING: t(zh_CN="执行中", en_US="Running"),
+            WorkspaceSandboxDisplayStatus.RESPONDING: t(zh_CN="回传结果", en_US="Responding"),
+            WorkspaceSandboxDisplayStatus.COMPLETED: t(zh_CN="已完成", en_US="Completed"),
+            WorkspaceSandboxDisplayStatus.CANCELLED: t(zh_CN="已中止", en_US="Cancelled"),
+        }
+        return labels.get(self, t(zh_CN="未知", en_US="Unknown"))
 
 
 def _format_channel_status(status: str) -> str:
@@ -58,22 +95,7 @@ def _format_agent_runtime_phase(phase: str | None) -> str:
 
 
 def _format_workspace_sandbox_status(status: WorkspaceSandboxDisplayStatus) -> str:
-    status_labels = {
-        WORKSPACE_SANDBOX_STATUS_IDLE: t(zh_CN="闲置中", en_US="Idle"),
-        WORKSPACE_CC_PHASE_QUEUED: t(zh_CN="排队中", en_US="Queued"),
-        WORKSPACE_CC_PHASE_RUNNING: t(zh_CN="执行中", en_US="Running"),
-        WORKSPACE_CC_PHASE_RESPONDING: t(zh_CN="回传结果", en_US="Responding"),
-        WORKSPACE_CC_PHASE_COMPLETED: t(zh_CN="已完成", en_US="Completed"),
-        WORKSPACE_CC_PHASE_FAILED: t(zh_CN="执行失败", en_US="Failed"),
-        WORKSPACE_CC_PHASE_CANCELLED: t(zh_CN="已中止", en_US="Cancelled"),
-        # `active` 是底层容器可用状态；展示层会将其归一化为“闲置中”。
-        WORKSPACE_STATUS_ACTIVE: t(zh_CN="闲置中", en_US="Idle"),
-        WORKSPACE_STATUS_STOPPED: t(zh_CN="已停止", en_US="Stopped"),
-        WORKSPACE_STATUS_FAILED: t(zh_CN="执行失败", en_US="Failed"),
-        WORKSPACE_STATUS_DELETING: t(zh_CN="删除中", en_US="Deleting"),
-        WORKSPACE_SANDBOX_STATUS_UNBOUND: t(zh_CN="未绑定", en_US="Unbound"),
-    }
-    return status_labels.get(status, t(zh_CN="未知", en_US="Unknown"))
+    return status.to_label()
 
 
 def _resolve_channel_agent_runtime_status(chat_key: str) -> tuple[str, str]:
@@ -105,10 +127,7 @@ def _get_workspace_status_state_from_snapshot(snapshot: dict[str, Any], workspac
 
 def _get_workspace_status_from_snapshot(snapshot: dict[str, Any], workspace_id: int) -> WorkspaceStatusValue | None:
     workspace_status = _get_workspace_status_state_from_snapshot(snapshot, workspace_id)
-    if workspace_status is not None and workspace_status.status in WORKSPACE_STATUS_VALUES:
-        return workspace_status.status
-
-    return None
+    return workspace_status.status if workspace_status is not None else None
 
 
 def _get_workspace_cc_runtime_state_from_snapshot(
@@ -138,43 +157,51 @@ def _get_workspace_cc_active_state_from_snapshot(snapshot: dict[str, Any], works
 
 def _get_workspace_cc_phase_from_snapshot(snapshot: dict[str, Any], workspace_id: int) -> WorkspaceCcRuntimePhase | None:
     runtime_status = _get_workspace_cc_runtime_state_from_snapshot(snapshot, workspace_id)
-    if runtime_status is not None and runtime_status.phase in WORKSPACE_CC_RUNTIME_PHASE_VALUES:
+    if runtime_status is not None:
         return runtime_status.phase
 
     if _get_workspace_cc_active_state_from_snapshot(snapshot, workspace_id) is not None:
-        return WORKSPACE_CC_PHASE_RUNNING
+        return WorkspaceSandboxDisplayStatus.RUNNING.value
 
     return None
 
 
 async def _resolve_bound_workspace_sandbox_status(workspace_id: int | None) -> tuple[str, WorkspaceSandboxDisplayStatus]:
     if workspace_id is None:
-        return _format_workspace_sandbox_status(WORKSPACE_SANDBOX_STATUS_UNBOUND), WORKSPACE_SANDBOX_STATUS_UNBOUND
+        return _format_workspace_sandbox_status(WorkspaceSandboxDisplayStatus.UNBOUND), WorkspaceSandboxDisplayStatus.UNBOUND
 
     from nekro_agent.models.db_workspace import DBWorkspace
     from nekro_agent.services.system_broadcast import get_state_snapshot
 
     snapshot = get_state_snapshot()
-    snapshot_status = _get_workspace_status_from_snapshot(snapshot, workspace_id)
+    snapshot_status = WorkspaceSandboxDisplayStatus.from_workspace_status(
+        _get_workspace_status_from_snapshot(snapshot, workspace_id) or ""
+    )
     if snapshot_status is not None:
-        if snapshot_status == WORKSPACE_STATUS_ACTIVE:
-            snapshot_phase = _get_workspace_cc_phase_from_snapshot(snapshot, workspace_id)
+        if snapshot_status is WorkspaceSandboxDisplayStatus.ACTIVE:
+            snapshot_phase = WorkspaceSandboxDisplayStatus.from_cc_phase(
+                _get_workspace_cc_phase_from_snapshot(snapshot, workspace_id) or ""
+            )
             if snapshot_phase is not None:
                 return _format_workspace_sandbox_status(snapshot_phase), snapshot_phase
 
             # `active` 仅表示工作区容器可用；没有 CC 任务时，展示层统一视为闲置中。
-            return _format_workspace_sandbox_status(WORKSPACE_SANDBOX_STATUS_IDLE), WORKSPACE_SANDBOX_STATUS_IDLE
+            return _format_workspace_sandbox_status(WorkspaceSandboxDisplayStatus.IDLE), WorkspaceSandboxDisplayStatus.IDLE
 
         return _format_workspace_sandbox_status(snapshot_status), snapshot_status
 
     workspace = await DBWorkspace.get_or_none(id=workspace_id)
     if workspace is None:
-        return t(zh_CN="未知", en_US="Unknown"), WORKSPACE_SANDBOX_STATUS_UNKNOWN
+        return t(zh_CN="未知", en_US="Unknown"), WorkspaceSandboxDisplayStatus.UNKNOWN
 
-    if workspace.status == WORKSPACE_STATUS_ACTIVE:
-        return _format_workspace_sandbox_status(WORKSPACE_SANDBOX_STATUS_IDLE), WORKSPACE_SANDBOX_STATUS_IDLE
+    workspace_status = WorkspaceSandboxDisplayStatus.from_workspace_status(workspace.status)
+    if workspace_status is None:
+        return t(zh_CN="未知", en_US="Unknown"), WorkspaceSandboxDisplayStatus.UNKNOWN
 
-    return _format_workspace_sandbox_status(workspace.status), workspace.status
+    if workspace_status is WorkspaceSandboxDisplayStatus.ACTIVE:
+        return _format_workspace_sandbox_status(WorkspaceSandboxDisplayStatus.IDLE), WorkspaceSandboxDisplayStatus.IDLE
+
+    return _format_workspace_sandbox_status(workspace_status), workspace_status
 
 
 class NaInfoCommand(BaseCommand):
@@ -240,7 +267,7 @@ class NaInfoCommand(BaseCommand):
                 "agent_runtime_status": runtime_status_label,
                 "agent_runtime_phase": runtime_status_phase,
                 "cc_sandbox_status": cc_sandbox_status_label,
-                "cc_sandbox_status_value": cc_sandbox_status_value,
+                "cc_sandbox_status_value": cc_sandbox_status_value.value,
                 "bound_workspace_id": db_chat_channel.workspace_id,
             },
         )

--- a/nekro_agent/services/command/built_in/info.py
+++ b/nekro_agent/services/command/built_in/info.py
@@ -30,6 +30,23 @@ def _format_agent_runtime_phase(phase: str | None) -> str:
     return phase_labels.get(phase or "", t(zh_CN="未知", en_US="Unknown"))
 
 
+def _format_workspace_sandbox_status(status: str) -> str:
+    status_labels = {
+        "idle": t(zh_CN="闲置中", en_US="Idle"),
+        "queued": t(zh_CN="排队中", en_US="Queued"),
+        "running": t(zh_CN="执行中", en_US="Running"),
+        "responding": t(zh_CN="回传结果", en_US="Responding"),
+        "completed": t(zh_CN="已完成", en_US="Completed"),
+        "cancelled": t(zh_CN="已中止", en_US="Cancelled"),
+        "active": t(zh_CN="闲置中", en_US="Idle"),
+        "stopped": t(zh_CN="已停止", en_US="Stopped"),
+        "failed": t(zh_CN="执行失败", en_US="Failed"),
+        "deleting": t(zh_CN="删除中", en_US="Deleting"),
+        "unbound": t(zh_CN="未绑定", en_US="Unbound"),
+    }
+    return status_labels.get(status, t(zh_CN="未知", en_US="Unknown"))
+
+
 def _resolve_channel_agent_runtime_status(chat_key: str) -> tuple[str, str]:
     from nekro_agent.services.system_broadcast import get_state_snapshot
 
@@ -44,6 +61,41 @@ def _resolve_channel_agent_runtime_status(chat_key: str) -> tuple[str, str]:
         return t(zh_CN="LLM 生成中", en_US="LLM generating"), "llm_generating"
 
     return t(zh_CN="闲置中", en_US="Idle"), "none"
+
+
+async def _resolve_bound_workspace_sandbox_status(workspace_id: int | None) -> tuple[str, str]:
+    if workspace_id is None:
+        return _format_workspace_sandbox_status("unbound"), "unbound"
+
+    from nekro_agent.models.db_workspace import DBWorkspace
+    from nekro_agent.services.system_broadcast import get_state_snapshot
+
+    snapshot = get_state_snapshot()
+    workspace_status: dict[str, Any] | None = snapshot.get("workspace_status", {}).get(str(workspace_id))
+    if workspace_status is not None:
+        status = str(workspace_status.get("status") or "")
+        if status == "active":
+            runtime_status: dict[str, Any] | None = snapshot.get("workspace_cc_runtime_status", {}).get(str(workspace_id))
+            if runtime_status is not None:
+                phase = str(runtime_status.get("phase") or "")
+                return _format_workspace_sandbox_status(phase), phase or "unknown"
+
+            active_status: dict[str, Any] | None = snapshot.get("workspace_cc_active", {}).get(str(workspace_id))
+            if active_status is not None:
+                return _format_workspace_sandbox_status("running"), "running"
+
+            return _format_workspace_sandbox_status("idle"), "idle"
+
+        return _format_workspace_sandbox_status(status), status or "unknown"
+
+    workspace = await DBWorkspace.get_or_none(id=workspace_id)
+    if workspace is None:
+        return t(zh_CN="未知", en_US="Unknown"), "unknown"
+
+    if workspace.status == "active":
+        return _format_workspace_sandbox_status("idle"), "idle"
+
+    return _format_workspace_sandbox_status(workspace.status), workspace.status
 
 
 class NaInfoCommand(BaseCommand):
@@ -72,6 +124,9 @@ class NaInfoCommand(BaseCommand):
         channel_status = db_chat_channel.channel_status.value
         channel_status_label = _format_channel_status(channel_status)
         runtime_status_label, runtime_status_phase = _resolve_channel_agent_runtime_status(context.chat_key)
+        cc_sandbox_status_label, cc_sandbox_status_value = await _resolve_bound_workspace_sandbox_status(
+            db_chat_channel.workspace_id
+        )
 
         title = t(zh_CN="[Nekro-Agent 信息]", en_US="[Nekro-Agent Info]")
         subtitle = t(zh_CN="> 更智能、更优雅的代理执行 AI", en_US="> Smarter, more elegant agent execution AI")
@@ -79,6 +134,7 @@ class NaInfoCommand(BaseCommand):
         preset_label = t(zh_CN="人设", en_US="Preset")
         channel_status_label_title = t(zh_CN="频道状态", en_US="Channel Status")
         runtime_status_label_title = t(zh_CN="Agent状态", en_US="Agent Status")
+        cc_sandbox_status_label_title = t(zh_CN="CC沙盒状态", en_US="CC Sandbox Status")
 
         message = (
             f"{title}\n"
@@ -90,7 +146,8 @@ class NaInfoCommand(BaseCommand):
             f"{chat_settings}\n"
             f"{preset_label}: {preset.name}\n"
             f"{channel_status_label_title}: {channel_status_label}\n"
-            f"{runtime_status_label_title}: {runtime_status_label}"
+            f"{runtime_status_label_title}: {runtime_status_label}\n"
+            f"{cc_sandbox_status_label_title}: {cc_sandbox_status_label}"
         )
 
         return CmdCtl.success(
@@ -103,6 +160,9 @@ class NaInfoCommand(BaseCommand):
                 "channel_status_value": channel_status,
                 "agent_runtime_status": runtime_status_label,
                 "agent_runtime_phase": runtime_status_phase,
+                "cc_sandbox_status": cc_sandbox_status_label,
+                "cc_sandbox_status_value": cc_sandbox_status_value,
+                "bound_workspace_id": db_chat_channel.workspace_id,
             },
         )
 

--- a/nekro_agent/services/command/built_in/info.py
+++ b/nekro_agent/services/command/built_in/info.py
@@ -1,11 +1,28 @@
 """内置命令 - 信息类: na_info, na_help"""
 
-from typing import Any
+from typing import Any, Literal
 
 from nekro_agent.schemas.i18n import i18n_text, t
 from nekro_agent.services.command.base import BaseCommand, CommandMetadata, CommandPermission
 from nekro_agent.services.command.ctl import CmdCtl
 from nekro_agent.services.command.schemas import CommandExecutionContext, CommandResponse
+from nekro_agent.services.system_broadcast import (
+    WORKSPACE_CC_PHASE_RUNNING,
+    WORKSPACE_CC_RUNTIME_PHASE_VALUES,
+    WORKSPACE_STATUS_ACTIVE,
+    WORKSPACE_STATUS_DELETING,
+    WORKSPACE_STATUS_FAILED,
+    WORKSPACE_STATUS_STOPPED,
+    WORKSPACE_STATUS_VALUES,
+    WorkspaceCcRuntimePhase,
+    WorkspaceStatusValue,
+)
+
+WORKSPACE_SANDBOX_STATUS_IDLE = "idle"
+WORKSPACE_SANDBOX_STATUS_UNBOUND = "unbound"
+WORKSPACE_SANDBOX_STATUS_UNKNOWN = "unknown"
+
+WorkspaceSandboxDisplayStatus = WorkspaceStatusValue | WorkspaceCcRuntimePhase | Literal["idle", "unbound", "unknown"]
 
 
 def _format_channel_status(status: str) -> str:
@@ -30,19 +47,18 @@ def _format_agent_runtime_phase(phase: str | None) -> str:
     return phase_labels.get(phase or "", t(zh_CN="未知", en_US="Unknown"))
 
 
-def _format_workspace_sandbox_status(status: str) -> str:
+def _format_workspace_sandbox_status(status: WorkspaceSandboxDisplayStatus) -> str:
     status_labels = {
-        "idle": t(zh_CN="闲置中", en_US="Idle"),
+        WORKSPACE_SANDBOX_STATUS_IDLE: t(zh_CN="闲置中", en_US="Idle"),
         "queued": t(zh_CN="排队中", en_US="Queued"),
-        "running": t(zh_CN="执行中", en_US="Running"),
+        WORKSPACE_CC_PHASE_RUNNING: t(zh_CN="执行中", en_US="Running"),
         "responding": t(zh_CN="回传结果", en_US="Responding"),
         "completed": t(zh_CN="已完成", en_US="Completed"),
         "cancelled": t(zh_CN="已中止", en_US="Cancelled"),
-        "active": t(zh_CN="闲置中", en_US="Idle"),
-        "stopped": t(zh_CN="已停止", en_US="Stopped"),
-        "failed": t(zh_CN="执行失败", en_US="Failed"),
-        "deleting": t(zh_CN="删除中", en_US="Deleting"),
-        "unbound": t(zh_CN="未绑定", en_US="Unbound"),
+        WORKSPACE_STATUS_STOPPED: t(zh_CN="已停止", en_US="Stopped"),
+        WORKSPACE_STATUS_FAILED: t(zh_CN="执行失败", en_US="Failed"),
+        WORKSPACE_STATUS_DELETING: t(zh_CN="删除中", en_US="Deleting"),
+        WORKSPACE_SANDBOX_STATUS_UNBOUND: t(zh_CN="未绑定", en_US="Unbound"),
     }
     return status_labels.get(status, t(zh_CN="未知", en_US="Unknown"))
 
@@ -63,37 +79,58 @@ def _resolve_channel_agent_runtime_status(chat_key: str) -> tuple[str, str]:
     return t(zh_CN="闲置中", en_US="Idle"), "none"
 
 
-async def _resolve_bound_workspace_sandbox_status(workspace_id: int | None) -> tuple[str, str]:
+def _get_workspace_status_from_snapshot(snapshot: dict[str, Any], workspace_id: int) -> WorkspaceStatusValue | None:
+    workspace_status = snapshot.get("workspace_status", {}).get(str(workspace_id))
+    if not isinstance(workspace_status, dict):
+        return None
+
+    status = workspace_status.get("status")
+    if isinstance(status, str) and status in WORKSPACE_STATUS_VALUES:
+        return status
+
+    return None
+
+
+def _get_workspace_cc_phase_from_snapshot(snapshot: dict[str, Any], workspace_id: int) -> WorkspaceCcRuntimePhase | None:
+    runtime_status = snapshot.get("workspace_cc_runtime_status", {}).get(str(workspace_id))
+    if isinstance(runtime_status, dict):
+        phase = runtime_status.get("phase")
+        if isinstance(phase, str) and phase in WORKSPACE_CC_RUNTIME_PHASE_VALUES:
+            return phase
+
+    active_status = snapshot.get("workspace_cc_active", {}).get(str(workspace_id))
+    if isinstance(active_status, dict):
+        return WORKSPACE_CC_PHASE_RUNNING
+
+    return None
+
+
+async def _resolve_bound_workspace_sandbox_status(workspace_id: int | None) -> tuple[str, WorkspaceSandboxDisplayStatus]:
     if workspace_id is None:
-        return _format_workspace_sandbox_status("unbound"), "unbound"
+        return _format_workspace_sandbox_status(WORKSPACE_SANDBOX_STATUS_UNBOUND), WORKSPACE_SANDBOX_STATUS_UNBOUND
 
     from nekro_agent.models.db_workspace import DBWorkspace
     from nekro_agent.services.system_broadcast import get_state_snapshot
 
     snapshot = get_state_snapshot()
-    workspace_status: dict[str, Any] | None = snapshot.get("workspace_status", {}).get(str(workspace_id))
-    if workspace_status is not None:
-        status = str(workspace_status.get("status") or "")
-        if status == "active":
-            runtime_status: dict[str, Any] | None = snapshot.get("workspace_cc_runtime_status", {}).get(str(workspace_id))
-            if runtime_status is not None:
-                phase = str(runtime_status.get("phase") or "")
-                return _format_workspace_sandbox_status(phase), phase or "unknown"
+    snapshot_status = _get_workspace_status_from_snapshot(snapshot, workspace_id)
+    if snapshot_status is not None:
+        if snapshot_status == WORKSPACE_STATUS_ACTIVE:
+            snapshot_phase = _get_workspace_cc_phase_from_snapshot(snapshot, workspace_id)
+            if snapshot_phase is not None:
+                return _format_workspace_sandbox_status(snapshot_phase), snapshot_phase
 
-            active_status: dict[str, Any] | None = snapshot.get("workspace_cc_active", {}).get(str(workspace_id))
-            if active_status is not None:
-                return _format_workspace_sandbox_status("running"), "running"
+            # `active` 仅表示工作区容器可用；没有 CC 任务时，展示层统一视为闲置中。
+            return _format_workspace_sandbox_status(WORKSPACE_SANDBOX_STATUS_IDLE), WORKSPACE_SANDBOX_STATUS_IDLE
 
-            return _format_workspace_sandbox_status("idle"), "idle"
-
-        return _format_workspace_sandbox_status(status), status or "unknown"
+        return _format_workspace_sandbox_status(snapshot_status), snapshot_status
 
     workspace = await DBWorkspace.get_or_none(id=workspace_id)
     if workspace is None:
-        return t(zh_CN="未知", en_US="Unknown"), "unknown"
+        return t(zh_CN="未知", en_US="Unknown"), WORKSPACE_SANDBOX_STATUS_UNKNOWN
 
-    if workspace.status == "active":
-        return _format_workspace_sandbox_status("idle"), "idle"
+    if workspace.status == WORKSPACE_STATUS_ACTIVE:
+        return _format_workspace_sandbox_status(WORKSPACE_SANDBOX_STATUS_IDLE), WORKSPACE_SANDBOX_STATUS_IDLE
 
     return _format_workspace_sandbox_status(workspace.status), workspace.status
 

--- a/nekro_agent/services/command/built_in/info.py
+++ b/nekro_agent/services/command/built_in/info.py
@@ -5,10 +5,12 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from nekro_agent.models.db_workspace import DBWorkspace
 from nekro_agent.schemas.i18n import i18n_text, t
 from nekro_agent.services.command.base import BaseCommand, CommandMetadata, CommandPermission
 from nekro_agent.services.command.ctl import CmdCtl
 from nekro_agent.services.command.schemas import CommandExecutionContext, CommandResponse
+from nekro_agent.services.plugin.task import task as task_api
 from nekro_agent.services.system_broadcast import (
     WorkspaceCcActiveState,
     WorkspaceCcRuntimePhase,
@@ -16,6 +18,7 @@ from nekro_agent.services.system_broadcast import (
     WorkspaceStatusState,
     WorkspaceStatusValue,
 )
+from nekro_agent.services.workspace.client import CCSandboxClient
 
 
 class WorkspaceSandboxDisplayStatus(StrEnum):
@@ -166,13 +169,51 @@ def _get_workspace_cc_phase_from_snapshot(snapshot: dict[str, Any], workspace_id
     return None
 
 
-async def _resolve_bound_workspace_sandbox_status(workspace_id: int | None) -> tuple[str, WorkspaceSandboxDisplayStatus]:
+async def _resolve_workspace_sandbox_live_status(
+    workspace: DBWorkspace,
+    *,
+    chat_key: str,
+) -> WorkspaceSandboxDisplayStatus:
+    if workspace.status != WorkspaceSandboxDisplayStatus.ACTIVE.value:
+        workspace_status = WorkspaceSandboxDisplayStatus.from_workspace_status(workspace.status)
+        return workspace_status or WorkspaceSandboxDisplayStatus.UNKNOWN
+
+    client = CCSandboxClient(workspace)
+    queue_status = await client.get_workspace_queue(workspace_id="default")
+    current_task = queue_status.get("current_task") or {}
+    current_source_chat_key = str(current_task.get("source_chat_key") or "")
+    channel_task_running = task_api.is_running("cc_delegate", chat_key)
+
+    if current_task:
+        if channel_task_running and current_source_chat_key and current_source_chat_key != chat_key:
+            return WorkspaceSandboxDisplayStatus.QUEUED
+        return WorkspaceSandboxDisplayStatus.RUNNING
+
+    if channel_task_running:
+        return WorkspaceSandboxDisplayStatus.QUEUED
+
+    return WorkspaceSandboxDisplayStatus.IDLE
+
+
+async def _resolve_bound_workspace_sandbox_status(
+    workspace_id: int | None,
+    *,
+    chat_key: str,
+) -> tuple[str, WorkspaceSandboxDisplayStatus]:
     if workspace_id is None:
         return _format_workspace_sandbox_status(WorkspaceSandboxDisplayStatus.UNBOUND), WorkspaceSandboxDisplayStatus.UNBOUND
 
-    from nekro_agent.models.db_workspace import DBWorkspace
     from nekro_agent.services.system_broadcast import get_state_snapshot
 
+    workspace = await DBWorkspace.get_or_none(id=workspace_id)
+    if workspace is None:
+        return t(zh_CN="未知", en_US="Unknown"), WorkspaceSandboxDisplayStatus.UNKNOWN
+
+    live_status = await _resolve_workspace_sandbox_live_status(workspace, chat_key=chat_key)
+    if live_status is not WorkspaceSandboxDisplayStatus.UNKNOWN:
+        return _format_workspace_sandbox_status(live_status), live_status
+
+    # 兜底保留旧快照链路，避免极端情况下完全丢状态。
     snapshot = get_state_snapshot()
     snapshot_status = WorkspaceSandboxDisplayStatus.from_workspace_status(
         _get_workspace_status_from_snapshot(snapshot, workspace_id) or ""
@@ -184,24 +225,10 @@ async def _resolve_bound_workspace_sandbox_status(workspace_id: int | None) -> t
             )
             if snapshot_phase is not None:
                 return _format_workspace_sandbox_status(snapshot_phase), snapshot_phase
-
-            # `active` 仅表示工作区容器可用；没有 CC 任务时，展示层统一视为闲置中。
             return _format_workspace_sandbox_status(WorkspaceSandboxDisplayStatus.IDLE), WorkspaceSandboxDisplayStatus.IDLE
-
         return _format_workspace_sandbox_status(snapshot_status), snapshot_status
 
-    workspace = await DBWorkspace.get_or_none(id=workspace_id)
-    if workspace is None:
-        return t(zh_CN="未知", en_US="Unknown"), WorkspaceSandboxDisplayStatus.UNKNOWN
-
-    workspace_status = WorkspaceSandboxDisplayStatus.from_workspace_status(workspace.status)
-    if workspace_status is None:
-        return t(zh_CN="未知", en_US="Unknown"), WorkspaceSandboxDisplayStatus.UNKNOWN
-
-    if workspace_status is WorkspaceSandboxDisplayStatus.ACTIVE:
-        return _format_workspace_sandbox_status(WorkspaceSandboxDisplayStatus.IDLE), WorkspaceSandboxDisplayStatus.IDLE
-
-    return _format_workspace_sandbox_status(workspace_status), workspace_status
+    return t(zh_CN="未知", en_US="Unknown"), WorkspaceSandboxDisplayStatus.UNKNOWN
 
 
 class NaInfoCommand(BaseCommand):
@@ -231,7 +258,8 @@ class NaInfoCommand(BaseCommand):
         channel_status_label = _format_channel_status(channel_status)
         runtime_status_label, runtime_status_phase = _resolve_channel_agent_runtime_status(context.chat_key)
         cc_sandbox_status_label, cc_sandbox_status_value = await _resolve_bound_workspace_sandbox_status(
-            db_chat_channel.workspace_id
+            db_chat_channel.workspace_id,
+            chat_key=context.chat_key,
         )
 
         title = t(zh_CN="[Nekro-Agent 信息]", en_US="[Nekro-Agent Info]")

--- a/nekro_agent/services/command/built_in/info.py
+++ b/nekro_agent/services/command/built_in/info.py
@@ -2,11 +2,18 @@
 
 from typing import Any, Literal
 
+from pydantic import ValidationError
+
 from nekro_agent.schemas.i18n import i18n_text, t
 from nekro_agent.services.command.base import BaseCommand, CommandMetadata, CommandPermission
 from nekro_agent.services.command.ctl import CmdCtl
 from nekro_agent.services.command.schemas import CommandExecutionContext, CommandResponse
 from nekro_agent.services.system_broadcast import (
+    WORKSPACE_CC_PHASE_CANCELLED,
+    WORKSPACE_CC_PHASE_COMPLETED,
+    WORKSPACE_CC_PHASE_FAILED,
+    WORKSPACE_CC_PHASE_QUEUED,
+    WORKSPACE_CC_PHASE_RESPONDING,
     WORKSPACE_CC_PHASE_RUNNING,
     WORKSPACE_CC_RUNTIME_PHASE_VALUES,
     WORKSPACE_STATUS_ACTIVE,
@@ -14,7 +21,10 @@ from nekro_agent.services.system_broadcast import (
     WORKSPACE_STATUS_FAILED,
     WORKSPACE_STATUS_STOPPED,
     WORKSPACE_STATUS_VALUES,
+    WorkspaceCcActiveState,
     WorkspaceCcRuntimePhase,
+    WorkspaceCcRuntimeStatusState,
+    WorkspaceStatusState,
     WorkspaceStatusValue,
 )
 
@@ -50,11 +60,14 @@ def _format_agent_runtime_phase(phase: str | None) -> str:
 def _format_workspace_sandbox_status(status: WorkspaceSandboxDisplayStatus) -> str:
     status_labels = {
         WORKSPACE_SANDBOX_STATUS_IDLE: t(zh_CN="闲置中", en_US="Idle"),
-        "queued": t(zh_CN="排队中", en_US="Queued"),
+        WORKSPACE_CC_PHASE_QUEUED: t(zh_CN="排队中", en_US="Queued"),
         WORKSPACE_CC_PHASE_RUNNING: t(zh_CN="执行中", en_US="Running"),
-        "responding": t(zh_CN="回传结果", en_US="Responding"),
-        "completed": t(zh_CN="已完成", en_US="Completed"),
-        "cancelled": t(zh_CN="已中止", en_US="Cancelled"),
+        WORKSPACE_CC_PHASE_RESPONDING: t(zh_CN="回传结果", en_US="Responding"),
+        WORKSPACE_CC_PHASE_COMPLETED: t(zh_CN="已完成", en_US="Completed"),
+        WORKSPACE_CC_PHASE_FAILED: t(zh_CN="执行失败", en_US="Failed"),
+        WORKSPACE_CC_PHASE_CANCELLED: t(zh_CN="已中止", en_US="Cancelled"),
+        # `active` 是底层容器可用状态；展示层会将其归一化为“闲置中”。
+        WORKSPACE_STATUS_ACTIVE: t(zh_CN="闲置中", en_US="Idle"),
         WORKSPACE_STATUS_STOPPED: t(zh_CN="已停止", en_US="Stopped"),
         WORKSPACE_STATUS_FAILED: t(zh_CN="执行失败", en_US="Failed"),
         WORKSPACE_STATUS_DELETING: t(zh_CN="删除中", en_US="Deleting"),
@@ -79,27 +92,56 @@ def _resolve_channel_agent_runtime_status(chat_key: str) -> tuple[str, str]:
     return t(zh_CN="闲置中", en_US="Idle"), "none"
 
 
-def _get_workspace_status_from_snapshot(snapshot: dict[str, Any], workspace_id: int) -> WorkspaceStatusValue | None:
+def _get_workspace_status_state_from_snapshot(snapshot: dict[str, Any], workspace_id: int) -> WorkspaceStatusState | None:
     workspace_status = snapshot.get("workspace_status", {}).get(str(workspace_id))
     if not isinstance(workspace_status, dict):
         return None
 
-    status = workspace_status.get("status")
-    if isinstance(status, str) and status in WORKSPACE_STATUS_VALUES:
-        return status
+    try:
+        return WorkspaceStatusState.model_validate(workspace_status)
+    except ValidationError:
+        return None
+
+
+def _get_workspace_status_from_snapshot(snapshot: dict[str, Any], workspace_id: int) -> WorkspaceStatusValue | None:
+    workspace_status = _get_workspace_status_state_from_snapshot(snapshot, workspace_id)
+    if workspace_status is not None and workspace_status.status in WORKSPACE_STATUS_VALUES:
+        return workspace_status.status
+
+    return None
+
+
+def _get_workspace_cc_runtime_state_from_snapshot(
+    snapshot: dict[str, Any],
+    workspace_id: int,
+) -> WorkspaceCcRuntimeStatusState | None:
+    runtime_status = snapshot.get("workspace_cc_runtime_status", {}).get(str(workspace_id))
+    if isinstance(runtime_status, dict):
+        try:
+            return WorkspaceCcRuntimeStatusState.model_validate(runtime_status)
+        except ValidationError:
+            return None
+
+    return None
+
+
+def _get_workspace_cc_active_state_from_snapshot(snapshot: dict[str, Any], workspace_id: int) -> WorkspaceCcActiveState | None:
+    active_status = snapshot.get("workspace_cc_active", {}).get(str(workspace_id))
+    if isinstance(active_status, dict):
+        try:
+            return WorkspaceCcActiveState.model_validate(active_status)
+        except ValidationError:
+            return None
 
     return None
 
 
 def _get_workspace_cc_phase_from_snapshot(snapshot: dict[str, Any], workspace_id: int) -> WorkspaceCcRuntimePhase | None:
-    runtime_status = snapshot.get("workspace_cc_runtime_status", {}).get(str(workspace_id))
-    if isinstance(runtime_status, dict):
-        phase = runtime_status.get("phase")
-        if isinstance(phase, str) and phase in WORKSPACE_CC_RUNTIME_PHASE_VALUES:
-            return phase
+    runtime_status = _get_workspace_cc_runtime_state_from_snapshot(snapshot, workspace_id)
+    if runtime_status is not None and runtime_status.phase in WORKSPACE_CC_RUNTIME_PHASE_VALUES:
+        return runtime_status.phase
 
-    active_status = snapshot.get("workspace_cc_active", {}).get(str(workspace_id))
-    if isinstance(active_status, dict):
+    if _get_workspace_cc_active_state_from_snapshot(snapshot, workspace_id) is not None:
         return WORKSPACE_CC_PHASE_RUNNING
 
     return None

--- a/nekro_agent/services/system_broadcast.py
+++ b/nekro_agent/services/system_broadcast.py
@@ -39,6 +39,35 @@ _MAX_QUEUE_SIZE = 200
 _MAX_SUBSCRIBERS = 50
 
 
+WorkspaceStatusValue = Literal["active", "stopped", "failed", "deleting"]
+WORKSPACE_STATUS_ACTIVE: WorkspaceStatusValue = "active"
+WORKSPACE_STATUS_STOPPED: WorkspaceStatusValue = "stopped"
+WORKSPACE_STATUS_FAILED: WorkspaceStatusValue = "failed"
+WORKSPACE_STATUS_DELETING: WorkspaceStatusValue = "deleting"
+WORKSPACE_STATUS_VALUES: tuple[WorkspaceStatusValue, ...] = (
+    WORKSPACE_STATUS_ACTIVE,
+    WORKSPACE_STATUS_STOPPED,
+    WORKSPACE_STATUS_FAILED,
+    WORKSPACE_STATUS_DELETING,
+)
+
+WorkspaceCcRuntimePhase = Literal["queued", "running", "responding", "completed", "failed", "cancelled"]
+WORKSPACE_CC_PHASE_QUEUED: WorkspaceCcRuntimePhase = "queued"
+WORKSPACE_CC_PHASE_RUNNING: WorkspaceCcRuntimePhase = "running"
+WORKSPACE_CC_PHASE_RESPONDING: WorkspaceCcRuntimePhase = "responding"
+WORKSPACE_CC_PHASE_COMPLETED: WorkspaceCcRuntimePhase = "completed"
+WORKSPACE_CC_PHASE_FAILED: WorkspaceCcRuntimePhase = "failed"
+WORKSPACE_CC_PHASE_CANCELLED: WorkspaceCcRuntimePhase = "cancelled"
+WORKSPACE_CC_RUNTIME_PHASE_VALUES: tuple[WorkspaceCcRuntimePhase, ...] = (
+    WORKSPACE_CC_PHASE_QUEUED,
+    WORKSPACE_CC_PHASE_RUNNING,
+    WORKSPACE_CC_PHASE_RESPONDING,
+    WORKSPACE_CC_PHASE_COMPLETED,
+    WORKSPACE_CC_PHASE_FAILED,
+    WORKSPACE_CC_PHASE_CANCELLED,
+)
+
+
 # ── 事件模型 ─────────────────────────────────────────────────────────────────
 
 
@@ -47,7 +76,7 @@ class WorkspaceStatusEvent(BaseModel):
 
     type: Literal["workspace_status"] = "workspace_status"
     workspace_id: int
-    status: Literal["active", "stopped", "failed", "deleting"]
+    status: WorkspaceStatusValue
     name: str
     container_name: Optional[str] = None
     host_port: Optional[int] = None
@@ -73,7 +102,7 @@ class WorkspaceCcRuntimeStatusEvent(BaseModel):
     name: Optional[str] = None
     started_at: int = Field(default=0, description="任务开始时间戳（ms）")
     updated_at: int = Field(default=0, description="本次状态更新时间戳（ms）")
-    phase: Literal["queued", "running", "responding", "completed", "failed", "cancelled"] = "running"
+    phase: WorkspaceCcRuntimePhase = WORKSPACE_CC_PHASE_RUNNING
     current_tool: Optional[str] = None
     source_chat_key: Optional[str] = None
     queue_length: int = 0
@@ -169,7 +198,7 @@ SystemEvent = Annotated[
 
 class WorkspaceStatusState(BaseModel):
     workspace_id: int
-    status: Literal["active", "stopped", "failed", "deleting"]
+    status: WorkspaceStatusValue
     name: str
     container_name: Optional[str] = None
     host_port: Optional[int] = None
@@ -189,7 +218,7 @@ class WorkspaceCcRuntimeStatusState(BaseModel):
     name: Optional[str] = None
     started_at: int
     updated_at: int
-    phase: Literal["queued", "running", "responding", "completed", "failed", "cancelled"]
+    phase: WorkspaceCcRuntimePhase
     current_tool: Optional[str] = None
     source_chat_key: Optional[str] = None
     queue_length: int = 0


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [√] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [√] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [√] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [ ] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [ ] 🐛 Bug 修复 (修复一个问题)
- [√] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

<!-- 请详细描述你的PR解决了什么问题，为什么这个变更是必要的 -->

## 🔗 相关 Issue

<!-- 如果有相关Issue，请在此处引用 (例如: Closes #123, Fixes #456) -->

## 📸 修改效果截图

<!-- 如果你的PR包含UI变更或功能改进，请提供修改前后的对比截图 -->

## 🛠️ 实现复杂度

<!-- 请选择一项 -->

- [√] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

<!-- 如果实现方式比较复杂或特殊，可以在这里详细说明技术实现 -->

## 🧪 测试步骤 (可选)

<!-- 说明如何测试这个PR的功能，例如:
1. 进入...页面
2. 点击...按钮
3. 观察...结果
-->

## Summary by Sourcery

扩展 `na_info` 命令，使其能够报告频道所绑定 workspace 的 CC sandbox 状态，并复用来自 system broadcast 模块的共享 workspace/CC runtime 状态类型。

新功能：
- 基于 workspace 和 CC runtime 状态快照，在 `na_info` 的文本和结构化响应中暴露 CC sandbox 状态和绑定的 workspace ID。

改进：
- 在 system broadcast 模块中新增共享的 workspace 状态和 CC runtime 阶段（phase）类型别名及常量，并更新相关的事件/状态模型和 workspace 路由辅助方法以使用这些类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the na_info command to report CC sandbox status for the channel’s bound workspace, using shared workspace/CC runtime status types from the system broadcast module.

New Features:
- Expose CC sandbox status and bound workspace ID in na_info’s text and structured responses based on workspace and CC runtime state snapshots.

Enhancements:
- Introduce shared workspace status and CC runtime phase type aliases and constants in the system broadcast module and update related event/state models and workspace router helpers to use them.

</details>

新特性：
- 在 `na_info` 的文本和结构化响应中包含 CC sandbox 状态以及绑定的工作区 ID。
- 基于工作区状态和 CC 运行时快照推导 CC sandbox 状态，并在必要时回退到数据库状态。

增强内容：
- 在 system broadcast 模块中引入共享的工作区状态和 CC 运行时阶段类型别名及常量，并更新相关的模型和辅助方法以使用它们。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

扩展 `na_info` 命令，使其能够报告频道所绑定 workspace 的 CC sandbox 状态，并复用来自 system broadcast 模块的共享 workspace/CC runtime 状态类型。

新功能：
- 基于 workspace 和 CC runtime 状态快照，在 `na_info` 的文本和结构化响应中暴露 CC sandbox 状态和绑定的 workspace ID。

改进：
- 在 system broadcast 模块中新增共享的 workspace 状态和 CC runtime 阶段（phase）类型别名及常量，并更新相关的事件/状态模型和 workspace 路由辅助方法以使用这些类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the na_info command to report CC sandbox status for the channel’s bound workspace, using shared workspace/CC runtime status types from the system broadcast module.

New Features:
- Expose CC sandbox status and bound workspace ID in na_info’s text and structured responses based on workspace and CC runtime state snapshots.

Enhancements:
- Introduce shared workspace status and CC runtime phase type aliases and constants in the system broadcast module and update related event/state models and workspace router helpers to use them.

</details>

</details>

新功能：
- 基于工作区和运行时快照，为频道绑定的工作区增加 CC 沙箱状态解析。
- 在 `na_info` 命令的结构化响应和文本消息中包含 CC 沙箱状态以及绑定的工作区 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

扩展 `na_info` 命令，使其能够报告频道所绑定 workspace 的 CC sandbox 状态，并复用来自 system broadcast 模块的共享 workspace/CC runtime 状态类型。

新功能：
- 基于 workspace 和 CC runtime 状态快照，在 `na_info` 的文本和结构化响应中暴露 CC sandbox 状态和绑定的 workspace ID。

改进：
- 在 system broadcast 模块中新增共享的 workspace 状态和 CC runtime 阶段（phase）类型别名及常量，并更新相关的事件/状态模型和 workspace 路由辅助方法以使用这些类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the na_info command to report CC sandbox status for the channel’s bound workspace, using shared workspace/CC runtime status types from the system broadcast module.

New Features:
- Expose CC sandbox status and bound workspace ID in na_info’s text and structured responses based on workspace and CC runtime state snapshots.

Enhancements:
- Introduce shared workspace status and CC runtime phase type aliases and constants in the system broadcast module and update related event/state models and workspace router helpers to use them.

</details>

新特性：
- 在 `na_info` 的文本和结构化响应中包含 CC sandbox 状态以及绑定的工作区 ID。
- 基于工作区状态和 CC 运行时快照推导 CC sandbox 状态，并在必要时回退到数据库状态。

增强内容：
- 在 system broadcast 模块中引入共享的工作区状态和 CC 运行时阶段类型别名及常量，并更新相关的模型和辅助方法以使用它们。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

扩展 `na_info` 命令，使其能够报告频道所绑定 workspace 的 CC sandbox 状态，并复用来自 system broadcast 模块的共享 workspace/CC runtime 状态类型。

新功能：
- 基于 workspace 和 CC runtime 状态快照，在 `na_info` 的文本和结构化响应中暴露 CC sandbox 状态和绑定的 workspace ID。

改进：
- 在 system broadcast 模块中新增共享的 workspace 状态和 CC runtime 阶段（phase）类型别名及常量，并更新相关的事件/状态模型和 workspace 路由辅助方法以使用这些类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the na_info command to report CC sandbox status for the channel’s bound workspace, using shared workspace/CC runtime status types from the system broadcast module.

New Features:
- Expose CC sandbox status and bound workspace ID in na_info’s text and structured responses based on workspace and CC runtime state snapshots.

Enhancements:
- Introduce shared workspace status and CC runtime phase type aliases and constants in the system broadcast module and update related event/state models and workspace router helpers to use them.

</details>

</details>

</details>