### PR TITLE
Enhance file message handling and optimize download process

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -84,8 +84,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            kromiose/nekro-agent:preview
-            kromiose/nekro-agent:preview-${{ steps.sha.outputs.short_sha }}
+            ${{ secrets.DOCKER_USERNAME }}/nekro-agent:preview
+            ${{ secrets.DOCKER_USERNAME }}/nekro-agent:preview-${{ steps.sha.outputs.short_sha }}
             ghcr.io/${{ steps.repo.outputs.owner }}/nekro-agent:preview
             ghcr.io/${{ steps.repo.outputs.owner }}/nekro-agent:preview-${{ steps.sha.outputs.short_sha }}
           cache-from: type=gha
@@ -140,8 +140,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            kromiose/nekro-agent-sandbox:preview
-            kromiose/nekro-agent-sandbox:preview-${{ steps.sha.outputs.short_sha }}
+            ${{ secrets.DOCKER_USERNAME }}/nekro-agent-sandbox:preview
+            ${{ secrets.DOCKER_USERNAME }}/nekro-agent-sandbox:preview-${{ steps.sha.outputs.short_sha }}
             ghcr.io/${{ steps.repo.outputs.owner }}/nekro-agent-sandbox:preview
             ghcr.io/${{ steps.repo.outputs.owner }}/nekro-agent-sandbox:preview-${{ steps.sha.outputs.short_sha }}
           cache-from: type=gha

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -84,8 +84,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/nekro-agent:preview
-            ${{ secrets.DOCKER_USERNAME }}/nekro-agent:preview-${{ steps.sha.outputs.short_sha }}
+            kromiose/nekro-agent:preview
+            kromiose/nekro-agent:preview-${{ steps.sha.outputs.short_sha }}
             ghcr.io/${{ steps.repo.outputs.owner }}/nekro-agent:preview
             ghcr.io/${{ steps.repo.outputs.owner }}/nekro-agent:preview-${{ steps.sha.outputs.short_sha }}
           cache-from: type=gha
@@ -140,8 +140,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/nekro-agent-sandbox:preview
-            ${{ secrets.DOCKER_USERNAME }}/nekro-agent-sandbox:preview-${{ steps.sha.outputs.short_sha }}
+            kromiose/nekro-agent-sandbox:preview
+            kromiose/nekro-agent-sandbox:preview-${{ steps.sha.outputs.short_sha }}
             ghcr.io/${{ steps.repo.outputs.owner }}/nekro-agent-sandbox:preview
             ghcr.io/${{ steps.repo.outputs.owner }}/nekro-agent-sandbox:preview-${{ steps.sha.outputs.short_sha }}
           cache-from: type=gha

