### PR TITLE
fix: recover resource secrets and offline image startup

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -64,17 +64,20 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 # 首先复制依赖文件和 README（pyproject.toml 需要），利用缓存
 COPY pyproject.toml uv.lock README.md ./
 
+# 先安装第三方依赖，避免源码变更时重复下载依赖
+RUN uv sync --frozen --no-dev --no-install-project
+
 # 复制入口脚本（force-include 需要）
 COPY run_bot.py ./
-
-# 使用 UV 安装依赖（包括 nb-cli）
-RUN uv sync --frozen --no-dev
 
 # 复制应用代码
 COPY nekro_agent ./nekro_agent
 COPY plugins ./plugins
 COPY migrations ./migrations
 COPY .env.prod ./
+
+# 安装当前项目，确保运行期不再触发本地包构建
+RUN uv sync --frozen --no-dev
 
 # 从前端构建产物复制静态文件
 COPY --from=frontend-dist /frontend-dist ${STATIC_DIR}
@@ -86,4 +89,4 @@ EXPOSE 8021
 HEALTHCHECK --interval=10s --timeout=3s CMD curl -f http://127.0.0.1:8021/api/health || exit 1
 
 # 启动应用
-CMD ["uv", "run", "bot", "--env=prod"]
+CMD ["/app/.venv/bin/bot", "--env=prod"]

--- a/frontend/src/locales/en-US/workspace.json
+++ b/frontend/src/locales/en-US/workspace.json
@@ -884,6 +884,22 @@
         "boundListTitle": "Affected Workspaces",
         "confirm": "Delete Resource"
       },
+      "secretHealth": {
+        "title": "Resource sensitive fields are unavailable",
+        "description": "{{count}} resources contain sensitive fields that cannot be read. This usually happens after moving devices when NEKRO_JWT_SECRET_KEY differs from the old environment.",
+        "recoverAction": "Recover with old key",
+        "purgeAction": "Clear invalid fields",
+        "recoverTitle": "Recover Resources with Old Key",
+        "recoverContent": "Enter the NEKRO_JWT_SECRET_KEY used on the old device when these resources were created. After recovery, legacy ciphertext will be converted to plaintext JSON readable by the current version.",
+        "recoverConfirm": "Recover",
+        "purgeTitle": "Clear Invalid Sensitive Fields",
+        "purgeContent": "This clears all currently unreadable sensitive field values. Non-sensitive data such as hosts, usernames, and notes will be kept. You will need to edit the resources again to fill passwords, tokens, or private keys.",
+        "purgeConfirm": "Clear Fields",
+        "recoverSuccess": "Recovered sensitive fields for {{count}} resources",
+        "recoverFailed": "Recovery failed: {{message}}",
+        "purgeSuccess": "Cleared invalid sensitive fields for {{count}} resources",
+        "purgeFailed": "Clear failed: {{message}}"
+      },
       "notifications": {
         "created": "Resource created",
         "createFailed": "Create failed: {{message}}",

--- a/frontend/src/locales/zh-CN/workspace.json
+++ b/frontend/src/locales/zh-CN/workspace.json
@@ -884,6 +884,22 @@
         "boundListTitle": "受影响的工作区",
         "confirm": "删除资源"
       },
