### PR TITLE
Fix/private chat file materialize [添加私聊接收文件，优化私聊回复流程]

### DIFF
--- a/nekro_agent/adapters/onebot_v11/adapter.py
+++ b/nekro_agent/adapters/onebot_v11/adapter.py
@@ -384,6 +384,8 @@ class OnebotV11Adapter(BaseAdapter[OnebotV11Config]):
                 await bot.send_group_msg(group_id=chat_id, message=msg)
             elif db_chat_channel.chat_type == ChatType.PRIVATE:
                 await bot.send_private_msg(user_id=chat_id, message=msg)
+            else:
+                logger.warning(f"不支持的聊天类型，文件发送跳过: {db_chat_channel.chat_type}")
 
     async def _send_to_chat(self, chat_key: str, message: Message) -> str:
         """发送消息到指定聊天"""

--- a/nekro_agent/adapters/onebot_v11/adapter.py
+++ b/nekro_agent/adapters/onebot_v11/adapter.py
@@ -352,55 +352,38 @@ class OnebotV11Adapter(BaseAdapter[OnebotV11Config]):
         return None
 
     async def _send_files(self, chat_key: str, file_segments: List) -> None:
-        """发送文件（文件上传模式）"""
+        """发送文件（物化模式）"""
         bot: Bot = get_bot()
-        files: List[Path] = []
-
-        # 收集所有文件路径
-        for segment in file_segments:
-            if segment.file_path:
-                file_path = Path(segment.file_path)
-                if file_path.exists():
-                    files.append(file_path)
-                else:
-                    logger.warning(f"File not found: {segment.file_path}")
-
-        if not files:
-            logger.warning("No valid files to send")
-            return
-
-        # 获取聊天频道信息
         db_chat_channel = await DBChatChannel.get_channel(chat_key=chat_key)
-        chat_type = db_chat_channel.chat_type
-
-        # 从channel_id中提取真实的ID
         chat_id = int(db_chat_channel.channel_id.split("_")[1])
 
-        # 如果配置了 OneBot 服务器挂载目录，需要转换路径
-        def get_onebot_path(file_path: Path) -> Path:
-            if config.SANDBOX_ONEBOT_SERVER_MOUNT_DIR:
-                return Path(config.SANDBOX_ONEBOT_SERVER_MOUNT_DIR) / file_path.relative_to(Path(OsEnv.DATA_DIR))
-            return file_path
+        from nekro_agent.tools.common_util import copy_to_upload_dir
 
-        if chat_type is ChatType.GROUP:
-            for file in files:
-                logger.info(f"Sending file: {file}")
-                onebot_path = get_onebot_path(file)
-                await bot.upload_group_file(
-                    group_id=chat_id,
-                    file=str(onebot_path),
-                    name=file.name,
-                )
-        elif chat_type is ChatType.PRIVATE:
-            for file in files:
-                onebot_path = get_onebot_path(file)
-                await bot.upload_private_file(
-                    user_id=chat_id,
-                    file=str(onebot_path),
-                    name=file.name,
-                )
-        else:
-            raise ValueError("Invalid chat type")
+        for segment in file_segments:
+            if not segment.file_path:
+                continue
+
+            src_path = Path(segment.file_path)
+            if not src_path.exists():
+                logger.warning(f"File not found: {segment.file_path}")
+                continue
+
+            # 物化到 uploads 目录
+            copied_path, copied_name = await copy_to_upload_dir(
+                file_path=str(src_path),
+                file_name=src_path.name,
+                from_chat_key=chat_key,
+            )
+            logger.info(f"文件已物化至: {copied_path}")
+
+            # 发送物化后的文件
+            # 协议端(NapCat)会读取该绝对路径并发送
+            msg = MessageSegment.file(file=str(copied_path))
+
+            if db_chat_channel.chat_type == ChatType.GROUP:
+                await bot.send_group_msg(group_id=chat_id, message=msg)
+            elif db_chat_channel.chat_type == ChatType.PRIVATE:
+                await bot.send_private_msg(user_id=chat_id, message=msg)
 
     async def _send_to_chat(self, chat_key: str, message: Message) -> str:
         """发送消息到指定聊天"""