--- a/nekro_agent/adapters/onebot_v11/matchers/message.py
+++ b/nekro_agent/adapters/onebot_v11/matchers/message.py
@@ -28,7 +28,11 @@ from nekro_agent.adapters.onebot_v11.tools.onebot_util import (
 from nekro_agent.core import config, logger
 from nekro_agent.models.db_chat_channel import DBChatChannel
 from nekro_agent.models.db_user import DBUser
-from nekro_agent.schemas.chat_message import ChatMessageSegmentForward
+from nekro_agent.schemas.chat_message import ChatMessageSegment, ChatMessageSegmentForward
+
+
+def _build_content_text_from_segments(content_data: list[ChatMessageSegment]) -> str:
+    return "".join(seg.text for seg in content_data if seg.text).strip()
 
 
 def register_matcher(adapter: BaseAdapter):
@@ -78,6 +82,8 @@ def register_matcher(adapter: BaseAdapter):
             if isinstance(seg, ChatMessageSegmentForward):
                 content_text = seg.text
                 break
+        if not content_text:
+            content_text = _build_content_text_from_segments(content_data)
 
         ignored_prefixes = (
             [config.AI_COMMAND_OUTPUT_PREFIX, *config.AI_IGNORED_PREFIXES]
@@ -148,7 +154,7 @@ def register_matcher(adapter: BaseAdapter):
             sender_name=sender_name,
             sender_nickname=sender_nickname,
             content_data=content_data,
-            content_text="",
+            content_text=_build_content_text_from_segments(content_data),
             is_tome=bool(msg_tome),
             timestamp=int(time.time()),
         )

--- a/nekro_agent/adapters/onebot_v11/tools/convertor.py
+++ b/nekro_agent/adapters/onebot_v11/tools/convertor.py
@@ -40,6 +40,40 @@ FORWARD_FALLBACK_TEXT = "[合并转发消息]"  # i18n: Forward message fallback
 MAX_FORWARD_DEPTH = 3  # 合并转发最大递归深度
 
 
+def _is_http_url(url: str) -> bool:
+    return url.startswith(("http://", "https://"))
+
+
+def _extract_http_url(data: object) -> str:
+    if isinstance(data, str):
+        return data if _is_http_url(data) else ""
+    if not isinstance(data, dict):
+        return ""
+
+    for key in ("url", "file_url"):
+        url = data.get(key, "")
+        if isinstance(url, str) and _is_http_url(url):
+            return url
+
+    return _extract_http_url(data.get("data"))
+
+
+def _extract_file_busid(*sources: object) -> Optional[Union[int, str]]:
+    for source in sources:
+        if isinstance(source, dict):
+            for key in ("busid", "bus_id"):
+                busid = source.get(key)
+                if busid not in (None, ""):
+                    return busid
+            continue
+
+        for attr in ("busid", "bus_id"):
+            busid = getattr(source, attr, None)
+            if busid not in (None, ""):
+                return busid
+    return None
+
+
 async def _parse_forward_nodes(
     nodes: list,
     bot: Bot,
@@ -417,65 +451,83 @@ async def _build_file_segment_from_onebot_file(
     seg: dict,
     bot: Bot,
     from_chat_key: str,
+    group_id: Optional[Union[int, str]] = None,
 ) -> Optional[ChatMessageSegmentFile]:
     """从 OneBot 文件消息段构建 ChatMessageSegmentFile
 
-    优先级：本地路径 → NapCat 临时目录 → get_file API（临时目录路径 → URL 下载）
+    优先级：本地路径 → NapCat 临时目录 → get_file API → 群/私聊文件直链 API
 
     Args:
         seg: OneBot MessageSegment 的 data 字典
         bot: Bot 实例
         from_chat_key: 聊天频道标识
+        group_id: 群号；为空时使用私聊文件直链兜底
 
     Returns:
         ChatMessageSegmentFile 或 None（所有方式均失败时）
     """
-    file_path = seg.data["file"]
+    file_path = seg.data.get("file", "")
     if file_path.startswith("file:"):
         file_path = file_path[len("file:"):]
 
     # 1. 尝试本地路径
-    local_path = Path(file_path)
-    if not local_path.exists():
-        local_path = Path(NAPCAT_TEMPFILE_DIR) / local_path.name
+    if file_path:
+        local_path = Path(file_path)
+        if not local_path.exists():
+            local_path = Path(NAPCAT_TEMPFILE_DIR) / local_path.name
 
-    if local_path.exists():
-        return await ChatMessageSegmentFile.create_form_local_path(
-            local_path=str(local_path),
-            from_chat_key=from_chat_key,
-            file_name=seg.data.get("name", ""),
-        )
+        if local_path.exists():
+            return await ChatMessageSegmentFile.create_form_local_path(
+                local_path=str(local_path),
+                from_chat_key=from_chat_key,
+                file_name=seg.data.get("name", ""),
+            )
 
     # 2. 无 file_id，无法继续
     if "file_id" not in seg.data:
         logger.warning(f"文件不存在且无 file_id: {seg}")
         return None
 
+    file_id = seg.data["file_id"]
+
     # 3. 通过 get_file API 获取文件信息
     try:
         file_data = await asyncio.wait_for(
-            bot.call_api("get_file", file_id=seg.data["file_id"]),
+            bot.call_api("get_file", file_id=file_id),
             timeout=30.0,
         )
     except asyncio.TimeoutError:
-        logger.warning(f"调用 get_file 超时 (file_id={seg.data['file_id']})")
-        return None
-    except Exception:
-        logger.exception(f"调用 get_file 异常 (file_id={seg.data['file_id']})")
-        return None
+        logger.warning(f"调用 get_file 超时 (file_id={file_id})")
+        file_data = {}
+    except Exception as e:
+        logger.warning(f"调用 get_file 异常 (file_id={file_id}): {e}")
+        file_data = {}
+    else:
+        # 3a. 检查 NapCat 临时目录
+        napcat_path = Path(NAPCAT_TEMPFILE_DIR) / file_data.get("file_name", "")
+        if napcat_path.exists():
+            return await ChatMessageSegmentFile.create_form_local_path(
+                local_path=str(napcat_path),
+                from_chat_key=from_chat_key,
+                file_name=file_data.get("file_name", ""),
+            )
 
-    # 3a. 检查 NapCat 临时目录
-    napcat_path = Path(NAPCAT_TEMPFILE_DIR) / file_data.get("file_name", "")
-    if napcat_path.exists():
-        return await ChatMessageSegmentFile.create_form_local_path(
-            local_path=str(napcat_path),
-            from_chat_key=from_chat_key,
-            file_name=file_data.get("file_name", ""),
-        )
+        # 3b. 通过 URL 下载
+        file_url = _extract_http_url(file_data)
+        if file_url:
+            return await ChatMessageSegmentFile.create_from_url(
+                url=file_url,
+                from_chat_key=from_chat_key,
+                file_name=seg.data.get("name", ""),
+            )
 
-    # 3b. 通过 URL 下载
-    file_url = file_data.get("url", "")
-    if file_url and file_url.startswith("http"):
+    file_url = await _get_onebot_file_url(
+        bot=bot,
+        file_id=file_id,
+        group_id=group_id,
+        busid=_extract_file_busid(seg.data, file_data),
+    )
+    if file_url:
         return await ChatMessageSegmentFile.create_from_url(
             url=file_url,
             from_chat_key=from_chat_key,
@@ -484,6 +536,36 @@ async def _build_file_segment_from_onebot_file(
 
     logger.warning(f"无法获取文件下载链接: {seg}")
     return None
+
+
+async def _get_onebot_file_url(
+    bot: Bot,
+    file_id: str,
+    group_id: Optional[Union[int, str]] = None,
+    busid: Optional[Union[int, str]] = None,
+) -> str:
+    if group_id is not None:
+        action = "get_group_file_url"
+        params: dict[str, object] = {"group_id": group_id, "file_id": file_id}
+        if busid is not None:
+            params["busid"] = busid
+    else:
+        action = "get_private_file_url"
+        params = {"file_id": file_id}
+
+    try:
+        file_data = await asyncio.wait_for(bot.call_api(action, **params), timeout=10.0)
+    except asyncio.TimeoutError:
+        logger.warning(f"调用 {action} 超时 (file_id={file_id})")
+        return ""
+    except Exception as e:
+        logger.warning(f"调用 {action} 异常 (file_id={file_id}): {e}")
+        return ""
+
+    file_url = _extract_http_url(file_data)
+    if not file_url:
+        logger.warning(f"{action} 未返回有效直链: {file_data}")
+    return file_url
 
 
 def parse_onebot_json_segment(seg: dict) -> tuple[str, dict[str, str | None], dict]:
@@ -591,18 +673,17 @@ async def convert_chat_message(
         if ob_event.file.size > config.MAX_UPLOAD_SIZE_MB * 1024 * 1024:
             logger.warning(f"文件过大，跳过处理: {ob_event.file.name}")
             return ret_list, False, ""
-        if ob_event.file.model_extra and ob_event.file.model_extra.get("url"):
-            suffix = "." + ob_event.file.name.rsplit(".", 1)[-1]
-            if not ob_event.file.model_extra["url"].startswith("http"):
-                logger.warning(f"上传文件无法获取到直链: {ob_event.file.model_extra['url']}")
-                return ret_list, False, ""
+        file_url = _extract_http_url(ob_event.file.model_extra)
+        if file_url:
             ret_list.append(
                 await ChatMessageSegmentFile.create_from_url(
-                    url=ob_event.file.model_extra["url"],
+                    url=file_url,
                     from_chat_key=db_chat_channel.chat_key,
                 ),
             )
+
         elif ob_event.file.id:
+            file_data = {}
             try:
                 file_data = await asyncio.wait_for(
                     bot.get_file(file_id=ob_event.file.id),
@@ -610,24 +691,51 @@ async def convert_chat_message(
                 )
             except asyncio.TimeoutError:
                 logger.warning(f"获取文件信息超时 (file_id={ob_event.file.id})")
-                return ret_list
             except Exception as e:
                 logger.warning(f"获取文件信息失败: {e}")
-                return ret_list
-            logger.debug(f"获取文件: {file_data}")
-            # TODO: 获取文件: {'file': '/app/.config/QQ/NapCat/temp/XXXXXX.csv', 'url': '/app/.config/QQ/NapCat/temp/XXXXXX.csv', 'file_size': '1079', 'file_name': 'XXXXXX.csv'}
-            # napcat 挂载目录 ${NEKRO_DATA_DIR}/napcat_data/QQ:/app/.config/QQ
-            target_file_path = str(Path(NAPCAT_TEMPFILE_DIR) / file_data["file_name"])
-            if Path(target_file_path).exists():
+            else:
+                logger.debug(f"获取文件: {file_data}")
+                # TODO: 获取文件: {'file': '/app/.config/QQ/NapCat/temp/XXXXXX.csv', 'url': '/app/.config/QQ/NapCat/temp/XXXXXX.csv', 'file_size': '1079', 'file_name': 'XXXXXX.csv'}
+                # napcat 挂载目录 ${NEKRO_DATA_DIR}/napcat_data/QQ:/app/.config/QQ
+                file_name = file_data.get("file_name", "")
+                target_file_path = str(Path(NAPCAT_TEMPFILE_DIR) / file_name)
+                if file_name and Path(target_file_path).exists():
+                    ret_list.append(
+                        await ChatMessageSegmentFile.create_form_local_path(
+                            local_path=target_file_path,
+                            from_chat_key=db_chat_channel.chat_key,
+                            file_name=file_name,
+                        ),
+                    )
+                elif file_name:
+                    logger.warning(f"文件不存在: {target_file_path}")
+
+            file_url = _extract_http_url(file_data)
+            if file_url and not ret_list:
                 ret_list.append(
-                    await ChatMessageSegmentFile.create_form_local_path(
-                        local_path=target_file_path,
+                    await ChatMessageSegmentFile.create_from_url(
+                        url=file_url,
                         from_chat_key=db_chat_channel.chat_key,
-                        file_name=file_data["file_name"],
+                        file_name=ob_event.file.name,
                     ),
                 )
-            else:
-                logger.warning(f"文件不存在: {target_file_path}")
+            elif not ret_list:
+                file_url = await _get_onebot_file_url(
+                    bot=bot,
+                    file_id=ob_event.file.id,
+                    group_id=ob_event.group_id,
+                    busid=_extract_file_busid(ob_event.file, ob_event.file.model_extra or {}, file_data),
+                )
+                if file_url:
+                    ret_list.append(
+                        await ChatMessageSegmentFile.create_from_url(
+                            url=file_url,
+                            from_chat_key=db_chat_channel.chat_key,
+                            file_name=ob_event.file.name,
+                        ),
+                    )
+                else:
+                    logger.warning(f"无法获取上传文件下载链接: {ob_event.file}")
         else:
             logger.debug(f"无法处理的文件消息: {ob_event.file}")
 
@@ -720,29 +828,25 @@ async def convert_chat_message(
                 file_name = seg.data.get("name", "unknown")
                 logger.warning(f"文件过大，跳过处理: {file_name}")
                 continue
-            if "url" in seg.data:
+            file_url = _extract_http_url(seg.data)
+            if file_url:
                 ret_list.append(
                     await ChatMessageSegmentFile.create_from_url(
-                        url=seg.data["url"],
+                        url=file_url,
                         from_chat_key=db_chat_channel.chat_key,
                     ),
                 )
-            elif "file" in seg.data:
+            elif "file" in seg.data or "file_id" in seg.data:
                 file_seg = await _build_file_segment_from_onebot_file(
                     seg=seg,
                     bot=bot,
                     from_chat_key=db_chat_channel.chat_key,
+                    group_id=ob_event.group_id if isinstance(ob_event, GroupMessageEvent) else None,
                 )
                 if file_seg:
                     ret_list.append(file_seg)
                 else:
-                    fallback_name = seg.data.get("name", "unknown")
-                    ret_list.append(
-                        ChatMessageSegment(
-                            type=ChatMessageSegmentType.TEXT,
-                            text=f"[文件: {fallback_name} (获取失败)]",
-                        ),
-                    )
+                    logger.warning(f"无法转换文件消息，已跳过: {seg}")
             else:
                 logger.warning(f"OneBot file message without url or file: {seg}")
                 continue


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [x] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
无类型忽略标记。

## 🔍 变更类型 (勾选所有适用项)

- [x] 🐛 Bug 修复 (修复一个问题)
- [ ] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

修复 OneBot V11 群文件上传在部分实现中同时上报 `notice.group_upload` 和普通 `message` 文件段时，NekroAgent 会将同一个文件重复收集进上下文的问题。

本次改动通过 `chat_key + user_id + file_id` 建立短时去重指纹。`notice.group_upload` 会先延迟等待普通文件消息；如果普通文件消息到达，则保留普通消息，因为它带有真实 `message_id`；如果普通消息没有到达，则继续使用 `notice.group_upload` 作为兜底收集，避免漏掉文件。

同时补充普通 OneBot 文件段的文件名兜底逻辑，在 `name` 缺失时从 `file_name`、`file` 或 `path` 中提取 basename，避免文件被保存成 md5 hash 名。

## 🔗 相关 Issue

无。

## 📸 修改效果截图

无 UI 变更。

## 🛠️ 实现复杂度

- [ ] 简单 (小改动，影响有限)
- [x] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

- 在 OneBot V11 message matcher 内增加 10 秒 TTL 的内存去重缓存。
- `notice.group_upload` 转换成功后延迟 2 秒收集；若期间普通文件消息命中同一 `file_id` 指纹，则跳过 notice。
- 普通文件消息命中 pending notice 时标记消费，并正常按普通消息入库。
- 若普通文件消息先到，则记录 seen key，后续同一 `group_upload` notice 会被跳过。
- 改动不涉及数据库 schema、公共消息 schema、前端或迁移。

## 🧪 测试步骤 (可选)

1. 运行后端静态检查：`poe lint`。
2. 在 OneBot V11 群聊中上传文件。
3. 观察日志中即使同时出现 `notice.group_upload` 和普通 file message，上下文中也只保留一条文件消息。
4. 验证普通 file message 正常到达时保留普通消息。
5. 验证普通 file message 未到达时，`notice.group_upload` 会在短暂延迟后作为兜底入库。
6. 验证缺少 `name` 字段的普通文件消息保存时使用原始文件名，而不是 md5 hash 文件名。

## Summary by Sourcery

改进 OneBot V11 文件消息处理，避免重复的上下文条目，并使文件下载更加健壮且可配置。

Bug 修复：
- 防止在同时收到 `group_upload` 通知和普通文件消息时，对同一个 OneBot V11 群文件进行重复收集。
- 确保在保存文件时，即使 OneBot 文件段中缺少 `name` 字段，仍然使用有意义的原始文件名，而不是 MD5 哈希值。

增强：
- 统一并强化 OneBot 文件 URL 提取与文件名解析逻辑，包括对 NapCat 临时文件、`get_file` 响应以及 群/私聊 文件直链 API 的支持。
- 精简 OneBot 适配器中的文件消息处理逻辑，优先使用真实文件 URL，在此基础上通过多种回退策略获取文件，并在下载失败时改进日志记录。

CI：
- 更新预览 Docker 镜像发布工作流，使用配置的 Docker Hub 用户名密钥来生成镜像标签，而不是使用硬编码的命名空间。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve OneBot V11 file message handling to avoid duplicate context entries and make file downloads more robust and configurable.

Bug Fixes:
- Prevent duplicate collection of the same OneBot V11 group file when both group_upload notices and normal file messages are reported.
- Ensure OneBot file segments without a name field still use a meaningful original filename instead of an MD5 hash when saving.

Enhancements:
- Unify and harden OneBot file URL extraction and filename resolution, including support for NapCat temp files, get_file responses, and group/private file direct-link APIs.
- Streamline handling of file messages in OneBot adapters by preferring real file URLs, falling back through multiple retrieval strategies, and improving logging when downloads fail.

CI:
- Update preview Docker image publishing workflow to use the configured Docker Hub username secret instead of a hardcoded namespace for image tags.

</details>