### PR TITLE
fix: 修复 ADMIN_PASSWORD 环境变量 fallback 逻辑

### DIFF
--- a/nekro_agent/core/os_env.py
+++ b/nekro_agent/core/os_env.py
@@ -52,7 +52,7 @@ class OsEnv:
     STATIC_DIR: str = OsEnvTypes.Str("STATIC_DIR", default="./static")
 
     """WebUI 管理员密码"""
-    ADMIN_PASSWORD: str = OsEnvTypes.Str("ADMIN_PASSWORD", default="")
+    ADMIN_PASSWORD: str = os.environ.get("NEKRO_ADMIN_PASSWORD") or os.environ.get("ADMIN_PASSWORD", "")
 
     """Nekro Cloud API"""
     NEKRO_CLOUD_API_BASE_URL: str = OsEnvTypes.Str("NEKRO_CLOUD_API_BASE_URL", default="https://cloud.nekro.ai")


### PR DESCRIPTION
## 问题描述

`os.environ.get("NEKRO_ADMIN_PASSWORD") or OsEnvTypes.Str("ADMIN_PASSWORD", default="")` 存在逻辑错误：

- `OsEnvTypes.Str("ADMIN_PASSWORD")` 在 `_use_env` 中自动加上 `NEKRO_` 前缀，实际读取的是 `NEKRO_ADMIN_PASSWORD`
- 当 `NEKRO_ADMIN_PASSWORD=""`（空字符串）时，`os.environ.get()` 返回 `""`，`or` 短路不会触发 fallback
- 导致无前缀的 `ADMIN_PASSWORD` 环境变量永远无法生效

## 修复方案

```python
ADMIN_PASSWORD: str = os.environ.get("NEKRO_ADMIN_PASSWORD") or os.environ.get("ADMIN_PASSWORD", "")
```

**读取顺序**：
1. `NEKRO_ADMIN_PASSWORD`（docker-compose.yml 使用的变量名）
2. `ADMIN_PASSWORD`（直接部署/systemd 使用）

## 验证

- [x] 代码逻辑审查
- [ ] 在 docker-compose 环境中验证

## 影响范围

| 场景 | 影响 |
|------|------|
| `NEKRO_ADMIN_PASSWORD=xxx` 已设置 | ✅ 正常读取 |
| `NEKRO_ADMIN_PASSWORD=""` (空) | ✅ 正确 fallback 到 ADMIN_PASSWORD |
| `ADMIN_PASSWORD=xxx` (无前缀) | ✅ 正常读取 |

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- 修正 `ADMIN_PASSWORD` 的查找逻辑：先读取 `NEKRO_ADMIN_PASSWORD`，如果不存在则回退到 `ADMIN_PASSWORD`，从而避免之前基于 `OsEnvTypes` 的错误解析方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct ADMIN_PASSWORD lookup to read NEKRO_ADMIN_PASSWORD first and then fall back to ADMIN_PASSWORD, avoiding the previous incorrect OsEnvTypes-based resolution.

</details>