### PR TITLE
feat: 将清理过期沙盒失败的日志级别从 error 降为 warning

### DIFF
--- a/nekro_agent/services/sandbox/runner.py
+++ b/nekro_agent/services/sandbox/runner.py
@@ -201,7 +201,7 @@ async def run_code_in_sandbox(
             if "404" in str(e):
                 logger.debug(f"沙盒容器已不存在: {from_chat_key} | {container_name}")
             else:
-                logger.error(f"清理过期沙盒失败: {e}")
+                logger.warning(f"清理过期沙盒失败: {e}")
         del chat_key_sandbox_container_map[from_chat_key]
 
     # 启动容器


### PR DESCRIPTION
## 修改内容

**文件**: `nekro_agent/services/sandbox/runner.py` 第 204 行

```python
# 修改前
logger.error(f"清理过期沙盒失败: {e}")

# 修改后
logger.warning(f"清理过期沙盒失败: {e}")
```

## 原因

"清理过期沙盒失败: Session is closed" 属于清理容器时的偶发连接异常，不影响主流程。从 error 降为 warning 可避免干扰日志可读性，让真正的问题更容易被发现。

## 影响范围

- 仅影响日志级别，不影响功能逻辑
- 404 错误（容器已不存在）保持 debug 级别
- 其他异常现为 warning 而非 error

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Enhancements:
- 将日志级别从 error 降低为 warning，用于非 404 的沙盒清理失败情况，同时保持 404 情况仍为 debug 级别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Lower the log level from error to warning for non-404 sandbox cleanup failures while keeping 404 cases at debug level.

</details>