### PR TITLE
fix(rpc): use JSON instead of pickle for sandbox RPC request body (CWE-502)

### DIFF
--- a/nekro_agent/services/rpc_service.py
+++ b/nekro_agent/services/rpc_service.py
@@ -1,5 +1,5 @@
 import asyncio
-import pickle
+import json
 from typing import Any, Tuple
 
 from pydantic import ValidationError as PydanticValidationError
@@ -9,9 +9,17 @@ from nekro_agent.schemas.rpc import RPCRequest
 
 
 def decode_rpc_request(raw_body: bytes) -> RPCRequest:
+    """Decode an RPC request body sent by the sandbox.
+
+    The body is parsed as JSON to avoid the arbitrary-code-execution risk
+    inherent to ``pickle.loads`` on attacker-influenced input (CWE-502).
+    Although the endpoint is gated by ``RPC_SECRET_KEY``, that key is shared
+    with sandbox containers running AI-generated code, so the request body
+    must be treated as untrusted and parsed with a safe deserializer.
+    """
     try:
-        payload = pickle.loads(raw_body)
-    except (pickle.UnpicklingError, EOFError, AttributeError, ValueError) as e:
+        payload = json.loads(raw_body)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
         raise ValidationError(reason="RPC 请求格式错误") from e
     try:
         return RPCRequest.model_validate(payload)

--- a/nekro_agent/services/sandbox/ext_caller_code.py
+++ b/nekro_agent/services/sandbox/ext_caller_code.py
@@ -32,7 +32,7 @@ def __extension_method_proxy(method: Callable):
         """Agent 执行沙盒扩展方法时实际调用的方法"""
 
         body = {"method": method.__name__, "args": list(args), "kwargs": dict(kwargs)}
