### PR TITLE
fix(onebot_v11): 修复文件消息重复解析 Bug

### DIFF
--- a/nekro_agent/adapters/onebot_v11/matchers/message.py
+++ b/nekro_agent/adapters/onebot_v11/matchers/message.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional, Union
+from typing import Optional, Set, Union
 
 from nonebot import on_message, on_notice
 from nonebot.adapters.onebot.v11 import (
@@ -29,6 +29,20 @@ from nekro_agent.core import config, logger
 from nekro_agent.models.db_chat_channel import DBChatChannel
 from nekro_agent.models.db_user import DBUser
 from nekro_agent.schemas.chat_message import ChatMessageSegmentForward
+
+# 用于去重的文件路径缓存，限制大小防止内存泄漏
+_FILE_PATH_SEEN: Set[str] = set()
+_FILE_PATH_CACHE_MAX = 1000
+
+
+def _mark_path_seen(file_path: str) -> bool:
+    """标记文件路径已处理，返回 True 表示是新文件（未重复），False 表示已见过（重复）。"""
+    if len(_FILE_PATH_SEEN) > _FILE_PATH_CACHE_MAX:
+        _FILE_PATH_SEEN.clear()
+    if file_path in _FILE_PATH_SEEN:
+        return False
+    _FILE_PATH_SEEN.add(file_path)
+    return True
 
 
 def register_matcher(adapter: BaseAdapter):
@@ -133,6 +147,19 @@ def register_matcher(adapter: BaseAdapter):
         # 消息内容处理
         content_data, msg_tome, message_id = await convert_chat_message(event, False, bot, db_chat_channel, adapter)
         if not content_data:  # 忽略无法转换的消息
+            return
+
+        # 去重：过滤掉已经处理过的文件（通过 GroupUploadNoticeEvent 和 GroupMessageEvent 指向同一文件）
+        from nekro_agent.schemas.chat_message import ChatMessageSegmentType
+        filtered_content = []
+        for seg in content_data:
+            if seg.type == ChatMessageSegmentType.FILE and hasattr(seg, "local_path"):
+                if not _mark_path_seen(seg.local_path):
+                    logger.debug(f"跳过重复文件: {seg.local_path}")
+                    continue
+            filtered_content.append(seg)
+        content_data = filtered_content
+        if not content_data:
             return
 
         sender_nickname: str = await get_user_name(


### PR DESCRIPTION
## Bug 描述

用户发送文件时，上下文中出现两条文件消息：
```
第一次：<File:/app/uploads/e62637ea8a114355b985fd86c9ffbd6e.plain>
第二次：<File:/app/uploads/LICENSE.txt>
```

## 根因

QQ 发送文件时，OneBot v11 协议同时触发 `GroupMessageEvent` 和 `GroupUploadNoticeEvent`，两个处理器共用优先级 `priority=99999, block=False`，导致无阻塞并行处理：

- `GroupMessageEvent` 通过 `get_file` API 拿到临时路径，复制时 `file_name` 为空，使用 **MD5 哈希文件名**（如 `e62637ea...plain`）
- `GroupUploadNoticeEvent` 稍后处理，使用 **真实文件名** 再次复制（如 `LICENSE.txt`）

两个文件段同时提交给 `collect_message`，用户看到两条不同的文件消息。

## 修复方案

在 `GroupUploadNoticeEvent` 处理器中，对文件段的 `local_path` 做去重检查。如果该路径已被 `GroupMessageEvent` 处理过，则跳过本次提交，避免重复记录。

## 修改文件

- `nekro_agent/adapters/onebot_v11/matchers/message.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- 在 `GroupUploadNoticeEvent` 处理器中使用有界的内存缓存来记录已见过的本地文件路径，从而过滤掉已经处理过的文件分片，避免重复的文件消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Filter out already-processed file segments in the GroupUploadNoticeEvent handler using a bounded in-memory cache of seen local file paths to avoid duplicate file messages.

</details>