### PR TITLE
fix: add explicit stream=False for non-streaming chat completions

### DIFF
--- a/nekro_agent/services/agent/openai.py
+++ b/nekro_agent/services/agent/openai.py
@@ -559,6 +559,7 @@ async def gen_openai_chat_response(
                     model=model,
                     messages=messages,
                     **gen_kwargs,
+                    stream=False,
                 )
                 if not res.choices or len(res.choices) == 0 or not res.choices[0].message.content:
                     raise ValueError(f"非流式响应内容为空，供应商未返回可用消息。原始响应: {res}")  # noqa: TRY301


### PR DESCRIPTION
## 问题描述

部分 OpenAI 兼容的 API 中转/代理服务，在请求体中**不包含 `stream` 字段**时，会默认返回 SSE 流式响应。

OpenAI Python SDK 在未显式传入 `stream` 参数时，**不会**在请求体中包含 `"stream": false`，而是直接省略该字段。这导致中转站将请求当作流式处理，返回 `text/event-stream` 格式的数据。

SDK 收到的原始 SSE 文本无法被解析为 `ChatCompletion` 对象，最终表现为响应类型是 `str`，后续访问 `.choices` 时报错：

```
AttributeError: 'str' object has no attribute 'choices'
```

该问题在管理面板的「连接测试」按钮中最容易触发（`model_test.py` 中 `build_openai_model_test_params` 传入 `stream_mode=False`，但 `gen_openai_chat_response` 的非流式分支未向 SDK 显式传递 `stream=False`）。

## 复现步骤

1. 配置一个使用 OpenAI 兼容中转站（如 new-api / one-api 等）的模型组
2. 该中转站在请求体缺少 `stream` 字段时默认返回流式响应
3. 在管理面板点击「连接测试」
4. 报错 `'str' object has no attribute 'choices'`

## 修复方案

在 `gen_openai_chat_response` 的非流式分支中显式传入 `stream=False`，确保请求体始终包含该字段。

改动仅一行，影响范围极小。

## Summary by Sourcery

Bug Fixes:
- 防止在省略 `stream` 字段时，会默认使用 SSE 的代理将非流式聊天补全调用误认为是流式调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent non-streaming chat completion calls from being treated as streaming by proxies that default to SSE when the stream field is omitted.

</details>