### PR TITLE
fix: validate one-shot timer trigger timestamps

### DIFF
--- a/nekro_agent/services/timer/timer_service.py
+++ b/nekro_agent/services/timer/timer_service.py
@@ -31,6 +31,7 @@ class TimerService:
 
     _PERSIST_VERSION = 2
     _MISFIRE_GRACE_SECONDS = 300
+    _MAX_TIMER_FUTURE_SECONDS = 10 * 365 * 24 * 60 * 60
 
     def __init__(self):
         self.tasks: Dict[str, List[TimerTask]] = {}  # chat_key -> [TimerTask]
@@ -41,6 +42,28 @@ class TimerService:
         path = Path(TIMER_ONE_SHOT_PERSIST_PATH)
         path.parent.mkdir(parents=True, exist_ok=True)
         return path
+
+    def _validate_trigger_time(self, trigger_time: int, *, now: Optional[int] = None) -> datetime:
+        """校验并转换定时器触发时间。
+
+        trigger_time 必须是 Unix 秒级时间戳，且不能超过合理的未来范围。
+        这可以避免模型或插件把 `20260430106805` 这类日期拼接值误传为时间戳，
+        导致 datetime.fromtimestamp() 溢出并污染内存/持久化数据。
+        """
+        if not isinstance(trigger_time, int):
+            raise ValueError(
+                f"trigger_time must be an integer Unix timestamp, got {type(trigger_time).__name__}",
+            )
+
+        now = int(time.time()) if now is None else now
+        max_trigger_time = now + self._MAX_TIMER_FUTURE_SECONDS
+        if trigger_time > max_trigger_time:
+            raise ValueError(f"trigger_time is too far in the future: {trigger_time}")
+
+        try:
+            return datetime.fromtimestamp(trigger_time)
+        except (OverflowError, OSError, ValueError) as e:
+            raise ValueError(f"invalid trigger_time: {trigger_time}") from e
 
     async def _load_persisted_tasks(self) -> None:
         """从数据目录恢复一次性/临时定时器。
@@ -84,6 +107,16 @@ class TimerService:
             if not isinstance(chat_key, str) or not isinstance(trigger_time, int) or not isinstance(event_desc, str):
                 continue
 
+            try:
+                self._validate_trigger_time(trigger_time, now=now)
+            except ValueError:
+                logger.warning(
+                    "丢弃非法持久化定时器: "
+                    f"task_id={task_id}, chat_key={chat_key}, trigger_time={trigger_time}",
+                )
+                dropped += 1
+                continue
+
             # 已过期：在宽限期内补发一次，否则丢弃
             if trigger_time <= now:
                 lag = now - trigger_time
@@ -106,6 +139,9 @@ class TimerService:
             task.callback = None
             self.tasks.setdefault(chat_key, []).append(task)
             restored += 1
+
+        if dropped:
+            await self._persist_tasks()
 
         logger.info(
             f"持久化定时器恢复完成: restored={restored}, triggered={triggered}, dropped={dropped}",
@@ -210,8 +246,15 @@ class TimerService:
             await message_service.schedule_agent_task(chat_key)
             return True
 
+        now = int(time.time())
         # 检查触发时间是否已过
-        if trigger_time <= int(time.time()):
+        if trigger_time <= now:
+            return False
+
+        try:
+            trigger_dt = self._validate_trigger_time(trigger_time, now=now)
+        except ValueError as e:
+            logger.warning(f"设置定时器失败: chat_key={chat_key}, trigger_time={trigger_time}, error={e}")
             return False
 
         if chat_key not in self.tasks:
@@ -226,7 +269,7 @@ class TimerService:
         task.callback = callback
         self.tasks[chat_key].append(task)
         if not silent:
-            logger.info(f"定时器设置成功: {chat_key} | 触发时间: {datetime.fromtimestamp(trigger_time)}")
+            logger.info(f"定时器设置成功: {chat_key} | 触发时间: {trigger_dt}")
 
         # 仅普通/临时定时器持久化；带 callback 的系统定时器不写磁盘
         if callback is None:

--- a/plugins/builtin/timer.py
+++ b/plugins/builtin/timer.py
@@ -159,8 +159,11 @@ async def timer_prompt(_ctx: AgentCtx) -> str:
         if len(desc) > config.MAX_DISPLAY_DESC_LENGTH:
             desc = desc[: config.MAX_DISPLAY_DESC_LENGTH // 2] + "..." + desc[-config.MAX_DISPLAY_DESC_LENGTH // 2 :]
 
-        # 格式化触发时间
-        trigger_time_str = datetime.fromtimestamp(t.trigger_time).strftime("%Y-%m-%d %H:%M:%S")
+        # 格式化触发时间。跳过非法时间戳，避免单条脏 timer 中断整个 prompt 渲染。
+        try:
+            trigger_time_str = datetime.fromtimestamp(t.trigger_time).strftime("%Y-%m-%d %H:%M:%S")
+        except (OverflowError, OSError, ValueError):
+            continue
 
         # 格式化剩余时间 - 更简洁的表示
         hours, remainder = divmod(remain_seconds, 3600)


### PR DESCRIPTION
## 问题描述

一次性/临时定时器的 `trigger_time` 期望是 Unix 秒级时间戳。但在 LLM/沙盒通过 RPC 调用 `set_timer` 时，可能会误传类似 `20260430106805` 这样的日期拼接值。

该值会在 `datetime.fromtimestamp(trigger_time)` 时被解释成极远未来时间，触发：

```text
ValueError: year 643997 is out of range
```

更糟糕的是，当前 `set_timer()` 在格式化日志前已经把 `TimerTask` 加入了内存列表。如果格式化日志时抛异常，坏任务会残留在内存中；之后任何正常 timer 持久化时，都会把这条坏数据一起写入 `one_shot_timers.json`。随后 `timer_prompt()` 每次渲染定时器列表都会再次触发异常，导致整轮 Agent 执行失败。

## 复现链路

1. RPC 调用 `set_timer(chat_key, 20260430106805, ...)`
2. `TimerTask` 已经加入内存
3. `datetime.fromtimestamp(20260430106805)` 抛出 `ValueError: year 643997 is out of range`
4. 后续正常 timer 触发 `_persist_tasks()` 时，把坏 timer 一起落盘
5. `timer_prompt()` 渲染时再次对坏 `trigger_time` 调用 `datetime.fromtimestamp()`，使聊天任务失败

## 修复内容

- 在 `TimerService` 中新增 `_validate_trigger_time()`：
  - 校验 `trigger_time` 必须是 int Unix 时间戳
  - 限制最大未来时间为 10 年，防止日期拼接值误入
  - 捕获 `datetime.fromtimestamp()` 的 `OverflowError/OSError/ValueError`
- `set_timer()` 在修改内存状态前先校验时间戳，非法值直接返回 `False`
- 启动恢复持久化 timer 时丢弃非法项，并重新持久化清理后的数据
- `timer_prompt()` 渲染时跳过非法 timer，避免单条脏数据拖垮整个 prompt 渲染

## 影响范围

仅影响一次性/临时 timer 的非法时间戳处理。正常 Unix 秒级时间戳不受影响。

## Summary by Sourcery

验证和清理一次性定时器触发时间戳，防止无效或过于遥远未来的值破坏内存中的定时器以及已持久化的定时器。

Bug 修复：
- 在将一次性定时器加入内存状态之前，拒绝并记录无效或过于遥远未来的触发时间戳。
- 在启动恢复过程中，丢弃并重新持久化存储的、具有无效 `trigger_time` 值的一次性定时器，避免重复失败。
- 在定时器提示中跳过渲染具有无效 `trigger_time` 值的定时器，防止单个异常定时器导致提示生成失败。

增强：
- 引入一个集中式的 `trigger_time` 校验辅助函数，设置受限的未来时间窗口，以防护格式错误的时间戳。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate and sanitize one-shot timer trigger timestamps to prevent invalid or excessively future values from corrupting in-memory and persisted timers.

Bug Fixes:
- Reject and log invalid or excessively future trigger timestamps before adding one-shot timers to in-memory state.
- Discard and re-persist stored one-shot timers with invalid trigger_time values during startup recovery to avoid repeated failures.
- Skip rendering of timers with invalid trigger_time values in the timer prompt to prevent a single bad timer from breaking prompt generation.

Enhancements:
- Introduce a centralized trigger_time validation helper with a bounded future window to guard against malformed timestamps.

</details>