### PR TITLE
fix: 收紧 CC 协作命令权限并禁用未启用插件命令

### DIFF
--- a/nekro_agent/adapters/interface/base.py
+++ b/nekro_agent/adapters/interface/base.py
@@ -473,7 +473,7 @@ class BaseAdapter(ABC, Generic[TConfig]):
             await self._send_command_plain_if_any(chat_key, response)
             return
 
-        enhanced_messages = build_command_output_messages(response)
+        enhanced_messages = await build_command_output_messages(response, chat_key)
         if enhanced_messages and self.config.COMMAND_ENHANCED_OUTPUT:
             sent = await self._try_send_enhanced_command_response(
                 chat_key,
@@ -483,7 +483,7 @@ class BaseAdapter(ABC, Generic[TConfig]):
             if sent:
                 return
 
-        platform_segments = build_command_output_platform_segments(response)
+        platform_segments = await build_command_output_platform_segments(response, chat_key)
         if platform_segments:
             plt_response = await self.forward_message(
                 PlatformSendRequest(chat_key=chat_key, segments=platform_segments),

--- a/nekro_agent/adapters/wxwork_corp_app/adapter.py
+++ b/nekro_agent/adapters/wxwork_corp_app/adapter.py
@@ -192,7 +192,7 @@ class WxWorkCorpAppAdapter(BaseAdapter[WxWorkCorpAppConfig]):
 
             if response.output_segments:
                 estimated_count = self._estimate_message_count(
-                    build_command_output_platform_segments(response)
+                    await build_command_output_platform_segments(response, chat_key)
                 )
                 if estimated_count > WXWORK_CORP_APP_KF_COMMAND_MAX_MESSAGES:
                     await self._send_kf_command_limit_error(chat_key, estimated_count)

--- a/nekro_agent/services/chat/universal_chat_service.py
+++ b/nekro_agent/services/chat/universal_chat_service.py
@@ -47,10 +47,13 @@ class UniversalChatService:
             message (str): 操作消息内容
         """
 
+        from nekro_agent.services.config_resolver import config_resolver
+
         adapter = await adapter_utils.get_adapter_for_chat(chat_key)
+        effective_config = await config_resolver.get_effective_config(chat_key)
         await self.send_agent_message(
             chat_key=chat_key,
-            messages=f"{config.AI_COMMAND_OUTPUT_PREFIX} {message}".strip(),
+            messages=f"{effective_config.AI_COMMAND_OUTPUT_PREFIX} {message}".strip(),
             adapter=adapter,
         )
 

--- a/nekro_agent/services/command/base.py
+++ b/nekro_agent/services/command/base.py
@@ -20,6 +20,10 @@ from nekro_agent.services.command.schemas import (
 )
 
 
+BUILT_IN_SOURCE = "built_in"
+"""内置命令的 source / namespace 标识符，用于与插件命令来源区分。"""
+
+
 class CommandPermission(str, Enum):
     PUBLIC = "public"
     USER = "user"
@@ -29,7 +33,7 @@ class CommandPermission(str, Enum):
 
 class CommandMetadata(BaseModel):
     name: str
-    namespace: str = "built_in"  # 命名空间（内置命令为 "built_in"，插件命令自动填充为插件 key）
+    namespace: str = BUILT_IN_SOURCE  # 命名空间（内置命令为 BUILT_IN_SOURCE，插件命令自动填充为插件 key）
     aliases: list[str] = []
     description: str
     i18n_description: Optional[I18nDict] = None  # 国际化描述
@@ -38,7 +42,7 @@ class CommandMetadata(BaseModel):
     permission: CommandPermission = CommandPermission.PUBLIC
     category: str = "general"
     i18n_category: Optional[I18nDict] = None  # 国际化分类
-    source: str = "built_in"  # "built_in" | 插件 key
+    source: str = BUILT_IN_SOURCE  # BUILT_IN_SOURCE | 插件 key
     tags: list[str] = []  # 标签 (便于 Agent 检索)
     params_schema: Optional[dict] = None  # 自动生成的 JSON Schema (用于 Agent Tool-Use)
     internal: bool = False  # 内部命令 (不在帮助列表和补全中显示, 如 wait 的 callback_cmd)

--- a/nekro_agent/services/command/completion.py
+++ b/nekro_agent/services/command/completion.py
@@ -33,7 +33,7 @@ class CommandCompletionProvider:
 
         entries = []
         for meta in command_registry.list_all_commands():
-            if not command_manager.is_command_enabled(meta.name, chat_key):
+            if not command_manager.is_command_enabled_for_meta(meta, chat_key):
                 continue
             effective_permission = command_manager.get_command_permission(meta.name, meta.permission, chat_key)
             entries.append(

--- a/nekro_agent/services/command/completion.py
+++ b/nekro_agent/services/command/completion.py
@@ -32,8 +32,13 @@ class CommandCompletionProvider:
         from nekro_agent.services.command.registry import command_registry
 
         entries = []
+        plugin_enabled_cache: dict[str, bool] = {}
         for meta in command_registry.list_all_commands():
-            if not command_manager.is_command_enabled_for_meta(meta, chat_key):
+            if not command_manager.is_command_enabled_for_meta(
+                meta,
+                chat_key,
+                plugin_enabled_cache=plugin_enabled_cache,
+            ):
                 continue
             effective_permission = command_manager.get_command_permission(meta.name, meta.permission, chat_key)
             entries.append(

--- a/nekro_agent/services/command/manager.py
+++ b/nekro_agent/services/command/manager.py
@@ -14,7 +14,7 @@ from nekro_agent.core.os_env import (
     COMMAND_SYSTEM_STATE_FILE,
 )
 from nekro_agent.schemas.errors import ValidationError
-from nekro_agent.services.command.base import CommandMetadata, CommandPermission
+from nekro_agent.services.command.base import BUILT_IN_SOURCE, CommandMetadata, CommandPermission
 
 
 class CommandManager:
@@ -149,7 +149,7 @@ class CommandManager:
         plugin_enabled_cache: Optional[dict[str, bool]] = None,
     ) -> bool:
         """检查插件来源命令对应的插件是否已启用。"""
-        if source == "built_in":
+        if source == BUILT_IN_SOURCE:
             return True
 
         if plugin_enabled_cache is not None and source in plugin_enabled_cache:
@@ -349,8 +349,8 @@ class CommandManager:
             permission = self.get_command_permission(meta.name, meta.permission, chat_key)
             has_channel_override = chat_key is not None and meta.name in channel_state
             has_permission_override = self.has_permission_override(meta.name, chat_key)
-            source_display_name = "内置" if meta.source == "built_in" else meta.source
-            if meta.source != "built_in":
+            source_display_name = "内置" if meta.source == BUILT_IN_SOURCE else meta.source
+            if meta.source != BUILT_IN_SOURCE:
                 plugin = plugin_collector.get_plugin(meta.source)
                 if plugin:
                     source_display_name = plugin.name

--- a/nekro_agent/services/command/manager.py
+++ b/nekro_agent/services/command/manager.py
@@ -144,54 +144,78 @@ class CommandManager:
         self._channel_permission_cache[chat_key] = state
 
     @staticmethod
-    def _is_plugin_command_source_enabled(source: str) -> bool:
+    def _is_plugin_command_source_enabled(
+        source: str,
+        plugin_enabled_cache: Optional[dict[str, bool]] = None,
+    ) -> bool:
         """检查插件来源命令对应的插件是否已启用。"""
         if source == "built_in":
             return True
 
+        if plugin_enabled_cache is not None and source in plugin_enabled_cache:
+            return plugin_enabled_cache[source]
+
         from nekro_agent.services.plugin.collector import plugin_collector
 
         plugin = plugin_collector.get_plugin(source)
-        return bool(plugin and plugin.is_enabled)
+        enabled = bool(plugin and plugin.is_enabled)
+        if plugin_enabled_cache is not None:
+            plugin_enabled_cache[source] = enabled
+        return enabled
+
+    def _is_command_enabled_impl(
+        self,
+        command_name: str,
+        chat_key: Optional[str] = None,
+        *,
+        meta: Optional[CommandMetadata] = None,
+        plugin_enabled_cache: Optional[dict[str, bool]] = None,
+    ) -> bool:
+        """统一的命令启用检查实现。"""
+        target_meta = meta
+        if target_meta is None:
+            from nekro_agent.services.command.registry import command_registry
+
+            command = command_registry.resolve(command_name)
+            if command is not None:
+                target_meta = command.metadata
+
+        state_key = target_meta.name if target_meta is not None else command_name
+        if target_meta is not None and not self._is_plugin_command_source_enabled(
+            target_meta.source,
+            plugin_enabled_cache,
+        ):
+            return False
+
+        if chat_key:
+            channel_state = self._load_channel_state(chat_key)
+            if state_key in channel_state:
+                return channel_state[state_key]
+
+        system_state = self._load_system_state()
+        if state_key in system_state:
+            return system_state[state_key]
+
+        return True
 
     def is_command_enabled_for_meta(
         self,
         meta: CommandMetadata,
         chat_key: Optional[str] = None,
+        *,
+        plugin_enabled_cache: Optional[dict[str, bool]] = None,
     ) -> bool:
         """按命令元数据查询启用状态，同时校验插件启用态。"""
-        if not self._is_plugin_command_source_enabled(meta.source):
-            return False
-
-        if chat_key:
-            channel_state = self._load_channel_state(chat_key)
-            if meta.name in channel_state:
-                return channel_state[meta.name]
-
-        system_state = self._load_system_state()
-        if meta.name in system_state:
-            return system_state[meta.name]
-
-        return True
+        return self._is_command_enabled_impl(
+            meta.name,
+            chat_key,
+            meta=meta,
+            plugin_enabled_cache=plugin_enabled_cache,
+        )
 
     def is_command_enabled(self, command_name: str, chat_key: Optional[str] = None) -> bool:
         """查询命令是否启用（频道级 > 系统级 > 默认），并兼容插件启用态。"""
-        from nekro_agent.services.command.registry import command_registry
-
-        command = command_registry.resolve(command_name)
-        if command is not None:
-            return self.is_command_enabled_for_meta(command.metadata, chat_key)
-
-        if chat_key:
-            channel_state = self._load_channel_state(chat_key)
-            if command_name in channel_state:
-                return channel_state[command_name]
-
-        system_state = self._load_system_state()
-        if command_name in system_state:
-            return system_state[command_name]
-
-        return True
+        return self._is_command_enabled_impl(command_name, chat_key)
 
     def get_command_permission(
         self,
@@ -318,9 +342,10 @@ class CommandManager:
 
         commands = command_registry.list_all_commands()
         channel_state = self._load_channel_state(chat_key) if chat_key else {}
+        plugin_enabled_cache: dict[str, bool] = {}
         result = []
         for meta in commands:
-            enabled = self.is_command_enabled_for_meta(meta, chat_key)
+            enabled = self.is_command_enabled_for_meta(meta, chat_key, plugin_enabled_cache=plugin_enabled_cache)
             permission = self.get_command_permission(meta.name, meta.permission, chat_key)
             has_channel_override = chat_key is not None and meta.name in channel_state
             has_permission_override = self.has_permission_override(meta.name, chat_key)

--- a/nekro_agent/services/command/manager.py
+++ b/nekro_agent/services/command/manager.py
@@ -246,13 +246,19 @@ class CommandManager:
         return command_name in self._load_system_permission_state()
 
     @staticmethod
-    def _get_command_default_permission(command_name: str) -> CommandPermission:
+    def _resolve_command(command_name: str) -> tuple[str, CommandPermission]:
+        """解析命令名（含别名）到规范名和默认权限，命令不存在则抛出 ValidationError。"""
         from nekro_agent.services.command.registry import command_registry
 
         command = command_registry.resolve(command_name)
         if command is None:
             raise ValidationError(reason=f"命令不存在: {command_name}")
-        return command.metadata.permission
+        return command.metadata.name, command.metadata.permission
+
+    @staticmethod
+    def _get_command_default_permission(command_name: str) -> CommandPermission:
+        _, permission = CommandManager._resolve_command(command_name)
+        return permission
 
     async def set_command_enabled(
         self,
@@ -261,14 +267,14 @@ class CommandManager:
         chat_key: Optional[str] = None,
     ) -> None:
         """设置命令启用状态"""
-        self._get_command_default_permission(command_name)
+        canonical_name, _ = self._resolve_command(command_name)
         if chat_key:
             state = self._load_channel_state(chat_key)
-            state[command_name] = enabled
+            state[canonical_name] = enabled
             self._save_channel_state(chat_key, state)
         else:
             state = self._load_system_state()
-            state[command_name] = enabled
+            state[canonical_name] = enabled
             self._save_system_state(state)
         await self.notify_commands_changed(chat_key)
 
@@ -282,21 +288,21 @@ class CommandManager:
         normalized_permission = (
             permission if isinstance(permission, CommandPermission) else CommandPermission(permission)
         )
-        default_permission = self._get_command_default_permission(command_name)
+        canonical_name, default_permission = self._resolve_command(command_name)
         if chat_key:
             state = self._load_channel_permission_state(chat_key)
-            inherited_permission = self.get_command_permission(command_name, default_permission, None)
+            inherited_permission = self.get_command_permission(canonical_name, default_permission, None)
             if normalized_permission == inherited_permission:
-                state.pop(command_name, None)
+                state.pop(canonical_name, None)
             else:
-                state[command_name] = normalized_permission
+                state[canonical_name] = normalized_permission
             self._save_channel_permission_state(chat_key, state)
         else:
             state = self._load_system_permission_state()
             if normalized_permission == default_permission:
-                state.pop(command_name, None)
+                state.pop(canonical_name, None)
             else:
-                state[command_name] = normalized_permission
+                state[canonical_name] = normalized_permission
             self._save_system_permission_state(state)
         await self.notify_commands_changed(chat_key)
 
@@ -306,13 +312,17 @@ class CommandManager:
         chat_key: Optional[str] = None,
     ) -> None:
         """重置命令状态（删除覆盖，回退到上级）"""
+        from nekro_agent.services.command.registry import command_registry
+
+        resolved = command_registry.resolve(command_name)
+        canonical_name = resolved.metadata.name if resolved is not None else command_name
         if chat_key:
             state = self._load_channel_state(chat_key)
-            state.pop(command_name, None)
+            state.pop(canonical_name, None)
             self._save_channel_state(chat_key, state)
         else:
             state = self._load_system_state()
-            state.pop(command_name, None)
+            state.pop(canonical_name, None)
             self._save_system_state(state)
         await self.notify_commands_changed(chat_key)
 
@@ -322,13 +332,17 @@ class CommandManager:
         chat_key: Optional[str] = None,
     ) -> None:
         """重置命令权限覆盖（删除覆盖，回退到上级）"""
+        from nekro_agent.services.command.registry import command_registry
+
+        resolved = command_registry.resolve(command_name)
+        canonical_name = resolved.metadata.name if resolved is not None else command_name
         if chat_key:
             state = self._load_channel_permission_state(chat_key)
-            state.pop(command_name, None)
+            state.pop(canonical_name, None)
             self._save_channel_permission_state(chat_key, state)
         else:
             state = self._load_system_permission_state()
-            state.pop(command_name, None)
+            state.pop(canonical_name, None)
             self._save_system_permission_state(state)
         await self.notify_commands_changed(chat_key)
 

--- a/nekro_agent/services/command/manager.py
+++ b/nekro_agent/services/command/manager.py
@@ -14,7 +14,7 @@ from nekro_agent.core.os_env import (
     COMMAND_SYSTEM_STATE_FILE,
 )
 from nekro_agent.schemas.errors import ValidationError
-from nekro_agent.services.command.base import CommandPermission
+from nekro_agent.services.command.base import CommandMetadata, CommandPermission
 
 
 class CommandManager:
@@ -143,8 +143,45 @@ class CommandManager:
             path.unlink(missing_ok=True)
         self._channel_permission_cache[chat_key] = state
 
+    @staticmethod
+    def _is_plugin_command_source_enabled(source: str) -> bool:
+        """检查插件来源命令对应的插件是否已启用。"""
+        if source == "built_in":
+            return True
+
+        from nekro_agent.services.plugin.collector import plugin_collector
+
+        plugin = plugin_collector.get_plugin(source)
+        return bool(plugin and plugin.is_enabled)
+
+    def is_command_enabled_for_meta(
+        self,
+        meta: CommandMetadata,
+        chat_key: Optional[str] = None,
+    ) -> bool:
+        """按命令元数据查询启用状态，同时校验插件启用态。"""
+        if not self._is_plugin_command_source_enabled(meta.source):
+            return False
+
+        if chat_key:
+            channel_state = self._load_channel_state(chat_key)
+            if meta.name in channel_state:
+                return channel_state[meta.name]
+
+        system_state = self._load_system_state()
+        if meta.name in system_state:
+            return system_state[meta.name]
+
+        return True
+
     def is_command_enabled(self, command_name: str, chat_key: Optional[str] = None) -> bool:
-        """查询命令是否启用（频道级 > 系统级 > 默认）"""
+        """查询命令是否启用（频道级 > 系统级 > 默认），并兼容插件启用态。"""
+        from nekro_agent.services.command.registry import command_registry
+
+        command = command_registry.resolve(command_name)
+        if command is not None:
+            return self.is_command_enabled_for_meta(command.metadata, chat_key)
+
         if chat_key:
             channel_state = self._load_channel_state(chat_key)
             if command_name in channel_state:
@@ -283,7 +320,7 @@ class CommandManager:
         channel_state = self._load_channel_state(chat_key) if chat_key else {}
         result = []
         for meta in commands:
-            enabled = self.is_command_enabled(meta.name, chat_key)
+            enabled = self.is_command_enabled_for_meta(meta, chat_key)
             permission = self.get_command_permission(meta.name, meta.permission, chat_key)
             has_channel_override = chat_key is not None and meta.name in channel_state
             has_permission_override = self.has_permission_override(meta.name, chat_key)

--- a/nekro_agent/services/command/output.py
+++ b/nekro_agent/services/command/output.py
@@ -12,7 +12,6 @@ from typing import TypeVar
 from urllib.parse import quote
 
 from nekro_agent.adapters.interface.schemas.platform import PlatformSendSegment, PlatformSendSegmentType
-from nekro_agent.core.config import config
 from nekro_agent.core.logger import get_sub_logger
 from nekro_agent.schemas.agent_message import AgentMessageSegment, AgentMessageSegmentType
 from nekro_agent.services.command.schemas import (
@@ -211,13 +210,19 @@ def _segments_to_platform_send_segments(
     )
 
 
-def build_command_output_messages(response: CommandResponse) -> list[AgentMessageSegment]:
+async def build_command_output_messages(response: CommandResponse, chat_key: str) -> list[AgentMessageSegment]:
     """将命令响应转换为增强发送使用的通用消息段列表。"""
-    normalized_segments = _normalize_command_segments(response, config.AI_COMMAND_OUTPUT_PREFIX)
+    from nekro_agent.services.config_resolver import config_resolver
+
+    effective_config = await config_resolver.get_effective_config(chat_key)
+    normalized_segments = _normalize_command_segments(response, effective_config.AI_COMMAND_OUTPUT_PREFIX)
     return _segments_to_agent_messages(normalized_segments)
 
 
-def build_command_output_platform_segments(response: CommandResponse) -> list[PlatformSendSegment]:
+async def build_command_output_platform_segments(response: CommandResponse, chat_key: str) -> list[PlatformSendSegment]:
     """将命令响应转换为协议端发送段列表。"""
-    normalized_segments = _normalize_command_segments(response, config.AI_COMMAND_OUTPUT_PREFIX)
+    from nekro_agent.services.config_resolver import config_resolver
+
+    effective_config = await config_resolver.get_effective_config(chat_key)
+    normalized_segments = _normalize_command_segments(response, effective_config.AI_COMMAND_OUTPUT_PREFIX)
     return _segments_to_platform_send_segments(normalized_segments)

--- a/nekro_agent/services/command/registry.py
+++ b/nekro_agent/services/command/registry.py
@@ -171,7 +171,7 @@ class CommandRegistry:
             )
             return
 
-        if not command_manager.is_command_enabled(cmd.metadata.name, request.context.chat_key):
+        if not command_manager.is_command_enabled_for_meta(cmd.metadata, request.context.chat_key):
             yield CommandResponse(
                 status=CommandResponseStatus.DISABLED,
                 message=t(

--- a/nekro_agent/services/command/tool_export.py
+++ b/nekro_agent/services/command/tool_export.py
@@ -18,10 +18,15 @@ class AgentToolExporter:
         from nekro_agent.services.command.registry import command_registry
 
         tools = []
+        plugin_enabled_cache: dict[str, bool] = {}
         for meta in command_registry.list_all_commands():
             if meta.internal:
                 continue
-            if not command_manager.is_command_enabled_for_meta(meta, chat_key):
+            if not command_manager.is_command_enabled_for_meta(
+                meta,
+                chat_key,
+                plugin_enabled_cache=plugin_enabled_cache,
+            ):
                 continue
             tools.append({
                 "type": "function",

--- a/nekro_agent/services/command/tool_export.py
+++ b/nekro_agent/services/command/tool_export.py
@@ -21,7 +21,7 @@ class AgentToolExporter:
         for meta in command_registry.list_all_commands():
             if meta.internal:
                 continue
-            if not command_manager.is_command_enabled(meta.name, chat_key):
+            if not command_manager.is_command_enabled_for_meta(meta, chat_key):
                 continue
             tools.append({
                 "type": "function",

--- a/nekro_agent/services/plugin/manager.py
+++ b/nekro_agent/services/plugin/manager.py
@@ -47,14 +47,18 @@ def _build_activation_strategy_meta(plugin) -> dict:
     }
 
 
-async def _notify_commands_changed_after_plugin_toggle(plugin_name: str) -> None:
-    """插件启停后同步命令清单，失败只记录日志。"""
+async def _notify_commands_changed_after_plugin_toggle(plugin_key: str, plugin_name: str) -> None:
+    """插件启停后同步命令清单，失败只记录日志。
+
+    plugin_key 是命令 source 字段所用的插件标识符，plugin_name 是供人阅读的显示名称。
+    两者均记录在日志中，便于排查时关联具体命令来源。
+    """
     from nekro_agent.services.command.manager import command_manager
 
     try:
         await command_manager.notify_commands_changed()
     except Exception as e:
-        logger.warning(f"插件 {plugin_name} 状态已更新，但命令同步失败: {e}")
+        logger.warning(f"插件 {plugin_name} (key={plugin_key}) 状态已更新，但命令同步失败: {e}")
 
 
 async def get_all_ext_meta_data() -> List[dict]:
@@ -271,7 +275,7 @@ async def enable_plugin(plugin_id: str) -> bool:
             logger.exception(f"插件 {plugin.name} 启用成功，但路由挂载失败: {router_error}")
             # 路由挂载失败不影响插件启用
 
-        await _notify_commands_changed_after_plugin_toggle(plugin.name)
+        await _notify_commands_changed_after_plugin_toggle(plugin.key, plugin.name)
 
     except Exception as e:
         logger.error(f"启用插件失败: {plugin_id}, 错误: {e}")
@@ -309,7 +313,7 @@ async def disable_plugin(plugin_id: str) -> bool:
             config.PLUGIN_ENABLED.remove(plugin.key)
             ConfigService.save_config(config, CONFIG_PATH)
 
-        await _notify_commands_changed_after_plugin_toggle(plugin.name)
+        await _notify_commands_changed_after_plugin_toggle(plugin.key, plugin.name)
 
     except Exception as e:
         logger.error(f"禁用插件失败: {plugin_id}, 错误: {e}")

--- a/nekro_agent/services/plugin/manager.py
+++ b/nekro_agent/services/plugin/manager.py
@@ -58,7 +58,7 @@ async def _notify_commands_changed_after_plugin_toggle(plugin_key: str, plugin_n
     try:
         await command_manager.notify_commands_changed()
     except Exception as e:
-        logger.warning(f"插件 {plugin_name} (key={plugin_key}) 状态已更新，但命令同步失败: {e}")
+        logger.exception(f"插件 {plugin_name} (key={plugin_key}) 状态已更新，但命令同步失败: {e}")
 
 
 async def get_all_ext_meta_data() -> List[dict]:

--- a/nekro_agent/services/plugin/manager.py
+++ b/nekro_agent/services/plugin/manager.py
@@ -234,6 +234,8 @@ async def get_all_plugin_router_info() -> Dict[str, Any]:
 
 async def enable_plugin(plugin_id: str) -> bool:
     """启用插件（支持热重载）"""
+    from nekro_agent.services.command.manager import command_manager
+
     plugin = plugin_collector.get_plugin(plugin_id)
     if not plugin:
         return False
@@ -261,6 +263,8 @@ async def enable_plugin(plugin_id: str) -> bool:
             logger.exception(f"插件 {plugin.name} 启用成功，但路由挂载失败: {router_error}")
             # 路由挂载失败不影响插件启用
 
+        await command_manager.notify_commands_changed()
+
     except Exception as e:
         logger.error(f"启用插件失败: {plugin_id}, 错误: {e}")
         return False
@@ -270,6 +274,8 @@ async def enable_plugin(plugin_id: str) -> bool:
 
 async def disable_plugin(plugin_id: str) -> bool:
     """禁用插件（支持热重载）"""
+    from nekro_agent.services.command.manager import command_manager
+
     plugin = plugin_collector.get_plugin(plugin_id)
     if not plugin:
         return False
@@ -296,6 +302,8 @@ async def disable_plugin(plugin_id: str) -> bool:
         if plugin.key in config.PLUGIN_ENABLED:
             config.PLUGIN_ENABLED.remove(plugin.key)
             ConfigService.save_config(config, CONFIG_PATH)
+
+        await command_manager.notify_commands_changed()
 
     except Exception as e:
         logger.error(f"禁用插件失败: {plugin_id}, 错误: {e}")

--- a/nekro_agent/services/plugin/manager.py
+++ b/nekro_agent/services/plugin/manager.py
@@ -47,6 +47,16 @@ def _build_activation_strategy_meta(plugin) -> dict:
     }
 
 
+async def _notify_commands_changed_after_plugin_toggle(plugin_name: str) -> None:
+    """插件启停后同步命令清单，失败只记录日志。"""
+    from nekro_agent.services.command.manager import command_manager
+
+    try:
+        await command_manager.notify_commands_changed()
+    except Exception as e:
+        logger.warning(f"插件 {plugin_name} 状态已更新，但命令同步失败: {e}")
+
+
 async def get_all_ext_meta_data() -> List[dict]:
     """获取所有已注册插件的元数据（包括加载成功和失败的插件）"""
     plugins = plugin_collector.get_all_plugins()
@@ -234,8 +244,6 @@ async def get_all_plugin_router_info() -> Dict[str, Any]:
 
 async def enable_plugin(plugin_id: str) -> bool:
     """启用插件（支持热重载）"""
-    from nekro_agent.services.command.manager import command_manager
-
     plugin = plugin_collector.get_plugin(plugin_id)
     if not plugin:
         return False
@@ -246,7 +254,7 @@ async def enable_plugin(plugin_id: str) -> bool:
     try:
         # 启用插件 - enable() 方法内部会自动触发回调
         await plugin.enable()
-        
+
         if plugin.key not in config.PLUGIN_ENABLED:
             config.PLUGIN_ENABLED.append(plugin.key)
             ConfigService.save_config(config, CONFIG_PATH)
@@ -263,7 +271,7 @@ async def enable_plugin(plugin_id: str) -> bool:
             logger.exception(f"插件 {plugin.name} 启用成功，但路由挂载失败: {router_error}")
             # 路由挂载失败不影响插件启用
 
-        await command_manager.notify_commands_changed()
+        await _notify_commands_changed_after_plugin_toggle(plugin.name)
 
     except Exception as e:
         logger.error(f"启用插件失败: {plugin_id}, 错误: {e}")
@@ -274,8 +282,6 @@ async def enable_plugin(plugin_id: str) -> bool:
 
 async def disable_plugin(plugin_id: str) -> bool:
     """禁用插件（支持热重载）"""
-    from nekro_agent.services.command.manager import command_manager
-
     plugin = plugin_collector.get_plugin(plugin_id)
     if not plugin:
         return False
@@ -298,12 +304,12 @@ async def disable_plugin(plugin_id: str) -> bool:
 
         # 禁用插件 - disable() 方法内部会自动触发回调
         await plugin.disable()
-        
+
         if plugin.key in config.PLUGIN_ENABLED:
             config.PLUGIN_ENABLED.remove(plugin.key)
             ConfigService.save_config(config, CONFIG_PATH)
 
-        await command_manager.notify_commands_changed()
+        await _notify_commands_changed_after_plugin_toggle(plugin.name)
 
     except Exception as e:
         logger.error(f"禁用插件失败: {plugin_id}, 错误: {e}")

--- a/plugins/builtin/cc_workspace/main.py
+++ b/plugins/builtin/cc_workspace/main.py
@@ -67,6 +67,7 @@ from .prompt_envelope import CcPromptEnvelope
 
 _TASK_TYPE = "cc_delegate"
 _CC_DATA_TIMEOUT: float = 300.0  # 300s 内无有效 data: 事件（keep-alive 不计）则终止 SSE 流
+_CC_COMMAND_PERMISSION = CommandPermission.SUPER_USER
 
 # 已投递结果去重：(workspace_id, source_chat_key, result_id) → 投递时间
 # 防止 SSE 实时路径和 Watcher 轮询路径重复投递同一结果
@@ -1718,7 +1719,7 @@ async def get_cc_context(_ctx: schemas.AgentCtx) -> str:
     name="cc_help",
     description="查看 CC 协作插件的使用帮助",
     aliases=["cc_guide"],
-    permission=CommandPermission.USER,
+    permission=_CC_COMMAND_PERMISSION,
     usage="cc_help",
     category="CC 协作",
 )
@@ -1759,7 +1760,7 @@ async def cc_help_cmd(context: CommandExecutionContext) -> CommandResponse:
     name="cc_status",
     description="查看当前频道的 CC 协作状态摘要",
     aliases=[],
-    permission=CommandPermission.USER,
+    permission=_CC_COMMAND_PERMISSION,
     usage="cc_status",
     category="CC 协作",
 )
@@ -1774,7 +1775,7 @@ async def cc_status_cmd(context: CommandExecutionContext) -> CommandResponse:
     name="cc_context",
     description="查看当前频道的 CC 协作上下文",
     aliases=[],
-    permission=CommandPermission.USER,
+    permission=_CC_COMMAND_PERMISSION,
     usage="cc_context",
     category="CC 协作",
 )
@@ -1795,7 +1796,7 @@ async def cc_context_cmd(context: CommandExecutionContext) -> CommandResponse:
     name="cc_recent",
     description="查看当前频道最近的 CC 协作记录",
     aliases=["cc_log"],
-    permission=CommandPermission.USER,
+    permission=_CC_COMMAND_PERMISSION,
     usage="cc_recent [数量]",
     category="CC 协作",
 )
@@ -1814,7 +1815,7 @@ async def cc_recent_cmd(
     name="cc_abort",
     description="强制中止当前绑定工作区正在运行的 CC 任务",
     aliases=["cc_kill"],
-    permission=CommandPermission.USER,
+    permission=_CC_COMMAND_PERMISSION,
     usage="cc_abort",
     category="CC 协作",
 )
@@ -1837,7 +1838,7 @@ async def cc_abort_cmd(context: CommandExecutionContext) -> CommandResponse:
     name="cc_reset_session",
     description="重置当前绑定工作区的 CC 会话并清理旧委托摘要缓存",
     aliases=["cc_reset"],
-    permission=CommandPermission.USER,
+    permission=_CC_COMMAND_PERMISSION,
     usage="cc_reset_session",
     category="CC 协作",
 )
@@ -1860,7 +1861,7 @@ async def cc_reset_session_cmd(context: CommandExecutionContext) -> CommandRespo
     name="cc_restart",
     description="重启当前绑定工作区的 CC 沙盒容器",
     aliases=[],
-    permission=CommandPermission.USER,
+    permission=_CC_COMMAND_PERMISSION,
     usage="cc_restart",
     category="CC 协作",
 )
@@ -1883,7 +1884,7 @@ async def cc_restart_cmd(context: CommandExecutionContext) -> CommandResponse:
     name="cc_stop",
     description="停止当前绑定工作区的 CC 沙盒容器",
     aliases=[],
-    permission=CommandPermission.USER,
+    permission=_CC_COMMAND_PERMISSION,
     usage="cc_stop",
     category="CC 协作",
 )


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [√] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [√] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [√] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [ ] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [ ] 🐛 Bug 修复 (修复一个问题)
- [√] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

<!-- 请详细描述你的PR解决了什么问题，为什么这个变更是必要的 -->

## 🔗 相关 Issue

<!-- 如果有相关Issue，请在此处引用 (例如: Closes #123, Fixes #456) -->

## 📸 修改效果截图

<!-- 如果你的PR包含UI变更或功能改进，请提供修改前后的对比截图 -->

## 🛠️ 实现复杂度

<!-- 请选择一项 -->

- [√] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

<!-- 如果实现方式比较复杂或特殊，可以在这里详细说明技术实现 -->

## 🧪 测试步骤 (可选)

<!-- 说明如何测试这个PR的功能，例如:
1. 进入...页面
2. 点击...按钮
3. 观察...结果
-->

## Summary by Sourcery

通过遵守插件启用状态，并将 CC 协作相关命令限制为高权限用户使用，从而收紧命令启用逻辑与权限控制。

New Features:
- 对当前未启用的插件禁用其命令，同时仍然遵守频道级和系统级的命令开关设置。
- 在插件启用或禁用时刷新全局命令列表，以便命令可用性始终与插件状态保持同步。

Bug Fixes:
- 确保命令补全和导出的工具中排除属于已禁用插件的命令。

Enhancements:
- 引入统一的命令启用性检查逻辑，将插件来源元数据纳入其中，并对插件启用状态进行缓存，以便在列表展示、补全和工具导出中复用。
- 通过共享常量规范内置命令的来源标识符，在命令元数据和展示中统一使用。
- 通过共享的权限常量，将 CC 工作区协作命令限制为超级用户可用，从而收紧访问控制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten command enablement and permissions by respecting plugin activation state and restricting CC collaboration commands to higher-privilege users.

New Features:
- Disable commands from plugins that are not currently enabled while still honoring channel and system-level command toggles.
- Refresh the global command list when plugins are enabled or disabled so command availability stays in sync with plugin state.

Bug Fixes:
- Ensure command completion and exported tools exclude commands belonging to disabled plugins.

Enhancements:
- Introduce a unified command enablement check that incorporates plugin source metadata and caches plugin enabled status for reuse across listings, completion, and tool export.
- Standardize the built-in command source identifier via a shared constant used across command metadata and display.
- Restrict CC workspace collaboration commands to super users through a shared permission constant, tightening access control.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过遵守插件启用状态，并将 CC 协作相关命令限制为高权限用户使用，从而收紧命令启用逻辑与权限控制。

New Features:
- 对当前未启用的插件禁用其命令，同时仍然遵守频道级和系统级的命令开关设置。
- 在插件启用或禁用时刷新全局命令列表，以便命令可用性始终与插件状态保持同步。

Bug Fixes:
- 确保命令补全和导出的工具中排除属于已禁用插件的命令。

Enhancements:
- 引入统一的命令启用性检查逻辑，将插件来源元数据纳入其中，并对插件启用状态进行缓存，以便在列表展示、补全和工具导出中复用。
- 通过共享常量规范内置命令的来源标识符，在命令元数据和展示中统一使用。
- 通过共享的权限常量，将 CC 工作区协作命令限制为超级用户可用，从而收紧访问控制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten command enablement and permissions by respecting plugin activation state and restricting CC collaboration commands to higher-privilege users.

New Features:
- Disable commands from plugins that are not currently enabled while still honoring channel and system-level command toggles.
- Refresh the global command list when plugins are enabled or disabled so command availability stays in sync with plugin state.

Bug Fixes:
- Ensure command completion and exported tools exclude commands belonging to disabled plugins.

Enhancements:
- Introduce a unified command enablement check that incorporates plugin source metadata and caches plugin enabled status for reuse across listings, completion, and tool export.
- Standardize the built-in command source identifier via a shared constant used across command metadata and display.
- Restrict CC workspace collaboration commands to super users through a shared permission constant, tightening access control.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过遵守插件启用状态，并将 CC 协作相关命令限制为高权限用户使用，从而收紧命令启用逻辑与权限控制。

New Features:
- 对当前未启用的插件禁用其命令，同时仍然遵守频道级和系统级的命令开关设置。
- 在插件启用或禁用时刷新全局命令列表，以便命令可用性始终与插件状态保持同步。

Bug Fixes:
- 确保命令补全和导出的工具中排除属于已禁用插件的命令。

Enhancements:
- 引入统一的命令启用性检查逻辑，将插件来源元数据纳入其中，并对插件启用状态进行缓存，以便在列表展示、补全和工具导出中复用。
- 通过共享常量规范内置命令的来源标识符，在命令元数据和展示中统一使用。
- 通过共享的权限常量，将 CC 工作区协作命令限制为超级用户可用，从而收紧访问控制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten command enablement and permissions by respecting plugin activation state and restricting CC collaboration commands to higher-privilege users.

New Features:
- Disable commands from plugins that are not currently enabled while still honoring channel and system-level command toggles.
- Refresh the global command list when plugins are enabled or disabled so command availability stays in sync with plugin state.

Bug Fixes:
- Ensure command completion and exported tools exclude commands belonging to disabled plugins.

Enhancements:
- Introduce a unified command enablement check that incorporates plugin source metadata and caches plugin enabled status for reuse across listings, completion, and tool export.
- Standardize the built-in command source identifier via a shared constant used across command metadata and display.
- Restrict CC workspace collaboration commands to super users through a shared permission constant, tightening access control.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过遵守插件启用状态，并将 CC 协作相关命令限制为高权限用户使用，从而收紧命令启用逻辑与权限控制。

New Features:
- 对当前未启用的插件禁用其命令，同时仍然遵守频道级和系统级的命令开关设置。
- 在插件启用或禁用时刷新全局命令列表，以便命令可用性始终与插件状态保持同步。

Bug Fixes:
- 确保命令补全和导出的工具中排除属于已禁用插件的命令。

Enhancements:
- 引入统一的命令启用性检查逻辑，将插件来源元数据纳入其中，并对插件启用状态进行缓存，以便在列表展示、补全和工具导出中复用。
- 通过共享常量规范内置命令的来源标识符，在命令元数据和展示中统一使用。
- 通过共享的权限常量，将 CC 工作区协作命令限制为超级用户可用，从而收紧访问控制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten command enablement and permissions by respecting plugin activation state and restricting CC collaboration commands to higher-privilege users.

New Features:
- Disable commands from plugins that are not currently enabled while still honoring channel and system-level command toggles.
- Refresh the global command list when plugins are enabled or disabled so command availability stays in sync with plugin state.

Bug Fixes:
- Ensure command completion and exported tools exclude commands belonging to disabled plugins.

Enhancements:
- Introduce a unified command enablement check that incorporates plugin source metadata and caches plugin enabled status for reuse across listings, completion, and tool export.
- Standardize the built-in command source identifier via a shared constant used across command metadata and display.
- Restrict CC workspace collaboration commands to super users through a shared permission constant, tightening access control.

</details>

</details>

</details>