### PR TITLE
fix:随机触发错误拦截并提示小时回复配额已用完 #252

### DIFF
--- a/nekro_agent/services/message_service.py
+++ b/nekro_agent/services/message_service.py
@@ -369,14 +369,16 @@ class MessageService:
         should_ignore = (user and user.is_prevent_trigger) or (user and not user.is_active)
 
         # 检查是否需要触发回复
-        should_trigger = (
+        explicit_triggered = (
             trigger_agent
             or signal == MsgSignal.FORCE_TRIGGER
             or preset.name in message.content_text
             or message.is_tome
-            or random_chat_check(config)
-            or check_content_trigger(message.content_text, config)
         )
+        random_triggered = random_chat_check(config)
+        content_triggered = check_content_trigger(message.content_text, config)
+        should_trigger = explicit_triggered or random_triggered or content_triggered
+        should_notify_quota_exhausted = explicit_triggered or content_triggered
 
         if not should_ignore and should_trigger:
             if not db_chat_channel.is_active:
@@ -418,6 +420,8 @@ class MessageService:
 
                     if daily_count >= effective_limit:
                         logger.info(f"频道 {message.chat_key} 今日配额已用完 ({daily_count}/{effective_limit})，跳过回复")
+                        if not should_notify_quota_exhausted:
+                            return
                         # 通过适配器发送可见通知
                         quota_msg = f"今日回复配额已用完 ({daily_count}/{effective_limit})，请明天再试或联系管理员使用 /quota_boost 临时提升配额"
                         try:
@@ -454,6 +458,8 @@ class MessageService:
 
                         if hourly_count >= hourly_limit:
                             logger.info(f"频道 {message.chat_key} 本小时配额已用完 ({hourly_count}/{hourly_limit})，跳过回复")
+                            if not should_notify_quota_exhausted:
+                                return
                             hourly_msg = f"本小时回复配额已用完 ({hourly_count}/{hourly_limit})，请稍后再试"
                             try:
                                 adapter = await adapter_utils.get_adapter_for_chat(message.chat_key)


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [ ] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [x] 🐛 Bug 修复 (修复一个问题)
- [ ] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

fix:随机触发错误拦截并提示小时回复配额已用完 #252
## 🔗 相关 Issue

Fixes #252 

## 📸 修改效果截图

<!-- 如果你的PR包含UI变更或功能改进，请提供修改前后的对比截图 -->

## 🛠️ 实现复杂度

<!-- 请选择一项 -->

- [x] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

<!-- 如果实现方式比较复杂或特殊，可以在这里详细说明技术实现 -->

## 🧪 测试步骤 (可选)

<!-- 说明如何测试这个PR的功能，例如:
1. 进入...页面
2. 点击...按钮
3. 观察...结果
-->

## Summary by Sourcery

错误修复：
- 确保仅在显式触发或基于内容的触发条件下发送配额耗尽通知，而不是在随机触发时发送。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure quota-exhausted notifications are only sent for explicit or content-based triggers instead of random triggers.

</details>