### PR TITLE
fix: 修复文件下载权限过宽问题并实现 Docker 非 root 运行

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# 确保数据目录存在且权限正确
+if [ -n "$NEKRO_DATA_DIR" ]; then
+    mkdir -p "$NEKRO_DATA_DIR"
+    chown -R nekro:nekro "$NEKRO_DATA_DIR"
+fi
+
+exec "$@"

--- a/docker/docker-compose-x-napcat.yml
+++ b/docker/docker-compose-x-napcat.yml
@@ -34,6 +34,7 @@ services:
   nekro_agent:
     image: kromiose/nekro-agent:latest
     container_name: ${INSTANCE_NAME:-}nekro_agent
+    user: "1000:1000"  # 以 nekro 用户运行，需确保宿主机数据目录权限匹配
     environment:
       - NEKRO_INSTANCE_NAME=${INSTANCE_NAME:-}nekro_agent
       - NEKRO_DATA_DIR=${NEKRO_DATA_DIR}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,6 +34,7 @@ services:
   nekro_agent:
     image: kromiose/nekro-agent:latest
     container_name: ${INSTANCE_NAME}nekro_agent
+    user: "1000:1000"  # 以 nekro 用户运行，需确保宿主机数据目录权限匹配
     environment:
       - NEKRO_DATA_DIR=${NEKRO_DATA_DIR}
       - NEKRO_EXPOSE_PORT=${NEKRO_EXPOSE_PORT:-8021}

