### PR TITLE
Warn on navigation with unsaved configuration changes

### DIFF
--- a/frontend/src/components/common/ConfigTable.tsx
+++ b/frontend/src/components/common/ConfigTable.tsx
@@ -1116,17 +1116,14 @@ export default function ConfigTable({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's' && !e.isComposing) {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
         e.preventDefault()
-        if (!hasUnsavedChanges) {
-          return
-        }
         handleSaveAllChanges(false)
       }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [handleSaveAllChanges, hasUnsavedChanges])
+  }, [handleSaveAllChanges])
 
   const handleReloadConfig = async () => {
     try {

--- a/frontend/src/components/common/ConfigTable.tsx
+++ b/frontend/src/components/common/ConfigTable.tsx
@@ -45,7 +45,7 @@ import {
   HelpOutline as HelpOutlineIcon,
   RestartAlt as RestartIcon,
 } from '@mui/icons-material'
-import { useNavigate } from 'react-router-dom'
+import { unstable_usePrompt as usePrompt, useBeforeUnload, useNavigate } from 'react-router-dom'
 import { UNIFIED_TABLE_STYLES, CHIP_VARIANTS } from '../../theme/variants'
 import ActionButton from './ActionButton'
 import IconActionButton from './IconActionButton'
@@ -941,6 +941,38 @@ export default function ConfigTable({
   const [expandedRows, setExpandedRows] = useState<ExpandedRowsState>({})
   const [restartDialogOpen, setRestartDialogOpen] = useState(false)
   const [isRestarting, setIsRestarting] = useState(false)
+  const hasUnsavedChanges = dirtyKeys.size > 0
+
+  useBeforeUnload(
+    useCallback((event: BeforeUnloadEvent) => {
+      if (!hasUnsavedChanges) {
+        return
+      }
+      event.preventDefault()
+      event.returnValue = ''
+    }, [hasUnsavedChanges])
+  )
+
+  usePrompt({
+    when: useCallback(
+      ({ currentLocation, nextLocation }) => {
+        if (!hasUnsavedChanges) {
+          return false
+        }
+
+        if (currentLocation.pathname !== nextLocation.pathname) {
+          return true
+        }
+
+        const currentCategory = new URLSearchParams(currentLocation.search).get('category')
+        const nextCategory = new URLSearchParams(nextLocation.search).get('category')
+
+        return currentCategory !== nextCategory
+      },
+      [hasUnsavedChanges]
+    ),
+    message: t('configTable.unsavedChangesConfirm'),
+  })
 
   useEffect(() => {
     if (!onSearchChange) {
@@ -1647,7 +1679,7 @@ export default function ConfigTable({
                 size="small"
                 onClick={() => handleSaveAllChanges(false)}
                 startIcon={<SaveIcon />}
-                disabled={dirtyKeys.size === 0}
+                disabled={!hasUnsavedChanges}
               >
                 {t('configTable.saveChanges')}
               </Button>

--- a/frontend/src/components/common/ConfigTable.tsx
+++ b/frontend/src/components/common/ConfigTable.tsx
@@ -1116,14 +1116,17 @@ export default function ConfigTable({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's' && !e.isComposing) {
         e.preventDefault()
+        if (!hasUnsavedChanges) {
+          return
+        }
         handleSaveAllChanges(false)
       }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [handleSaveAllChanges])
+  }, [handleSaveAllChanges, hasUnsavedChanges])
 
   const handleReloadConfig = async () => {
     try {

--- a/frontend/src/locales/en-US/common.json
+++ b/frontend/src/locales/en-US/common.json
@@ -233,6 +233,7 @@
     "restarting": "Restarting...",
     "resetConfirmTitle": "Confirm Reset Config",
     "resetConfirmContent": "Resetting config will lose all unsaved changes. Continue?",
+    "unsavedChangesConfirm": "You have unsaved configuration changes. Leave this page anyway?",
     "saveWarningTitle": "Save Warning",
     "saveWarningContent": "The following required fields are empty. Continue saving?",
     "saveWarningContentSimple": "Continue saving?",

--- a/frontend/src/locales/zh-CN/common.json
+++ b/frontend/src/locales/zh-CN/common.json
@@ -234,6 +234,7 @@
     "restarting": "重启中...",
     "resetConfirmTitle": "确认重置配置",
     "resetConfirmContent": "重置配置将丢失所有未保存的修改，是否继续？",
+    "unsavedChangesConfirm": "当前配置尚未保存，确定要离开当前页面吗？",
     "saveWarningTitle": "保存警告",
     "saveWarningContent": "以下必填项未填写，是否仍要继续保存？",
     "saveWarningContentSimple": "是否仍要继续保存？",

--- a/frontend/src/pages/workspace/tabs/ResourcesTab.tsx
+++ b/frontend/src/pages/workspace/tabs/ResourcesTab.tsx
@@ -147,10 +147,10 @@ function ResourceFieldEditor({
         <Card
           key={`${field.field_key || 'field'}-${index}`}
           variant="outlined"
-          draggable
-          onDragStart={() => setDragIndex(index)}
+          data-resource-field-card="true"
           onDragOver={event => event.preventDefault()}
           onDrop={() => handleDrop(index)}
+          onDragEnd={() => setDragIndex(null)}
           sx={{
             borderColor: dragIndex === index ? 'primary.main' : 'divider',
             backgroundColor: dragIndex === index ? alpha('#1976d2', 0.04) : 'background.paper',
@@ -159,7 +159,27 @@ function ResourceFieldEditor({
           <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
             <Stack spacing={1.25}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', color: 'text.secondary', cursor: 'grab' }}>
+                <Box
+                  draggable
+                  onDragStart={event => {
+                    event.stopPropagation()
+                    event.dataTransfer.effectAllowed = 'move'
+                    const card = event.currentTarget.closest('[data-resource-field-card="true"]')
+                    if (card instanceof HTMLElement) {
+                      const rect = card.getBoundingClientRect()
+                      event.dataTransfer.setDragImage(card, event.clientX - rect.left, event.clientY - rect.top)
+                    }
+                    setDragIndex(index)
+                  }}
+                  onDragEnd={() => setDragIndex(null)}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    color: 'text.secondary',
+                    cursor: 'grab',
+                    '&:active': { cursor: 'grabbing' },
+                  }}
+                >
                   <DragIcon fontSize="small" />
                 </Box>
                 <Typography variant="subtitle2" sx={{ fontWeight: 600, flexGrow: 1 }}>


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [ ] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [ ] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [ ] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [ ] 🐛 Bug 修复 (修复一个问题)
- [x] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [x] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [x] 🔄 其他...

## 📄 PR 描述

当用户尝试离开页面或切换配置类别时，对未保存的配置更改发出警告。

## 🔗 相关 Issue

<!-- 如果有相关Issue，请在此处引用 (例如: Closes #123, Fixes #456) -->

## 📸 修改效果截图

<img width="450" height="135" alt="image" src="https://github.com/user-attachments/assets/6dbb1b28-d044-4f86-89c0-0b6214cb7879" />
## 🛠️ 实现复杂度

<!-- 请选择一项 -->

- [x] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

<!-- 如果实现方式比较复杂或特殊，可以在这里详细说明技术实现 -->

## 🧪 测试步骤 (可选)

<!-- 说明如何测试这个PR的功能，例如:
1. 进入...页面
2. 点击...按钮
3. 观察...结果
-->

## Summary by Sourcery

在配置表视图中添加未保存配置变更的检测和导航警告。

新功能：
- 当用户尝试离开页面或切换配置类别时，对未保存的配置更改发出警告。

优化：
- 将未保存更改状态的复用重构为专门的 `hasUnsavedChanges` 标志，以使按钮禁用逻辑更清晰。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unsaved-configuration change detection and navigation warnings to the configuration table view.

New Features:
- Warn users about unsaved configuration changes when attempting to leave the page or switch configuration categories.

Enhancements:
- Refactor reuse of the unsaved-change state into a dedicated hasUnsavedChanges flag for clearer button disabling logic.

</details>

## Summary by Sourcery

在配置表中添加未保存配置更改的警告，并优化资源字段编辑器中的拖拽行为。

新功能：
- 当用户离开配置页面或切换配置类别时，提醒其存在未保存的配置更改。

增强改进：
- 引入独立的未保存更改标志，用于简化配置表中按钮状态的控制。
- 调整资源字段的拖拽操作，改为使用专用拖拽手柄，并改进拖拽反馈和状态重置机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unsaved-configuration change warnings in the configuration table and refine drag-and-drop behavior in the resource field editor.

New Features:
- Warn users about unsaved configuration changes when leaving the configuration page or switching configuration categories.

Enhancements:
- Introduce a dedicated unsaved-changes flag to simplify button state control in the configuration table.
- Adjust resource field drag-and-drop to use a dedicated drag handle with improved drag feedback and state reset.

</details>

新功能：
- 当用户通过浏览器导航或应用内路由提示离开页面或切换配置类别时，如存在未保存的配置更改，则提醒用户。

增强优化：
- 引入独立的 `hasUnsavedChanges` 标志，用于集中管理未保存状态，并复用该状态以禁用保存按钮。
- 改进资源字段编辑器的拖放用户体验：将拖拽行为移动到单独的拖拽手柄上，添加自定义拖拽图像，并在拖拽结束时重置拖拽状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在配置表中添加未保存配置更改的警告，并优化资源字段编辑器中的拖拽行为。

新功能：
- 当用户离开配置页面或切换配置类别时，提醒其存在未保存的配置更改。

增强改进：
- 引入独立的未保存更改标志，用于简化配置表中按钮状态的控制。
- 调整资源字段的拖拽操作，改为使用专用拖拽手柄，并改进拖拽反馈和状态重置机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unsaved-configuration change warnings in the configuration table and refine drag-and-drop behavior in the resource field editor.

New Features:
- Warn users about unsaved configuration changes when leaving the configuration page or switching configuration categories.

Enhancements:
- Introduce a dedicated unsaved-changes flag to simplify button state control in the configuration table.
- Adjust resource field drag-and-drop to use a dedicated drag handle with improved drag feedback and state reset.

</details>

</details>