### PR TITLE
Implement OpenAI service with response logging and metrics tracking

### DIFF
--- a/nekro_agent/services/agent/openai.py
+++ b/nekro_agent/services/agent/openai.py
@@ -456,12 +456,21 @@ async def gen_openai_chat_response(
     def _extract_valid_delta(chunk: ChatCompletionChunk) -> Optional[Any]:
         delta = chunk.choices[0].delta if chunk.choices else None
         if not delta:
-            logger.warning(f"OpenAI流式生成: 空 choices，跳过块 {chunk}")
+            if not chunk.usage:
+                logger.warning(f"OpenAI流式生成: 空 choices，跳过块 {chunk}")
             return None
         return delta
 
     async def _apply_stream_chunk(chunk: ChatCompletionChunk) -> bool:
         nonlocal output, thought_chain, token_consumption, token_input, token_output, first_token_time
+
+        if chunk.usage:
+            if chunk.usage.total_tokens is not None:
+                token_consumption = chunk.usage.total_tokens
+            if chunk.usage.prompt_tokens is not None:
+                token_input = chunk.usage.prompt_tokens
+            if chunk.usage.completion_tokens is not None:
+                token_output = chunk.usage.completion_tokens
 
         delta = _extract_valid_delta(chunk)
         if delta is None:
@@ -475,17 +484,6 @@ async def gen_openai_chat_response(
             output += chunk_text
         current_thought_chain = getattr(delta, thought_chain_field_name, "") or ""
         thought_chain += current_thought_chain
-
-        if chunk.usage and chunk.usage.total_tokens is not None:
-            token_consumption += chunk.usage.total_tokens
-
-        if chunk.usage and chunk.usage.prompt_tokens is not None:
-            token_input += chunk.usage.prompt_tokens
-
-        completion_tokens = 0
-        if chunk.usage and chunk.usage.completion_tokens is not None:
-            completion_tokens = chunk.usage.completion_tokens
-        token_output += completion_tokens
 
         if chunk_callback and await chunk_callback(
             OpenAIStreamChunk(
@@ -540,8 +538,9 @@ async def gen_openai_chat_response(
                 res_stream: AsyncStream[ChatCompletionChunk] = await client.chat.completions.create(
                     model=model,
                     messages=messages,
-                    **gen_kwargs,   
+                    **gen_kwargs,
                     stream=True,
+                    stream_options={"include_usage": True},
                 )
                 first_chunk = await _get_first_stream_chunk(res_stream, first_token_timeout)
                 if first_chunk and not first_token_time:

--- a/nekro_agent/services/agent/openai.py
+++ b/nekro_agent/services/agent/openai.py
@@ -456,7 +456,9 @@ async def gen_openai_chat_response(
     def _extract_valid_delta(chunk: ChatCompletionChunk) -> Optional[Any]:
         delta = chunk.choices[0].delta if chunk.choices else None
         if not delta:
-            if not chunk.usage:
+            if chunk.usage:
+                logger.debug(f"OpenAI流式生成: 收到仅包含 usage 的空 choices 块 {chunk}")
+            else:
                 logger.warning(f"OpenAI流式生成: 空 choices，跳过块 {chunk}")
             return None
         return delta
@@ -465,6 +467,7 @@ async def gen_openai_chat_response(
         nonlocal output, thought_chain, token_consumption, token_input, token_output, first_token_time
 
         if chunk.usage:
+            # include_usage 返回的是整次流式响应的最终统计值，而不是当前 chunk 的增量。
             if chunk.usage.total_tokens is not None:
                 token_consumption = chunk.usage.total_tokens
             if chunk.usage.prompt_tokens is not None:


### PR DESCRIPTION
…etrics tracking

# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [ ] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [ ] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [ ] 🐛 Bug 修复 (修复一个问题)
- [x] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

<!-- 请详细描述你的PR解决了什么问题，为什么这个变更是必要的 -->

## 🔗 相关 Issue

<!-- 如果有相关Issue，请在此处引用 (例如: Closes #123, Fixes #456) -->

## 📸 修改效果截图

<!-- 如果你的PR包含UI变更或功能改进，请提供修改前后的对比截图 -->

## 🛠️ 实现复杂度

<!-- 请选择一项 -->

- [x] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

<!-- 如果实现方式比较复杂或特殊，可以在这里详细说明技术实现 -->

## 🧪 测试步骤 (可选)

<!-- 说明如何测试这个PR的功能，例如:
1. 进入...页面
2. 点击...按钮
3. 观察...结果
-->

## Summary by Sourcery

为 OpenAI 流式使用情况报告提供支持，并改进对流式聊天响应的 token 统计和日志记录。

新功能：
- 通过流式选项，使 OpenAI 流式聊天响应能够包含使用情况（usage）信息。

改进：
- 从流式分片的 usage 元数据中推导输入、输出和总 token 数，而不是通过增量累加计算。
- 通过将仅包含 usage 数据的空选择（empty-choice）流式分片记录等级从 warning 降为 debug，减少噪声警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for OpenAI streaming usage reporting and improve token accounting and logging for streamed chat responses.

New Features:
- Enable OpenAI streamed chat responses to include usage information via stream options.

Enhancements:
- Derive input, output, and total token counts from the usage metadata of streaming chunks instead of incremental accumulation.
- Reduce noisy warnings by logging empty-choice streaming chunks that only contain usage data at debug level instead of warning.

</details>

新功能：
- 通过流式选项，使 OpenAI 流式响应能够包含用量信息。

增强改进：
- 优化流式 token 统计方式，改为基于分片（chunk）的使用元数据推导输入、输出和总 token 数，而不是通过增量累加。
- 减少噪声日志，当分片仅携带用量数据时跳过空选择（empty-choice）警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 OpenAI 流式使用情况报告提供支持，并改进对流式聊天响应的 token 统计和日志记录。

新功能：
- 通过流式选项，使 OpenAI 流式聊天响应能够包含使用情况（usage）信息。

改进：
- 从流式分片的 usage 元数据中推导输入、输出和总 token 数，而不是通过增量累加计算。
- 通过将仅包含 usage 数据的空选择（empty-choice）流式分片记录等级从 warning 降为 debug，减少噪声警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for OpenAI streaming usage reporting and improve token accounting and logging for streamed chat responses.

New Features:
- Enable OpenAI streamed chat responses to include usage information via stream options.

Enhancements:
- Derive input, output, and total token counts from the usage metadata of streaming chunks instead of incremental accumulation.
- Reduce noisy warnings by logging empty-choice streaming chunks that only contain usage data at debug level instead of warning.

</details>

</details>