+      "secretHealth": {
+        "title": "检测到资源敏感字段不可用",
+        "description": "{{count}} 条资源的敏感字段无法读取，通常是迁移设备后 NEKRO_JWT_SECRET_KEY 与旧环境不一致导致。",
+        "recoverAction": "使用旧密钥恢复",
+        "purgeAction": "抹除失效字段",
+        "recoverTitle": "使用旧密钥恢复资源",
+        "recoverContent": "请输入旧设备创建这些资源时使用的 NEKRO_JWT_SECRET_KEY。恢复成功后，旧密文会转换为当前版本可读取的明文 JSON。",
+        "recoverConfirm": "开始恢复",
+        "purgeTitle": "抹除失效敏感字段",
+        "purgeContent": "此操作会清空所有当前无法解密的敏感字段值，主机、用户名、备注等非敏感信息会保留。清空后需要重新编辑资源填写密码、令牌或私钥。",
+        "purgeConfirm": "确认抹除",
+        "recoverSuccess": "已恢复 {{count}} 条资源敏感字段",
+        "recoverFailed": "恢复失败：{{message}}",
+        "purgeSuccess": "已抹除 {{count}} 条失效敏感字段",
+        "purgeFailed": "抹除失败：{{message}}"
+      },
       "notifications": {
         "created": "资源已创建",
         "createFailed": "创建失败：{{message}}",

--- a/frontend/src/pages/oobe/index.tsx
+++ b/frontend/src/pages/oobe/index.tsx
@@ -855,8 +855,6 @@ function WelcomeStep({
   useEffect(() => {
     if (isExiting) return // 转场中停止打字计时器，节省开销
 
-    let timer: number
-
     const handleType = () => {
       const i = loopNum % helloWords.length
       const fullText = helloWords[i]
@@ -889,7 +887,7 @@ function WelcomeStep({
       }
     }
 
-    timer = window.setTimeout(handleType, typingSpeed)
+    const timer = window.setTimeout(handleType, typingSpeed)
     return () => window.clearTimeout(timer)
   }, [displayText, isDeleting, loopNum, typingSpeed, isExiting])
 

--- a/frontend/src/pages/workspace/tabs/ResourcesTab.tsx
+++ b/frontend/src/pages/workspace/tabs/ResourcesTab.tsx
@@ -1017,6 +1017,9 @@ export default function ResourcesTab({ workspace }: { workspace?: WorkspaceDetai
   const [editingResourceId, setEditingResourceId] = useState<number | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<WorkspaceResourceBinding['resource'] | null>(null)
   const [dragBindingId, setDragBindingId] = useState<number | null>(null)
+  const [recoverDialogOpen, setRecoverDialogOpen] = useState(false)
+  const [purgeDialogOpen, setPurgeDialogOpen] = useState(false)
+  const [legacySecret, setLegacySecret] = useState('')
 
   const { data: templates = [] } = useQuery({
     queryKey: ['resource-templates'],
@@ -1025,6 +1028,10 @@ export default function ResourcesTab({ workspace }: { workspace?: WorkspaceDetai
   const { data: resources = [] } = useQuery({
     queryKey: ['resources'],
     queryFn: () => workspaceApi.getResources(),
+  })
+  const { data: secretHealth } = useQuery({
+    queryKey: ['resource-secret-health'],
+    queryFn: () => workspaceApi.getResourceSecretHealth(),
   })
   const { data: bindings = [] } = useQuery({
     queryKey: ['workspace-resources', workspace?.id],
@@ -1037,15 +1044,21 @@ export default function ResourcesTab({ workspace }: { workspace?: WorkspaceDetai
     enabled: editingResourceId !== null,
   })
 
-  const invalidateAll = () => {
-    queryClient.invalidateQueries({ queryKey: ['resources'] })
+  const invalidateAll = async () => {
+    const refreshTasks = [
+      queryClient.invalidateQueries({ queryKey: ['resources'] }),
+      queryClient.invalidateQueries({ queryKey: ['resource-secret-health'] }),
+    ]
     if (workspace) {
-      queryClient.invalidateQueries({ queryKey: ['workspace-resources', workspace.id] })
-      queryClient.invalidateQueries({ queryKey: ['workspace', workspace.id] })
+      refreshTasks.push(
+        queryClient.invalidateQueries({ queryKey: ['workspace-resources', workspace.id] }),
+        queryClient.invalidateQueries({ queryKey: ['workspace', workspace.id] }),
+      )
     }
     if (editingResourceId !== null) {
-      queryClient.invalidateQueries({ queryKey: ['resource-detail', editingResourceId] })
+      refreshTasks.push(queryClient.invalidateQueries({ queryKey: ['resource-detail', editingResourceId] }))
     }
+    await Promise.all(refreshTasks)
   }
 
   const createMutation = useMutation({
@@ -1121,6 +1134,27 @@ export default function ResourcesTab({ workspace }: { workspace?: WorkspaceDetai
     onSuccess: () => invalidateAll(),
   })
 
+  const recoverSecretsMutation = useMutation({
+    mutationFn: (secret: string) => workspaceApi.recoverResourceSecrets(secret),
+    onSuccess: async result => {
+      await invalidateAll()
+      notification.success(t('detail.resources.secretHealth.recoverSuccess', { count: result.recovered_count }))
+      setRecoverDialogOpen(false)
+      setLegacySecret('')
+    },
+    onError: (error: Error) => notification.error(t('detail.resources.secretHealth.recoverFailed', { message: error.message })),
+  })
+
+  const purgeSecretsMutation = useMutation({
+    mutationFn: () => workspaceApi.purgeUnreadableResourceSecrets(),
+    onSuccess: async result => {
+      await invalidateAll()
+      notification.success(t('detail.resources.secretHealth.purgeSuccess', { count: result.purged_count }))
+      setPurgeDialogOpen(false)
+    },
+    onError: (error: Error) => notification.error(t('detail.resources.secretHealth.purgeFailed', { message: error.message })),
+  })
+
   const mountedResourceIds = useMemo(() => new Set(bindings.map(item => item.resource_id)), [bindings])
 
   const filteredResources = useMemo(() => {
@@ -1137,6 +1171,36 @@ export default function ResourcesTab({ workspace }: { workspace?: WorkspaceDetai
   const availableCount = resources.length
   const aliasResourceCount = resources.filter(item => item.fixed_aliases.length > 0).length
   const sharedCount = resources.filter(item => item.bound_workspace_count > 1).length
+  const showSecretHealthAlert = Boolean(secretHealth && !secretHealth.ok)
+  const secretHealthAlert = showSecretHealthAlert ? (
+    <Alert
+      severity="warning"
+      action={(
+        <Stack direction="row" spacing={1}>
+          <ActionButton size="small" onClick={() => setRecoverDialogOpen(true)}>
+            {t('detail.resources.secretHealth.recoverAction')}
+          </ActionButton>
+          <ActionButton size="small" tone="danger" onClick={() => setPurgeDialogOpen(true)}>
+            {t('detail.resources.secretHealth.purgeAction')}
+          </ActionButton>
+        </Stack>
+      )}
+    >
+      <Stack spacing={0.5}>
+        <Typography variant="body2" sx={{ fontWeight: 700 }}>
+          {t('detail.resources.secretHealth.title')}
+        </Typography>
+        <Typography variant="body2">
+          {t('detail.resources.secretHealth.description', { count: secretHealth?.invalid_count ?? 0 })}
+        </Typography>
+        {secretHealth?.issues?.slice(0, 3).map(issue => (
+          <Typography key={issue.resource_id} variant="caption" color="text.secondary">
+            {issue.resource_name}: {issue.reason}
+          </Typography>
+        ))}
+      </Stack>
+    </Alert>
+  ) : null
 
   const initialCreateValue: WorkspaceResourceUpsertBody = useMemo(() => createEmptyResourceValue(), [])
 
@@ -1189,6 +1253,71 @@ export default function ResourcesTab({ workspace }: { workspace?: WorkspaceDetai
   const handleOpenWorkspaceMounts = (workspaceId: number) => {
     navigate(workspaceDetailPath(workspaceId, 'resources'))
   }
+
+  const resourceSecretDialogs = (
+    <>
+      <Dialog
+        open={recoverDialogOpen}
+        onClose={() => !recoverSecretsMutation.isPending && setRecoverDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+        disableRestoreFocus
+      >
+        <DialogTitle>{t('detail.resources.secretHealth.recoverTitle')}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={1.5} sx={{ pt: 0.5 }}>
+            <DialogContentText>{t('detail.resources.secretHealth.recoverContent')}</DialogContentText>
+            <TextField
+              type="password"
+              label="NEKRO_JWT_SECRET_KEY"
+              value={legacySecret}
+              onChange={event => setLegacySecret(event.target.value)}
+              fullWidth
+              autoComplete="off"
+              slotProps={{ htmlInput: NO_AUTOFILL_INPUT_PROPS }}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <ActionButton onClick={() => setRecoverDialogOpen(false)} disabled={recoverSecretsMutation.isPending}>
+            {t('actions.cancel', { ns: 'common' })}
+          </ActionButton>
+          <ActionButton
+            variant="contained"
+            onClick={() => recoverSecretsMutation.mutate(legacySecret)}
+            disabled={!legacySecret.trim() || recoverSecretsMutation.isPending}
+          >
+            {t('detail.resources.secretHealth.recoverConfirm')}
+          </ActionButton>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        open={purgeDialogOpen}
+        onClose={() => !purgeSecretsMutation.isPending && setPurgeDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+        disableRestoreFocus
+      >
+        <DialogTitle>{t('detail.resources.secretHealth.purgeTitle')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{t('detail.resources.secretHealth.purgeContent')}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <ActionButton onClick={() => setPurgeDialogOpen(false)} disabled={purgeSecretsMutation.isPending}>
+            {t('actions.cancel', { ns: 'common' })}
+          </ActionButton>
+          <ActionButton
+            tone="danger"
+            variant="contained"
+            onClick={() => purgeSecretsMutation.mutate()}
+            disabled={purgeSecretsMutation.isPending}
+          >
+            {t('detail.resources.secretHealth.purgeConfirm')}
+          </ActionButton>
+        </DialogActions>
+      </Dialog>
+    </>
+  )
 
   if (!inWorkspace) {
     return (
@@ -1244,6 +1373,8 @@ export default function ResourcesTab({ workspace }: { workspace?: WorkspaceDetai
                   </Box>
                 </Box>
 
+                {secretHealthAlert}
+
                 {filteredResources.length === 0 ? (
                   <Box
                     sx={{
@@ -1277,7 +1408,7 @@ export default function ResourcesTab({ workspace }: { workspace?: WorkspaceDetai
           </Card>
         </Box>
 
-      <ResourceEditorDialog
+        <ResourceEditorDialog
           open={editorOpen}
           mode={editorMode}
           templates={templates}
@@ -1349,11 +1480,13 @@ export default function ResourcesTab({ workspace }: { workspace?: WorkspaceDetai
             </ActionButton>
           </DialogActions>
         </Dialog>
+        {resourceSecretDialogs}
       </>
     )
   }
 
   return (
+    <>
     <Stack spacing={2}>
       <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
         <StatCard
@@ -1369,6 +1502,8 @@ export default function ResourcesTab({ workspace }: { workspace?: WorkspaceDetai
           color={theme.palette.info.main}
         />
       </Box>
+
+      {secretHealthAlert}
 
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, xl: 5 }}>
@@ -1499,5 +1634,7 @@ export default function ResourcesTab({ workspace }: { workspace?: WorkspaceDetai
         </Grid>
       </Grid>
     </Stack>
+    {resourceSecretDialogs}
+    </>
   )
 }

--- a/frontend/src/services/api/workspace.ts
+++ b/frontend/src/services/api/workspace.ts
@@ -493,6 +493,33 @@ export interface WorkspaceResourceUpsertBody {
   enabled: boolean
 }
 
+export interface WorkspaceResourceSecretIssue {
+  resource_id: number
+  resource_name: string
+  reason: string
+}
+
+export interface WorkspaceResourceSecretHealth {
+  ok: boolean
+  total: number
+  plaintext_count: number
+  legacy_encrypted_count: number
+  invalid_count: number
+  issues: WorkspaceResourceSecretIssue[]
+}
+
+export interface WorkspaceResourceSecretRecoverResult {
+  ok: boolean
+  recovered_count: number
+  invalid_count: number
+  issues: WorkspaceResourceSecretIssue[]
+}
+
+export interface WorkspaceResourceSecretPurgeResult {
+  ok: boolean
+  purged_count: number
+}
+
 export const workspaceApi = {
   // 工作区 CRUD
   getList: async (): Promise<WorkspaceSummary[]> => {
@@ -663,6 +690,23 @@ export const workspaceApi = {
   getResources: async (): Promise<WorkspaceResourceSummary[]> => {
     const response = await axios.get<{ items: WorkspaceResourceSummary[] }>('/resources')
     return response.data.items
+  },
+
+  getResourceSecretHealth: async (): Promise<WorkspaceResourceSecretHealth> => {
+    const response = await axios.get<WorkspaceResourceSecretHealth>('/resources/secret-health')
+    return response.data
+  },
+
+  recoverResourceSecrets: async (legacySecret: string): Promise<WorkspaceResourceSecretRecoverResult> => {
+    const response = await axios.post<WorkspaceResourceSecretRecoverResult>('/resources/secret-recover', {
+      legacy_secret: legacySecret,
+    })
+    return response.data
+  },
+
+  purgeUnreadableResourceSecrets: async (): Promise<WorkspaceResourceSecretPurgeResult> => {
+    const response = await axios.post<WorkspaceResourceSecretPurgeResult>('/resources/secret-purge')
+    return response.data
   },
 
   getResourceDetail: async (resourceId: number): Promise<WorkspaceResourceDetail> => {

--- a/nekro_agent/routers/resources.py
+++ b/nekro_agent/routers/resources.py
@@ -13,6 +13,10 @@ from nekro_agent.schemas.workspace_resource import (
     WorkspaceResourceDetailResponse,
     WorkspaceResourceListResponse,
     WorkspaceResourceReorderBody,
+    WorkspaceResourceSecretHealthResponse,
+    WorkspaceResourceSecretPurgeResponse,
+    WorkspaceResourceSecretRecoverBody,
+    WorkspaceResourceSecretRecoverResponse,
     WorkspaceResourceTemplatesResponse,
     WorkspaceResourceUpdate,
 )
@@ -45,6 +49,44 @@ async def list_resources(
     _current_user: DBUser = Depends(get_current_active_user),
 ) -> WorkspaceResourceListResponse:
     return WorkspaceResourceListResponse(items=await workspace_resource_service.list_resources())
+
+
+@router.get(
+    "/resources/secret-health",
+    summary="检查工作区资源敏感字段可用性",
+    response_model=WorkspaceResourceSecretHealthResponse,
+)
+@require_role(Role.Admin)
+async def check_resource_secret_health(
+    _current_user: DBUser = Depends(get_current_active_user),
+) -> WorkspaceResourceSecretHealthResponse:
+    return await workspace_resource_service.check_secret_payload_health()
+
+
+@router.post(
+    "/resources/secret-recover",
+    summary="使用旧密钥恢复工作区资源敏感字段",
+    response_model=WorkspaceResourceSecretRecoverResponse,
+)
+@require_role(Role.Admin)
+async def recover_resource_secrets(
+    body: WorkspaceResourceSecretRecoverBody,
+    _current_user: DBUser = Depends(get_current_active_user),
+) -> WorkspaceResourceSecretRecoverResponse:
+    return await workspace_resource_service.recover_legacy_secret_payloads(body.legacy_secret)
+
+
+@router.post(
+    "/resources/secret-purge",
+    summary="抹除无法解密的工作区资源敏感字段",
+    response_model=WorkspaceResourceSecretPurgeResponse,
+)
+@require_role(Role.Admin)
+async def purge_unreadable_resource_secrets(
+    _current_user: DBUser = Depends(get_current_active_user),
+) -> WorkspaceResourceSecretPurgeResponse:
+    purged_count = await workspace_resource_service.purge_unreadable_secret_payloads()
+    return WorkspaceResourceSecretPurgeResponse(ok=True, purged_count=purged_count)
 
 
 @router.post("/resources", summary="创建工作区资源", response_model=WorkspaceResourceDetailResponse)
@@ -87,16 +129,26 @@ async def delete_resource(
     return ActionOkResponse()
 
 
-@router.get("/workspaces/{workspace_id}/resources", summary="获取工作区已绑定资源", response_model=WorkspaceResourceBindingsResponse)
+@router.get(
+    "/workspaces/{workspace_id}/resources",
+    summary="获取工作区已绑定资源",
+    response_model=WorkspaceResourceBindingsResponse,
+)
 @require_role(Role.Admin)
 async def list_workspace_resources(
     workspace_id: int,
     _current_user: DBUser = Depends(get_current_active_user),
 ) -> WorkspaceResourceBindingsResponse:
-    return WorkspaceResourceBindingsResponse(items=await workspace_resource_service.list_workspace_bindings(workspace_id))
+    return WorkspaceResourceBindingsResponse(
+        items=await workspace_resource_service.list_workspace_bindings(workspace_id)
+    )
 
 
-@router.post("/workspaces/{workspace_id}/resources/check-bind", summary="检查资源绑定冲突", response_model=WorkspaceResourceCheckBindResponse)
+@router.post(
+    "/workspaces/{workspace_id}/resources/check-bind",
+    summary="检查资源绑定冲突",
+    response_model=WorkspaceResourceCheckBindResponse,
+)
 @require_role(Role.Admin)
 async def check_workspace_resource_bind(
     workspace_id: int,
@@ -107,7 +159,9 @@ async def check_workspace_resource_bind(
     return WorkspaceResourceCheckBindResponse(ok=not conflicts, conflicts=conflicts)
 
 
-@router.post("/workspaces/{workspace_id}/resources/{resource_id}", summary="绑定资源到工作区", response_model=ActionOkResponse)
+@router.post(
+    "/workspaces/{workspace_id}/resources/{resource_id}", summary="绑定资源到工作区", response_model=ActionOkResponse
+)
 @require_role(Role.Admin)
 async def bind_workspace_resource(
     workspace_id: int,
@@ -120,7 +174,9 @@ async def bind_workspace_resource(
     return ActionOkResponse()
 
 
-@router.delete("/workspaces/{workspace_id}/resources/{resource_id}", summary="解绑工作区资源", response_model=ActionOkResponse)
+@router.delete(
+    "/workspaces/{workspace_id}/resources/{resource_id}", summary="解绑工作区资源", response_model=ActionOkResponse
+)
 @require_role(Role.Admin)
 async def unbind_workspace_resource(
     workspace_id: int,

--- a/nekro_agent/schemas/workspace_resource.py
+++ b/nekro_agent/schemas/workspace_resource.py
@@ -136,5 +136,36 @@ class WorkspaceResourceCheckBindResponse(BaseModel):
     conflicts: List[WorkspaceResourceConflict] = Field(default_factory=list)
 
 
+class WorkspaceResourceSecretIssue(BaseModel):
+    resource_id: int
+    resource_name: str
+    reason: str
+
+
+class WorkspaceResourceSecretHealthResponse(BaseModel):
+    ok: bool
+    total: int = 0
+    plaintext_count: int = 0
+    legacy_encrypted_count: int = 0
+    invalid_count: int = 0
+    issues: List[WorkspaceResourceSecretIssue] = Field(default_factory=list)
+
+
+class WorkspaceResourceSecretRecoverBody(BaseModel):
+    legacy_secret: str = Field(..., min_length=1, description="旧 NEKRO_JWT_SECRET_KEY")
+
+
+class WorkspaceResourceSecretRecoverResponse(BaseModel):
+    ok: bool
+    recovered_count: int = 0
+    invalid_count: int = 0
+    issues: List[WorkspaceResourceSecretIssue] = Field(default_factory=list)
+
+
+class WorkspaceResourceSecretPurgeResponse(BaseModel):
+    ok: bool
+    purged_count: int = 0
+
+
 class ActionOkResponse(BaseModel):
     ok: bool = True

--- a/nekro_agent/services/resources/crypto.py
+++ b/nekro_agent/services/resources/crypto.py
@@ -1,6 +1,8 @@
 import base64
 import hashlib
 import json
+from dataclasses import dataclass
+from enum import Enum
 from typing import Dict
 
 from Crypto.Cipher import AES
@@ -8,32 +10,40 @@ from Crypto.Cipher import AES
 from nekro_agent.core.os_env import OsEnv
 
 
-def _get_secret_key() -> bytes:
-    return hashlib.sha256(OsEnv.JWT_SECRET_KEY.encode("utf-8")).digest()
+class SecretPayloadDecodeError(ValueError):
+    """敏感资源载荷无法解码。"""
 
 
-def encrypt_secret_payload(payload: Dict[str, str]) -> str:
-    if not payload:
-        return ""
-    cipher = AES.new(_get_secret_key(), AES.MODE_GCM)
-    plaintext = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-    ciphertext, tag = cipher.encrypt_and_digest(plaintext)
-    return json.dumps(
-        {
-            "nonce": base64.b64encode(cipher.nonce).decode("ascii"),
-            "ciphertext": base64.b64encode(ciphertext).decode("ascii"),
-            "tag": base64.b64encode(tag).decode("ascii"),
-        },
-        ensure_ascii=False,
-    )
+class SecretPayloadFormat(str, Enum):
+    EMPTY = "empty"
+    PLAIN = "plain"
+    LEGACY_ENCRYPTED = "legacy_encrypted"
+    INVALID = "invalid"
 
 
-def decrypt_secret_payload(value: str) -> Dict[str, str]:
-    if not value.strip():
-        return {}
-    data = json.loads(value)
+@dataclass(frozen=True)
+class SecretPayloadDecodeResult:
+    payload: Dict[str, str]
+    format: SecretPayloadFormat
+
+
+def _get_secret_key(secret: str | None = None) -> bytes:
+    return hashlib.sha256((secret if secret is not None else OsEnv.JWT_SECRET_KEY).encode("utf-8")).digest()
+
+
+def _normalize_payload(payload: object) -> Dict[str, str]:
+    if not isinstance(payload, dict):
+        raise SecretPayloadDecodeError("敏感资源载荷必须是 JSON 对象")
+    return {str(k): str(v) for k, v in payload.items()}
+
+
+def _is_legacy_encrypted_payload(data: object) -> bool:
+    return isinstance(data, dict) and {"nonce", "ciphertext", "tag"}.issubset(data.keys())
+
+
+def _decrypt_legacy_payload(data: dict, *, secret: str | None = None) -> Dict[str, str]:
     cipher = AES.new(
-        _get_secret_key(),
+        _get_secret_key(secret),
         AES.MODE_GCM,
         nonce=base64.b64decode(data["nonce"]),
     )
@@ -41,5 +51,36 @@ def decrypt_secret_payload(value: str) -> Dict[str, str]:
         base64.b64decode(data["ciphertext"]),
         base64.b64decode(data["tag"]),
     )
-    parsed = json.loads(plaintext.decode("utf-8"))
-    return {str(k): str(v) for k, v in parsed.items()}
+    return _normalize_payload(json.loads(plaintext.decode("utf-8")))
+
+
+def encrypt_secret_payload(payload: Dict[str, str]) -> str:
+    if not payload:
+        return ""
+    return json.dumps(_normalize_payload(payload), ensure_ascii=False)
+
+
+def decrypt_secret_payload(value: str, *, legacy_secret: str | None = None) -> Dict[str, str]:
+    return decode_secret_payload(value, legacy_secret=legacy_secret).payload
+
+
+def decode_secret_payload(value: str, *, legacy_secret: str | None = None) -> SecretPayloadDecodeResult:
+    if not value.strip():
+        return SecretPayloadDecodeResult(payload={}, format=SecretPayloadFormat.EMPTY)
+    data = json.loads(value)
+    if _is_legacy_encrypted_payload(data):
+        try:
+            return SecretPayloadDecodeResult(
+                payload=_decrypt_legacy_payload(data, secret=legacy_secret),
+                format=SecretPayloadFormat.LEGACY_ENCRYPTED,
+            )
+        except Exception as e:
+            raise SecretPayloadDecodeError(
+                "旧版加密敏感字段无法解密，请提供创建资源时使用的旧 NEKRO_JWT_SECRET_KEY"
+            ) from e
+    try:
+        return SecretPayloadDecodeResult(payload=_normalize_payload(data), format=SecretPayloadFormat.PLAIN)
+    except SecretPayloadDecodeError:
+        raise
+    except Exception as e:
+        raise SecretPayloadDecodeError("敏感资源载荷格式无效") from e

--- a/nekro_agent/services/resources/service.py
+++ b/nekro_agent/services/resources/service.py
@@ -14,10 +14,19 @@ from nekro_agent.schemas.workspace_resource import (
     WorkspaceResourceConflict,
     WorkspaceResourceCreate,
     WorkspaceResourceDetail,
+    WorkspaceResourceSecretHealthResponse,
+    WorkspaceResourceSecretIssue,
+    WorkspaceResourceSecretRecoverResponse,
     WorkspaceResourceSummary,
     WorkspaceResourceUpdate,
 )
-from nekro_agent.services.resources.crypto import decrypt_secret_payload, encrypt_secret_payload
+from nekro_agent.services.resources.crypto import (
+    SecretPayloadDecodeError,
+    SecretPayloadFormat,
+    decode_secret_payload,
+    decrypt_secret_payload,
+    encrypt_secret_payload,
+)
 from nekro_agent.services.resources.registry import get_resource_template
 
 
@@ -79,7 +88,9 @@ class WorkspaceResourceService:
                     public_payload[field.field_key] = field.value
         return public_payload, secret_payload
 
-    def _merge_field_values(self, fields: list[ResourceField], public_payload: dict[str, str], secret_payload: dict[str, str]) -> list[ResourceField]:
+    def _merge_field_values(
+        self, fields: list[ResourceField], public_payload: dict[str, str], secret_payload: dict[str, str]
+    ) -> list[ResourceField]:
         result: list[ResourceField] = []
         for field in self._sorted_fields(fields):
             field = field.model_copy(deep=True)
@@ -121,7 +132,10 @@ class WorkspaceResourceService:
     async def _build_detail(self, resource: DBWorkspaceResource) -> WorkspaceResourceDetail:
         summary = await self._build_summary(resource)
         fields = [ResourceField.model_validate(item) for item in (resource.schema_json or [])]
-        secret_payload = decrypt_secret_payload(resource.secret_payload_encrypted)
+        try:
+            secret_payload = decrypt_secret_payload(resource.secret_payload_encrypted)
+        except SecretPayloadDecodeError:
+            secret_payload = {}
         merged_fields = self._merge_field_values(fields, dict(resource.public_payload or {}), secret_payload)
         return WorkspaceResourceDetail(**summary.model_dump(), fields=merged_fields)
 
@@ -206,11 +220,101 @@ class WorkspaceResourceService:
         if not fields:
             raise ValidationError(reason="资源至少需要一个字段")
         existing_keys: set[str] = set()
-        normalized = [self._normalize_field(field, index, existing_keys) for index, field in enumerate(self._sorted_fields(fields))]
+        normalized = [
+            self._normalize_field(field, index, existing_keys)
+            for index, field in enumerate(self._sorted_fields(fields))
+        ]
         return normalized
 
     def _build_env_name(self, resource_key: str, field_key: str) -> str:
         return f"NEKRO_RESOURCE_{self._slugify(resource_key, upper=True)}_{self._slugify(field_key, upper=True)}"
+
+    async def check_secret_payload_health(self) -> WorkspaceResourceSecretHealthResponse:
+        resources = await DBWorkspaceResource.all().order_by("name", "id")
+        plaintext_count = 0
+        legacy_encrypted_count = 0
+        invalid_count = 0
+        issues: list[WorkspaceResourceSecretIssue] = []
+
+        for resource in resources:
+            try:
+                result = decode_secret_payload(resource.secret_payload_encrypted)
+            except Exception as e:
+                invalid_count += 1
+                issues.append(
+                    WorkspaceResourceSecretIssue(
+                        resource_id=resource.id,
+                        resource_name=resource.name,
+                        reason=str(e),
+                    )
+                )
+                continue
+            if result.format in (SecretPayloadFormat.EMPTY, SecretPayloadFormat.PLAIN):
+                plaintext_count += 1
+            elif result.format == SecretPayloadFormat.LEGACY_ENCRYPTED:
+                legacy_encrypted_count += 1
+
+        return WorkspaceResourceSecretHealthResponse(
+            ok=invalid_count == 0,
+            total=len(resources),
+            plaintext_count=plaintext_count,
+            legacy_encrypted_count=legacy_encrypted_count,
+            invalid_count=invalid_count,
+            issues=issues,
+        )
+
+    async def recover_legacy_secret_payloads(self, legacy_secret: str) -> WorkspaceResourceSecretRecoverResponse:
+        resources = await DBWorkspaceResource.all().order_by("name", "id")
+        recovered_count = 0
+        issues: list[WorkspaceResourceSecretIssue] = []
+
+        for resource in resources:
+            try:
+                result = decode_secret_payload(resource.secret_payload_encrypted)
+            except SecretPayloadDecodeError:
+                try:
+                    result = decode_secret_payload(resource.secret_payload_encrypted, legacy_secret=legacy_secret)
+                except Exception as e:
+                    issues.append(
+                        WorkspaceResourceSecretIssue(
+                            resource_id=resource.id,
+                            resource_name=resource.name,
+                            reason=str(e),
+                        )
+                    )
+                    continue
+            except Exception as e:
+                issues.append(
+                    WorkspaceResourceSecretIssue(
+                        resource_id=resource.id,
+                        resource_name=resource.name,
+                        reason=str(e),
+                    )
+                )
+                continue
+            if result.format == SecretPayloadFormat.LEGACY_ENCRYPTED:
+                resource.secret_payload_encrypted = encrypt_secret_payload(result.payload)
+                await resource.save(update_fields=["secret_payload_encrypted", "update_time"])
+                recovered_count += 1
+
+        return WorkspaceResourceSecretRecoverResponse(
+            ok=not issues,
+            recovered_count=recovered_count,
+            invalid_count=len(issues),
+            issues=issues,
+        )
+
+    async def purge_unreadable_secret_payloads(self) -> int:
+        resources = await DBWorkspaceResource.all().order_by("name", "id")
+        purged_count = 0
+        for resource in resources:
+            try:
+                decode_secret_payload(resource.secret_payload_encrypted)
+            except Exception:
+                resource.secret_payload_encrypted = ""
+                await resource.save(update_fields=["secret_payload_encrypted", "update_time"])
+                purged_count += 1
+        return purged_count
 
     async def check_bind_conflicts(self, workspace_id: int, resource_id: int) -> list[WorkspaceResourceConflict]:
         target = await self.get_resource_or_404(resource_id)
@@ -268,7 +372,9 @@ class WorkspaceResourceService:
         await self.refresh_workspace_cache(workspace_id)
         return await self._build_binding(binding, resource=resource)
 
-    async def _build_binding(self, binding: DBWorkspaceResourceBinding, *, resource: DBWorkspaceResource | None = None) -> WorkspaceResourceBinding:
+    async def _build_binding(
+        self, binding: DBWorkspaceResourceBinding, *, resource: DBWorkspaceResource | None = None
+    ) -> WorkspaceResourceBinding:
         resource = resource or await self.get_resource_or_404(binding.resource_id)
         return WorkspaceResourceBinding(
             binding_id=binding.id,
@@ -285,7 +391,11 @@ class WorkspaceResourceService:
             return []
         resources = await DBWorkspaceResource.filter(id__in=[item.resource_id for item in bindings]).all()
         resource_map = {item.id: item for item in resources}
-        return [await self._build_binding(binding, resource=resource_map[binding.resource_id]) for binding in bindings if binding.resource_id in resource_map]
+        return [
+            await self._build_binding(binding, resource=resource_map[binding.resource_id])
+            for binding in bindings
+            if binding.resource_id in resource_map
+        ]
 
     async def unbind_resource(self, workspace_id: int, resource_id: int) -> None:
         binding = await DBWorkspaceResourceBinding.get_or_none(workspace_id=workspace_id, resource_id=resource_id)
@@ -306,7 +416,9 @@ class WorkspaceResourceService:
         await self.refresh_workspace_cache(workspace_id)
 
     async def resolve_workspace_resources_to_env(self, workspace_id: int) -> dict[str, str]:
-        bindings = await DBWorkspaceResourceBinding.filter(workspace_id=workspace_id, enabled=True).order_by("sort_order", "id")
+        bindings = await DBWorkspaceResourceBinding.filter(workspace_id=workspace_id, enabled=True).order_by(
+            "sort_order", "id"
+        )
         if not bindings:
             return {}
         resources = await DBWorkspaceResource.filter(id__in=[item.resource_id for item in bindings], enabled=True).all()
@@ -318,12 +430,17 @@ class WorkspaceResourceService:
             if resource is None:
                 continue
             fields = [ResourceField.model_validate(item) for item in (resource.schema_json or [])]
-            secret_payload = decrypt_secret_payload(resource.secret_payload_encrypted)
+            try:
+                secret_payload = decrypt_secret_payload(resource.secret_payload_encrypted)
+            except SecretPayloadDecodeError as e:
+                raise ValidationError(reason=f"资源“{resource.name}”的敏感字段不可用，请在资源中心恢复或重新填写") from e
             public_payload = dict(resource.public_payload or {})
             for field in fields:
                 if field.export_mode != "env":
                     continue
-                value = secret_payload.get(field.field_key, "") if field.secret else public_payload.get(field.field_key, "")
+                value = (
+                    secret_payload.get(field.field_key, "") if field.secret else public_payload.get(field.field_key, "")
+                )
                 if not value:
                     continue
                 env_name = self._build_env_name(resource.resource_key, field.field_key)
@@ -382,7 +499,9 @@ class WorkspaceResourceService:
         WorkspaceService.update_claude_md(workspace)
 
     async def refresh_related_workspace_caches(self, resource_id: int) -> None:
-        workspace_ids = await DBWorkspaceResourceBinding.filter(resource_id=resource_id).values_list("workspace_id", flat=True)
+        workspace_ids = await DBWorkspaceResourceBinding.filter(resource_id=resource_id).values_list(
+            "workspace_id", flat=True
+        )
         for workspace_id in workspace_ids:
             await self.refresh_workspace_cache(int(workspace_id))
 


### PR DESCRIPTION
## Summary
- add resource secret health checks, legacy key recovery, and invalid secret purge APIs
- surface resource secret recovery and purge actions in the workspace resources UI
- install the app during Docker image build and run the installed bot entrypoint to avoid PyPI access at container startup
- clean up an existing OOBE prefer-const lint issue exposed by frontend checks

## Checks
- uv run poe lint
- uv run poe frontend-check
- docker build -f dockerfile -t nekro-agent-runtime-test .
- docker run --rm --network none --entrypoint /bin/sh nekro-agent-runtime-test -lc 'test -x /app/.venv/bin/bot && /app/.venv/bin/python -c "import importlib.metadata as m; print(m.version(\"nekro-agent\")); print(any(ep.name == \"bot\" for ep in m.entry_points(group=\"console_scripts\")))"'

## Summary by Sourcery

添加资源密钥健康状况管理功能，并改进容器启动流程，使其在无法访问 PyPI 的情况下也能正常工作。

新功能：
- 提供后端 API 和前端 UI，用于检查资源密钥健康状况、恢复使用旧版加密的密钥，以及清理工作区资源中无法读取的密钥。

缺陷修复：
- 在构建资源详情以及将工作区资源解析为环境变量时，能够优雅地处理无法读取或无效的资源密钥负载，给出清晰的校验错误提示，而不是静默失败。

功能增强：
- 优化资源密钥负载的编码格式，以区分明文、旧版加密和无效数据，并支持使用旧的 JWT 密钥进行恢复。
- 改进与工作区资源相关的缓存失效和数据拉取逻辑，使密钥健康状态与资源列表保持同步。
- 整理 OOBE 欢迎步骤中的打字效果逻辑，使其符合前端 lint 规则。

构建：
- 调整 Docker 镜像构建流程，将依赖与应用预先安装到虚拟环境中，并通过已安装的 bot 入口二进制文件启动容器，而不是在运行时调用 `uv run`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add resource secret health management and improve container startup to work without PyPI access.

New Features:
- Expose backend APIs and frontend UI to inspect resource secret health, recover legacy-encrypted secrets, and purge unreadable secrets for workspace resources.

Bug Fixes:
- Handle unreadable or invalid resource secret payloads gracefully when building resource details and resolving workspace resources to environment variables, surfacing clear validation errors instead of failing silently.

Enhancements:
- Refine resource secret payload encoding format to distinguish plaintext, legacy-encrypted, and invalid data, and support recovery using an old JWT secret key.
- Improve cache invalidation and data fetching around workspace resources to keep secret health status and resource lists in sync.
- Tidy up typing effect logic in the OOBE welcome step to satisfy frontend linting rules.

Build:
- Adjust the Docker image build to pre-install dependencies and the application into the virtualenv and start the container via the installed bot entrypoint binary instead of invoking `uv run` at runtime.

</details>