### PR TITLE
fix(frontend): 锁定模型组编辑对话框中的 API 地址和密钥字段

### DIFF
--- a/frontend/src/pages/settings/model_group.tsx
+++ b/frontend/src/pages/settings/model_group.tsx
@@ -381,6 +381,7 @@ function EditDialog({
             onInputChange={(_, newInputValue) => {
               setConfig({ ...config, BASE_URL: newInputValue })
             }}
+            disabled={!!initialConfig && !isCopy}
             renderOption={(props, option) => (
               <li {...props} key={option}>
                 <Box sx={{ display: 'flex', flexDirection: 'column' }}>
@@ -418,6 +419,7 @@ function EditDialog({
             type="text"
             fullWidth
             autoComplete="off"
+            disabled={!!initialConfig && !isCopy}
             size={isSmall ? 'small' : 'medium'}
             name={`apikey_${Math.random().toString(36).slice(2)}`}
             inputProps={{
@@ -438,6 +440,7 @@ function EditDialog({
                     onClick={() => setShowApiKey(!showApiKey)}
                     edge="end"
                     size={isSmall ? 'small' : 'medium'}
+                    disabled={!!initialConfig && !isCopy}
                     title={showApiKey ? t('actions.hide', { ns: 'common', defaultValue: '隐藏' }) : t('actions.show', { ns: 'common', defaultValue: '显示' })}
                   >
                     {showApiKey ? <VisibilityOffIcon /> : <VisibilityIcon />}


### PR DESCRIPTION
## 概述

在模型组编辑对话框中，将"API 地址"和"API 密钥"字段设置为 disabled 状态，防止用户误修改已有配置。

## 修改内容

`frontend/src/pages/settings/model_group.tsx`：

1. **API 地址（BASE_URL）**：Autocomplete 组件添加 `disabled={!!initialConfig && !isCopy}`
2. **API 密钥（API_KEY）**：TextField 组件添加 `disabled={!!initialConfig && !isCopy}`
3. **密钥显示/隐藏按钮**：IconActionButton 添加 `disabled={!!initialConfig && !isCopy}`

## 行为说明

| 操作 | API 地址 | API 密钥 |
|------|---------|---------|
| 新建模型组 | 可编辑 | 可编辑 |
| 编辑已有模型组 | **禁用** | **禁用** |
| 复制模型组 | 可编辑 | 可编辑 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- 通过禁用 API URL 和 API key 字段及其可见性切换，在编辑现有模型组时防止对这些字段产生未预期的更改。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent unintended changes to API URL and API key when editing existing model groups by disabling those fields and their visibility toggle.

</details>