--- a/nekro_agent/adapters/onebot_v11/tools/convertor.py
+++ b/nekro_agent/adapters/onebot_v11/tools/convertor.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 
 from nonebot.adapters.onebot.v11 import (

--- a/nekro_agent/adapters/onebot_v11/tools/convertor.py
+++ b/nekro_agent/adapters/onebot_v11/tools/convertor.py
@@ -496,7 +496,7 @@ def _extract_detail_from_meta(json_data: dict) -> dict | None:
 async def convert_chat_message(
     ob_event: Union[MessageEvent, GroupMessageEvent, GroupUploadNoticeEvent],
     msg_to_me: bool,
-    bot: Bot,  # noqa: ARG001
+    bot: Bot,
     db_chat_channel: DBChatChannel,
     adapter: BaseAdapter,
 ) -> Tuple[List[ChatMessageSegment], bool, str]:
@@ -658,13 +658,50 @@ async def convert_chat_message(
                 file_path = seg.data["file"]
                 if file_path.startswith("file:"):
                     file_path = file_path[len("file:") :]
-                ret_list.append(
-                    await ChatMessageSegmentFile.create_form_local_path(
-                        local_path=file_path,
-                        from_chat_key=db_chat_channel.chat_key,
-                        file_name=seg.data.get("name", ""),
-                    ),
-                )
+
+                local_path = Path(file_path)
+                if not local_path.exists():
+                    local_path = Path(NAPCAT_TEMPFILE_DIR) / local_path.name
+
+                if local_path.exists():
+                    ret_list.append(
+                        await ChatMessageSegmentFile.create_form_local_path(
+                            local_path=str(local_path),
+                            from_chat_key=db_chat_channel.chat_key,
+                            file_name=seg.data.get("name", ""),
+                        ),
+                    )
+                elif "file_id" in seg.data:
+                    try:
+                        file_data = await asyncio.wait_for(
+                            bot.call_api("get_file", file_id=seg.data["file_id"]),
+                            timeout=30.0,
+                        )
+                        file_url = file_data.get("url", "")
+                        napcat_path = Path(NAPCAT_TEMPFILE_DIR) / file_data.get("file_name", "")
+                        if napcat_path.exists():
+                            ret_list.append(
+                                await ChatMessageSegmentFile.create_form_local_path(
+                                    local_path=str(napcat_path),
+                                    from_chat_key=db_chat_channel.chat_key,
+                                    file_name=file_data.get("file_name", ""),
+                                ),
+                            )
+                        elif file_url and file_url.startswith("http"):
+                            ret_list.append(
+                                await ChatMessageSegmentFile.create_from_url(
+                                    url=file_url,
+                                    from_chat_key=db_chat_channel.chat_key,
+                                    file_name=seg.data.get("name", ""),
+                                ),
+                            )
+                        else:
+                            logger.warning(f"无法获取文件下载链接: {seg}")
+                    except Exception as e:
+                        logger.warning(f"通过 API 获取文件失败: {e}")
+                else:
+                    logger.warning(f"文件不存在且无 file_id: {seg}")
+                    continue
             else:
                 logger.warning(f"OneBot file message without url or file: {seg}")
                 continue

--- a/nekro_agent/adapters/onebot_v11/tools/convertor.py
+++ b/nekro_agent/adapters/onebot_v11/tools/convertor.py
@@ -413,6 +413,79 @@ def _generate_json_card_summary(card_info: dict[str, str | None]) -> str:
     return "".join(parts)
 
 
+async def _build_file_segment_from_onebot_file(
+    seg: dict,
+    bot: Bot,
+    from_chat_key: str,
+) -> Optional[ChatMessageSegmentFile]:
+    """从 OneBot 文件消息段构建 ChatMessageSegmentFile
+
+    优先级：本地路径 → NapCat 临时目录 → get_file API（临时目录路径 → URL 下载）
+
+    Args:
+        seg: OneBot MessageSegment 的 data 字典
+        bot: Bot 实例
+        from_chat_key: 聊天频道标识
+
+    Returns:
+        ChatMessageSegmentFile 或 None（所有方式均失败时）
+    """
+    file_path = seg.data["file"]
+    if file_path.startswith("file:"):
+        file_path = file_path[len("file:"):]
+
+    # 1. 尝试本地路径
+    local_path = Path(file_path)
+    if not local_path.exists():
+        local_path = Path(NAPCAT_TEMPFILE_DIR) / local_path.name
+
+    if local_path.exists():
+        return await ChatMessageSegmentFile.create_form_local_path(
+            local_path=str(local_path),
+            from_chat_key=from_chat_key,
+            file_name=seg.data.get("name", ""),
+        )
+
+    # 2. 无 file_id，无法继续
+    if "file_id" not in seg.data:
+        logger.warning(f"文件不存在且无 file_id: {seg}")
+        return None
+
+    # 3. 通过 get_file API 获取文件信息
+    try:
+        file_data = await asyncio.wait_for(
+            bot.call_api("get_file", file_id=seg.data["file_id"]),
+            timeout=30.0,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(f"调用 get_file 超时 (file_id={seg.data['file_id']})")
+        return None
+    except Exception:
+        logger.exception(f"调用 get_file 异常 (file_id={seg.data['file_id']})")
+        return None
+
+    # 3a. 检查 NapCat 临时目录
+    napcat_path = Path(NAPCAT_TEMPFILE_DIR) / file_data.get("file_name", "")
+    if napcat_path.exists():
+        return await ChatMessageSegmentFile.create_form_local_path(
+            local_path=str(napcat_path),
+            from_chat_key=from_chat_key,
+            file_name=file_data.get("file_name", ""),
+        )
+
+    # 3b. 通过 URL 下载
+    file_url = file_data.get("url", "")
+    if file_url and file_url.startswith("http"):
+        return await ChatMessageSegmentFile.create_from_url(
+            url=file_url,
+            from_chat_key=from_chat_key,
+            file_name=seg.data.get("name", ""),
+        )
+
+    logger.warning(f"无法获取文件下载链接: {seg}")
+    return None
+
+
 def parse_onebot_json_segment(seg: dict) -> tuple[str, dict[str, str | None], dict]:
     """解析OneBot JSON卡片消息段
 
@@ -655,53 +728,21 @@ async def convert_chat_message(
                     ),
                 )
             elif "file" in seg.data:
-                file_path = seg.data["file"]
-                if file_path.startswith("file:"):
-                    file_path = file_path[len("file:") :]
-
-                local_path = Path(file_path)
-                if not local_path.exists():
-                    local_path = Path(NAPCAT_TEMPFILE_DIR) / local_path.name
-
-                if local_path.exists():
+                file_seg = await _build_file_segment_from_onebot_file(
+                    seg=seg,
+                    bot=bot,
+                    from_chat_key=db_chat_channel.chat_key,
+                )
+                if file_seg:
+                    ret_list.append(file_seg)
+                else:
+                    fallback_name = seg.data.get("name", "unknown")
                     ret_list.append(
-                        await ChatMessageSegmentFile.create_form_local_path(
-                            local_path=str(local_path),
-                            from_chat_key=db_chat_channel.chat_key,
-                            file_name=seg.data.get("name", ""),
+                        ChatMessageSegment(
+                            type=ChatMessageSegmentType.TEXT,
+                            text=f"[文件: {fallback_name} (获取失败)]",
                         ),
                     )
-                elif "file_id" in seg.data:
-                    try:
-                        file_data = await asyncio.wait_for(
-                            bot.call_api("get_file", file_id=seg.data["file_id"]),
-                            timeout=30.0,
-                        )
-                        file_url = file_data.get("url", "")
-                        napcat_path = Path(NAPCAT_TEMPFILE_DIR) / file_data.get("file_name", "")
-                        if napcat_path.exists():
-                            ret_list.append(
-                                await ChatMessageSegmentFile.create_form_local_path(
-                                    local_path=str(napcat_path),
-                                    from_chat_key=db_chat_channel.chat_key,
-                                    file_name=file_data.get("file_name", ""),
-                                ),
-                            )
-                        elif file_url and file_url.startswith("http"):
-                            ret_list.append(
-                                await ChatMessageSegmentFile.create_from_url(
-                                    url=file_url,
-                                    from_chat_key=db_chat_channel.chat_key,
-                                    file_name=seg.data.get("name", ""),
-                                ),
-                            )
-                        else:
-                            logger.warning(f"无法获取文件下载链接: {seg}")
-                    except Exception as e:
-                        logger.warning(f"通过 API 获取文件失败: {e}")
-                else:
-                    logger.warning(f"文件不存在且无 file_id: {seg}")
-                    continue
             else:
                 logger.warning(f"OneBot file message without url or file: {seg}")
                 continue

--- a/nekro_agent/services/message_service.py
+++ b/nekro_agent/services/message_service.py
@@ -25,7 +25,7 @@ from nekro_agent.schemas.agent_message import (
     AgentMessageSegmentType,
     convert_agent_message_to_prompt,
 )
-from nekro_agent.schemas.chat_message import ChatMessage, ChatType
+from nekro_agent.schemas.chat_message import ChatMessage, ChatMessageSegmentType, ChatType
 from nekro_agent.schemas.errors import AdapterUnavailableError
 from nekro_agent.schemas.signal import MsgSignal
 from nekro_agent.services.channel_broadcaster import channel_broadcaster
@@ -379,6 +379,14 @@ class MessageService:
         content_triggered = check_content_trigger(message.content_text, config)
         should_trigger = explicit_triggered or random_triggered or content_triggered
         should_notify_quota_exhausted = explicit_triggered or content_triggered
+
+        # 纯媒体消息（无文本内容）不触发 AI 回复，仅记录
+        _MEDIA_TYPES = {"file", "image", "voice", "video"}
+        _MEDIA_OR_AT_TYPES = _MEDIA_TYPES | {"at"}
+        if should_trigger and all(seg.type in _MEDIA_OR_AT_TYPES for seg in message.content_data):
+            if any(seg.type in _MEDIA_TYPES for seg in message.content_data):
+                logger.info(f"纯媒体消息，仅记录不触发: {message.content_text[:32]}...")
+                should_trigger = False
 
         if not should_ignore and should_trigger:
             if not db_chat_channel.is_active:


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [x] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 无类型忽略标记 -->

## 🔍 变更类型 (勾选所有适用项)

- [x] 🐛 Bug 修复 (修复一个问题)
- [x] ✨ 新功能 (添加新功能)

## 📄 PR 描述

### 问题背景

OneBot V11 适配器在私聊场景下存在两个问题：

1. **私聊文件无法保存**：`_send_files` 方法调用 `bot.upload_private_file` 上传文件，受协议端（NapCat）限制，ZIP 等非多媒体格式文件可能无法上传或静默失败。同时，接收私聊文件时直接使用协议端返回的相对路径调用 `create_form_local_path`，导致 `FileNotFoundError`。

2. **纯文件消息立即触发 AI 回复**：私聊中发送文件后，AI 会立即触发回复流程。用户期望文件消息仅保存记录，等后续发送文本消息时再触发 AI（AI 可在历史记录中看到之前收到的文件）。

### 变更内容

#### 1. 文件发送统一物化模式 (`adapter.py`)

- `_send_files` 方法移除对 `upload_private_file` / `upload_group_file` 的依赖
- 统一使用 `copy_to_upload_dir` 将文件物化到 `uploads/{chat_key}/` 目录
- 通过 `MessageSegment.file` + `send_private_msg` / `send_group_msg` 发送，绕过协议端上传接口限制

#### 2. 私聊文件接收增强 (`convertor.py`)

- 当本地路径不存在时，先尝试在 `NAPCAT_TEMPFILE_DIR` 中查找
- 若仍未找到，通过 `file_id` 调用 NapCat 的 `get_file` API 获取下载 URL
- 优先使用 NapCat 临时目录路径，其次使用 URL 下载物化

#### 3. 纯媒体消息静默处理 (`message_service.py`)

- 在 `push_human_message` 的触发判断逻辑中，检测消息是否为纯媒体消息（所有 segment 为 file/image/voice/video 类型）
- 纯媒体消息写入数据库但不触发 AI 回复
- 兼容 `use_enum_values = True` 的字符串类型比较
- 排除私聊自动插入的 AT 段干扰（`convertor.py` 中 `msg_to_me=True` 时会插入 AT 段）

### 用户工作流

1. 私聊发送 file1.zip → 静默保存到 `uploads/`，不触发 AI 回复
2. 私聊发送 file2.zip → 静默保存，不回复
3. 私聊发送 "分析这些文件" → 触发 AI 回复，AI 在历史记录中能看到 file1 和 file2

## 🔗 相关 Issue

无关联 Issue。

## 📸 修改效果截图

无 UI 变更。

## 🛠️ 实现复杂度

- [x] 中等 (需要一些技术考量)

## 📋 实现细节

### 关键技术点

1. **枚举值序列化**：`ChatMessageSegment` 的 `Config` 中设置了 `use_enum_values = True`，导致 `seg.type` 存储的是字符串值（如 `"file"`）而非枚举成员（如 `ChatMessageSegmentType.FILE`）。纯媒体检测逻辑使用字符串集合进行比较。

2. **私聊 AT 段注入**：`convertor.py` L733-743 中，当 `msg_to_me=True` 且 `is_tome=False` 时，会在消息段列表头部插入 `ChatMessageSegmentAt` 段。纯媒体检测逻辑将 AT 段纳入白名单，确保 `[AT, FILE]` 结构的消息仍被判定为纯媒体消息。

3. **NapCat 文件获取**：NapCat 的 `get_file` API 返回 `{file, url, file_size, file_name}` 结构，优先使用临时目录路径，其次使用 URL 下载。

### 修改文件列表

| 文件 | 变更说明 |
|------|----------|
| `nekro_agent/adapters/onebot_v11/adapter.py` | `_send_files` 改为物化模式 |
| `nekro_agent/adapters/onebot_v11/tools/convertor.py` | 私聊文件接收增加 NapCat API 回退 |
| `nekro_agent/services/message_service.py` | 纯媒体消息静默处理 |

## 🧪 测试步骤

1. 启动服务，连接 NapCat 协议端
2. **私聊发送文件**（如 ZIP）→ 验证文件保存到 `uploads/onebot_v11-private_{qq}/` 目录，且不触发 AI 回复
3. **私聊发送文本消息** → 验证 AI 正常回复，且能在历史记录中看到之前收到的文件
4. **私聊同时发送文本+文件** → 验证正常触发 AI 回复
5. **群聊发送文件** → 验证文件正常保存且行为一致
<img width="1686" height="747" alt="屏幕截图 2026-04-28 203853" src="https://github.com/user-attachments/assets/38b92519-03e7-4416-a361-249e3c55a500" />

## Summary by Sourcery

通过将要发送的文件实体化到本地上传目录，统一 OneBot V11 的文件处理逻辑，提高私聊文件接收的鲁棒性，并防止纯媒体消息触发 AI 回复的同时，仍然对其进行记录。

New Features:
- 支持通过 NapCat 临时目录或 `get_file` API 回退机制解析缺失的本地路径来接收私聊文件，并将其持久化到聊天记录中。
- 允许在私聊和群聊中，通过实体化后的上传目录路径发送文件，使用标准消息段而非适配器特定的上传 API。

Bug Fixes:
- 通过检查 NapCat 临时路径并在必要时通过 URL 下载，修复处理私聊文件消息时的 `FileNotFoundError`。
- 防止纯媒体消息（包括仅文件的私聊消息）触发 AI 回复，确保它们仅被存入历史记录。

Enhancements:
- 简化 OneBot V11 适配器的文件发送逻辑，始终将文件实体化到上传目录中，并以文件消息段的方式发送。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify OneBot V11 file handling by materializing files to the local uploads directory for sending, improving private file reception robustness, and preventing pure media-only messages from triggering AI replies while still recording them.

New Features:
- Support receiving private chat files by resolving missing local paths via NapCat temp directory or get_file API fallbacks and persisting them into chat history.
- Allow sending files in both private and group chats via materialized upload directory paths using standard message segments instead of adapter-specific upload APIs.

Bug Fixes:
- Fix FileNotFoundError when handling private file messages by checking NapCat temporary paths and downloading via URL when necessary.
- Prevent pure media-only messages (including file-only private messages) from triggering AI responses, ensuring they are only stored in history.

Enhancements:
- Simplify OneBot V11 adapter file sending logic to always materialize files into the uploads directory and send them as file message segments.

</details>