--- a/dockerfile
+++ b/dockerfile
@@ -52,6 +52,9 @@ RUN apt install -y git
 # 清理缓存
 RUN apt clean && rm -rf /var/lib/apt/lists/*
 
+# 创建非 root 用户
+RUN groupadd -g 1000 nekro && useradd -u 1000 -g nekro -m nekro
+
 # 设置工作目录
 WORKDIR /app
 
@@ -79,11 +82,22 @@ COPY .env.prod ./
 # 从前端构建产物复制静态文件
 COPY --from=frontend-dist /frontend-dist ${STATIC_DIR}
 
+# 复制入口脚本
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# 设置 /app 目录权限
+RUN chown -R nekro:nekro /app
+
 # 暴露端口
 EXPOSE 8021
 
 # 健康检查
 HEALTHCHECK --interval=10s --timeout=3s CMD curl -f http://127.0.0.1:8021/api/health || exit 1
 
+# 切换到非 root 用户
+USER nekro
+
 # 启动应用
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["uv", "run", "bot", "--env=prod"]

--- a/nekro_agent/adapters/sse/tools/common.py
+++ b/nekro_agent/adapters/sse/tools/common.py
@@ -141,7 +141,7 @@ async def bytes_to_file(
     async with aiofiles.open(file_path, "wb") as f:
         await f.write(file_bytes)
 
-    file_path.chmod(0o755)
+    file_path.chmod(0o644)
     return str(file_path), file_name
 
 

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -114,7 +114,7 @@ async def download_file(
                 save_path.parent.mkdir(parents=True, exist_ok=True)
                 file_path = str(save_path)
             Path(file_path).write_bytes(content)
-            Path(file_path).chmod(0o755)
+            Path(file_path).chmod(0o644)
     except Exception:
         if retry_count > 0:
             return await download_file(
@@ -156,7 +156,7 @@ async def download_file_from_bytes(
         save_path.parent.mkdir(parents=True, exist_ok=True)
         file_path = str(save_path)
     Path(file_path).write_bytes(bytes_data)
-    Path(file_path).chmod(0o755)
+    Path(file_path).chmod(0o644)
     return file_path, file_name
 
 
@@ -192,7 +192,7 @@ async def download_file_from_base64(
         save_path.parent.mkdir(parents=True, exist_ok=True)
         file_path = str(save_path)
     Path(file_path).write_bytes(base64.b64decode(base64_str.encode(encoding="utf-8")))
-    Path(file_path).chmod(0o755)
+    Path(file_path).chmod(0o644)
     return file_path, file_name
 
 
@@ -219,7 +219,7 @@ async def copy_to_upload_dir(
         save_path = Path(USER_UPLOAD_DIR) / Path(file_name)
     save_path.parent.mkdir(parents=True, exist_ok=True)
     Path(save_path).write_bytes(Path(file_path).read_bytes())
-    Path(save_path).chmod(0o755)
+    Path(save_path).chmod(0o644)
     return str(save_path), file_name
 
 

--- a/plugins/builtin/email_utils.py
+++ b/plugins/builtin/email_utils.py
@@ -276,7 +276,7 @@ async def send_email_attachment(
             content = await src_file.read()
         async with aiofiles.open(target_path, "wb") as target_file:
             await target_file.write(content)
-        target_path.chmod(0o755)
+        target_path.chmod(0o644)
 
         logger.info(f"[附件发送] 文件复制到宿主机: {target_path}")
         logger.info(f"[附件发送] 参数 chat_key: {chat_key}")


### PR DESCRIPTION
## 修复内容

### 1. 安全问题：文件下载权限过宽（`0o755` → `0o644`）

`download_file`、`download_file_from_bytes`、`download_file_from_base64`、`copy_to_upload_dir` 等方法中下载/保存的文件被硬编码为 `0o755`（所有用户可执行），改为更安全的 `0o644`（仅所有者可写，所有人可读）。

涉及文件：
- `nekro_agent/tools/common_util.py` — 4 处修改
- `nekro_agent/adapters/sse/tools/common.py` — 1 处修改
- `plugins/builtin/email_utils.py` — 1 处修改

### 2. Docker 非 root 运行

Dockerfile 修改：
- 创建 `nekro` 用户（UID/GID=1000）
- 添加 `docker-entrypoint.sh` 入口脚本，确保 `${NEKRO_DATA_DIR}` 目录存在且权限正确
- 设置 `/app` 目录所有权为 `nekro:nekro`
- 使用 `USER nekro` 切换到非 root 用户运行

docker-compose.yml 修改：
- `nekro_agent` 服务添加 `user: "1000:1000"` 配置

## 测试计划

- [ ] 验证 Docker 构建成功
- [ ] 验证容器以 nekro 用户运行（`docker exec <container> whoami` 输出 `nekro`）
- [ ] 验证文件下载功能正常，文件权限为 0o644
- [ ] 验证数据目录挂载后权限正确

## 注意事项

- 宿主机的 `${NEKRO_DATA_DIR}` 目录需要确保 UID 1000 有写权限（entrypoint 会尝试 chown）
- 如果宿主机数据目录已存在且属于 root，可能需要手动 `chown -R 1000:1000 ${NEKRO_DATA_DIR}`

## 由 Sourcery 生成的摘要

收紧已下载和生成文件的默认文件权限，并以非 root 用户身份运行 Docker 化应用程序。

Bug 修复：
- 将下载、拷贝和邮件附件的文件权限从可执行（755）限制为仅对其他用户只读（644），以减少过度暴露的文件访问。

增强：
- 以非特权用户 `nekro` 身份运行应用容器，并通过 entrypoint 脚本调整应用和数据目录的所有权。

部署：
- 更新 Dockerfile 以创建并使用专用的非 root 用户，为 `/app` 设置适当的所有权，并引入一个 entrypoint 脚本，以确保数据目录存在且具有正确的权限。
- 配置 docker-compose 服务，使 `nekro_agent` 容器以 UID/GID 1000 运行，以符合新的非 root 运行模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten file permission defaults for downloaded and generated files and run the Dockerized application as a non-root user.

Bug Fixes:
- Restrict permissions on downloaded, copied, and email attachment files from executable (755) to read-only for others (644) to reduce overexposed file access.

Enhancements:
- Run the application container as an unprivileged 'nekro' user, including ownership adjustments for the app and data directories via an entrypoint script.

Deployment:
- Update Dockerfile to create and use a dedicated non-root user, set appropriate ownership on /app, and introduce an entrypoint script that ensures the data directory exists with correct permissions.
- Configure docker-compose services to run the nekro_agent container with UID/GID 1000 to align with the new non-root runtime model.

</details>