-        data: bytes = _json.dumps(body, default=str).encode("utf-8")
+        data: bytes = _json.dumps(body).encode("utf-8")
         response = _requests.post(
             f"{CHAT_API}/ext/rpc_exec?container_key={CONTAINER_KEY}&from_chat_key={FROM_CHAT_KEY}",
             data=data,

--- a/nekro_agent/services/sandbox/ext_caller_code.py
+++ b/nekro_agent/services/sandbox/ext_caller_code.py
@@ -1,6 +1,7 @@
 """沙盒环境下的扩展方法调用代理"""
 
 import importlib
+import json as _json
 import pickle as _pickle
 import subprocess
 import sys
@@ -30,13 +31,13 @@ def __extension_method_proxy(method: Callable):
     def acutely_call_method(*args: Tuple[Any], **kwargs: Dict[str, Any]):
         """Agent 执行沙盒扩展方法时实际调用的方法"""
 
-        body = {"method": method.__name__, "args": args, "kwargs": kwargs}
-        data: bytes = _pickle.dumps(body)
+        body = {"method": method.__name__, "args": list(args), "kwargs": dict(kwargs)}
+        data: bytes = _json.dumps(body, default=str).encode("utf-8")
         response = _requests.post(
             f"{CHAT_API}/ext/rpc_exec?container_key={CONTAINER_KEY}&from_chat_key={FROM_CHAT_KEY}",
             data=data,
             headers={
-                "Content-Type": "application/octet-stream",
+                "Content-Type": "application/json",
                 "X-RPC-Token": RPC_SECRET_KEY,
             },
         )

--- a/tests/test_cwe502_rpc_service_pickle.py
+++ b/tests/test_cwe502_rpc_service_pickle.py
@@ -4,15 +4,19 @@ Imports the rpc_service module by file path so the heavy package __init__
 (nonebot, FastAPI, etc.) is not required to run the security regression test.
 """
 import importlib.util
+import json
 import os
 import pickle
 import sys
 import tempfile
 import types
+from pathlib import Path
 
 import pytest
 
-ROOT = "/Users/sebastion/projects/audits/KroMiose-nekro-agent-worktrees/cwe502-rpc-service-pickle-1c7e"
+# Derive the project root from this test file's location so the test is
+# portable across checkouts and CI environments.
+ROOT = str(Path(__file__).resolve().parents[1])
 
 
 def _load_module(name: str, path: str):
@@ -57,9 +61,29 @@ def test_pickle_payload_does_not_execute():
 
 
 def test_valid_json_request_is_accepted():
-    import json
     body = json.dumps({"method": "foo", "args": [1, "x"], "kwargs": {"a": 1}}).encode()
     req = decode_rpc_request(body)
     assert req.method == "foo"
     assert req.args == [1, "x"]
     assert req.kwargs == {"a": 1}
+
+
+def test_structurally_invalid_json_is_rejected():
+    """Syntactically valid JSON that does not match the RPCRequest schema must be rejected."""
+    # Missing required `method` field and `args` is not a list.
+    raw = json.dumps({"args": "not-a-list"}).encode("utf-8")
+    with pytest.raises(ValidationError):
+        decode_rpc_request(raw)
+
+
+def test_non_json_bytes_are_rejected():
+    """Arbitrary non-JSON bytes must raise ValidationError, not crash with JSONDecodeError."""
+    with pytest.raises(ValidationError):
+        decode_rpc_request(b"not json at all")
+
+
+def test_invalid_utf8_bytes_are_rejected():
+    """Bytes that are not valid UTF-8 must raise ValidationError, not UnicodeDecodeError."""
+    # 0xff is invalid as a UTF-8 start byte.
+    with pytest.raises(ValidationError):
+        decode_rpc_request(b"\xff\xfe\xfd")

--- a/tests/test_cwe502_rpc_service_pickle.py
+++ b/tests/test_cwe502_rpc_service_pickle.py
@@ -1,0 +1,65 @@
+"""PoC test for CWE-502 in nekro_agent.services.rpc_service.decode_rpc_request.
+
+Imports the rpc_service module by file path so the heavy package __init__
+(nonebot, FastAPI, etc.) is not required to run the security regression test.
+"""
+import importlib.util
+import os
+import pickle
+import sys
+import tempfile
+import types
+
+import pytest
+
+ROOT = "/Users/sebastion/projects/audits/KroMiose-nekro-agent-worktrees/cwe502-rpc-service-pickle-1c7e"
+
+
+def _load_module(name: str, path: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Stub the parent packages so relative imports work without running their __init__.
+for pkg in ("nekro_agent", "nekro_agent.schemas", "nekro_agent.services"):
+    if pkg not in sys.modules:
+        m = types.ModuleType(pkg)
+        m.__path__ = [os.path.join(ROOT, *pkg.split("."))]
+        sys.modules[pkg] = m
+
+errors = _load_module("nekro_agent.schemas.errors", os.path.join(ROOT, "nekro_agent/schemas/errors.py"))
+rpc_schema = _load_module("nekro_agent.schemas.rpc", os.path.join(ROOT, "nekro_agent/schemas/rpc.py"))
+rpc_service = _load_module("nekro_agent.services.rpc_service", os.path.join(ROOT, "nekro_agent/services/rpc_service.py"))
+
+decode_rpc_request = rpc_service.decode_rpc_request
+ValidationError = errors.ValidationError
+
+
+SENTINEL = os.path.join(tempfile.gettempdir(), "nekro_rpc_pickle_pwn.txt")
+
+
+class _Pwn:
+    def __reduce__(self):
+        import os as _os
+        return (_os.system, (f"touch {SENTINEL}",))
+
+
+def test_pickle_payload_does_not_execute():
+    if os.path.exists(SENTINEL):
+        os.remove(SENTINEL)
+    raw = pickle.dumps(_Pwn())
+    with pytest.raises(ValidationError):
+        decode_rpc_request(raw)
+    assert not os.path.exists(SENTINEL), "RCE: pickle payload was executed!"
+
+
+def test_valid_json_request_is_accepted():
+    import json
+    body = json.dumps({"method": "foo", "args": [1, "x"], "kwargs": {"a": 1}}).encode()
+    req = decode_rpc_request(body)
+    assert req.method == "foo"
+    assert req.args == [1, "x"]
+    assert req.kwargs == {"a": 1}


### PR DESCRIPTION
## Summary

The `/ext/rpc_exec` endpoint deserializes the POST body with `pickle.loads`, which allows arbitrary code execution on the host process when an attacker controls the body. Because the only legitimate caller of this endpoint is the sandbox itself — and the sandbox is the trust boundary nekro-agent is designed to defend — this is a sandbox‑escape primitive (CWE-502).

- **CWE:** CWE-502 (Deserialization of Untrusted Data)
- **Severity:** High (sandbox escape → RCE on host)
- **Affected file/function:** `nekro_agent/services/rpc_service.py` → `decode_rpc_request`
- **Caller:** `nekro_agent/services/sandbox/ext_caller_code.py` (templated into the sandbox container)

### Data flow

1. `ext_caller_code.py` is rendered into the sandbox container with `RPC_SECRET_KEY` substituted in plaintext, so any code running in the sandbox can read the token from its environment / module globals.
2. AI/LLM-generated Python running in the sandbox crafts a malicious pickle payload (e.g. an object whose `__reduce__` returns `(os.system, ("…",))`) and `POST`s it to `/ext/rpc_exec` with the RPC token.
3. The host route handler hands the body to `decode_rpc_request`, which calls `pickle.loads(raw_body)` — executing the payload **in the host agent process**, outside the sandbox.

## Fix

Replace `pickle.loads` with `json.loads` on the request path, and update the sandbox-side client to send `application/json`. `RPCRequest` is a Pydantic model with only JSON-serializable fields (`method: str`, `args: list`, `kwargs: dict`), so this is a drop-in change.

```python
# nekro_agent/services/rpc_service.py
try:
    payload = json.loads(raw_body)
except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
    raise ValidationError(reason="RPC 请求格式错误") from e
return RPCRequest.model_validate(payload)
```

The host→sandbox **response** path still uses pickle, and is intentionally left unchanged: data flows from the trusted host into the sandbox there, so it is not an attack vector and modifying it would expand the diff without security benefit.

## Test results

A regression test (`tests/test_cwe502_rpc_service_pickle.py`) exercises both the exploit and the happy path:

- `test_pickle_payload_does_not_execute` — sends a `pickle.dumps` of an object whose `__reduce__` runs `os.system("touch <sentinel>")`. Before the fix this creates the sentinel file (RCE confirmed); after the fix, `decode_rpc_request` raises `ValidationError` and the sentinel is never created.
- `test_valid_json_request_is_accepted` — a normal JSON body round-trips correctly into an `RPCRequest`.

Both tests pass against the patched code. The schema was reviewed to confirm `args`/`kwargs` only carry JSON-compatible primitives in normal operation.

## Security analysis

The endpoint is gated by `X-RPC-Token: RPC_SECRET_KEY`, which at first glance looks like sufficient protection. It is not — by design the secret is shared with every sandbox container so that legitimate extension calls work, and the rendered `ext_caller_code.py` literally embeds it as a module constant. Any Python executed inside the sandbox can read it. Since the sandbox runs LLM-generated code on behalf of users, the threat model already assumes that body content could be hostile, and the deserializer must therefore be safe.

The fix removes the unsafe deserializer entirely on the only path where attacker-influenced bytes reach it. After the change, the worst a malicious sandbox payload can do via this endpoint is submit a well-formed JSON RPC call that the existing dispatcher already validates and authorizes.

### Adversarial review

Before submitting, we tried to disprove this. We checked whether the `RPC_SECRET_KEY` check, container isolation, or the `container_key`/`from_chat_key` query parameters would prevent exploitation; none do, because the secret is intentionally provisioned into the sandbox and the dangerous `pickle.loads` runs *before* any of the application-level checks that consume those parameters. We also confirmed the response path (host→sandbox) does not need changing, since the trust direction there is reversed. The preconditions ("execute Python in the sandbox") are exactly the sandbox's intended trust boundary, so a bug that crosses it is a real escape rather than a duplicate of an existing capability.

cc @lewiswigmore

## Summary by Sourcery

将沙箱 RPC 请求处理从基于 pickle 的反序列化切换为 JSON，以消除在攻击者可控输入上进行不安全反序列化的问题，并为 CWE-502 漏洞添加回归测试。

Bug 修复：
- 通过将 `/ext/rpc_exec` 请求体中的 `pickle.loads` 替换为 `json.loads`，防止在主机代理中发生任意代码执行。
- 确保沙箱 RPC 客户端发送经过 JSON 编码的请求，并使用合适的 `Content-Type` 头，而不是发送经过 pickle 序列化的负载。

测试：
- 添加安全回归测试，以证明恶意的 pickle 负载不再被执行，并验证格式正确的 JSON RPC 请求仍然会被接受。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch sandbox RPC request handling from pickle-based deserialization to JSON to eliminate unsafe deserialization on attacker-controlled input and add a regression test for the CWE-502 vulnerability.

Bug Fixes:
- Prevent arbitrary code execution in the host agent by replacing pickle.loads with json.loads for /ext/rpc_exec request bodies.
- Ensure the sandbox RPC client sends JSON-encoded requests with the appropriate Content-Type header instead of pickled payloads.

Tests:
- Add a security regression test that proves malicious pickle payloads are no longer executed and validates that well-formed JSON RPC requests are still accepted.

</details>