### PR TITLE
Add default model group name lock prompt and disable input field

### DIFF
--- a/frontend/src/locales/en-US/settings.json
+++ b/frontend/src/locales/en-US/settings.json
@@ -602,6 +602,7 @@
     },
     "model": {
       "groupName": "Model Group Name",
+      "groupNameLocked": "OOBE always writes to the default model group name, so this cannot be changed here.",
       "baseUrl": "API URL",
       "apiKey": "API Key",
       "proxy": "Model group proxy",

--- a/frontend/src/locales/zh-CN/settings.json
+++ b/frontend/src/locales/zh-CN/settings.json
@@ -602,6 +602,7 @@
     },
     "model": {
       "groupName": "模型组名称",
+      "groupNameLocked": "不可更改默认模型组名称",
       "baseUrl": "API 地址",
       "apiKey": "API 密钥",
       "proxy": "模型组代理",

--- a/frontend/src/pages/oobe/index.tsx
+++ b/frontend/src/pages/oobe/index.tsx
@@ -191,6 +191,13 @@ const defaultSystemSettings: OobeSystemSettings = {
   defaultProxy: '',
 }
 
+const noBrowserAutofillProps = {
+  autoComplete: 'off',
+  autoCorrect: 'off',
+  autoCapitalize: 'none',
+  spellCheck: false,
+} as const
+
 const isModelReady = (model: OobeModelSettings) =>
   Boolean(model.groupName.trim() && model.CHAT_MODEL.trim() && model.BASE_URL.trim() && model.API_KEY.trim())
 
@@ -826,6 +833,9 @@ function PageShell({ children }: { children: ReactNode }) {
   const theme = useTheme()
   return (
     <Box
+      component="form"
+      autoComplete="off"
+      onSubmit={event => event.preventDefault()}
       sx={{
         minHeight: '100vh',
         background: `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.08)}, ${alpha(theme.palette.secondary.main, 0.06)} 46%, ${theme.palette.background.default})`,
@@ -1348,6 +1358,7 @@ function SystemStep({
                 type={showCloudKey ? 'text' : 'password'}
                 onChange={event => onChange({ ...settings, nekroCloudApiKey: event.target.value })}
                 disabled={!settings.enableNekroCloud}
+                inputProps={noBrowserAutofillProps}
                 sx={fieldSx}
                 InputProps={{
                   endAdornment: (
@@ -1407,6 +1418,7 @@ function SystemStep({
                 placeholder="http://127.0.0.1:7890"
                 value={settings.defaultProxy}
                 onChange={event => onChange({ ...settings, defaultProxy: event.target.value })}
+                inputProps={noBrowserAutofillProps}
                 sx={fieldSx}
               />
               <Typography
@@ -1465,12 +1477,17 @@ function ModelDraft({
         <TextField
           label={t('oobe.model.groupName')}
           value={model.groupName}
-          onChange={event => onChange({ ...model, groupName: event.target.value })}
+          helperText={t('oobe.model.groupNameLocked')}
+          disabled
+          inputProps={noBrowserAutofillProps}
           fullWidth
         />
         <Autocomplete
           freeSolo
           options={providerOptions}
+          autoComplete={false}
+          autoHighlight={false}
+          autoSelect={false}
           value={model.BASE_URL}
           onChange={(_, value) => onChange({ ...model, BASE_URL: value ?? '' })}
           onInputChange={(_, value) => onChange({ ...model, BASE_URL: value })}
@@ -1492,6 +1509,10 @@ function ModelDraft({
               {...params}
               label={t('oobe.model.baseUrl')}
               placeholder="https://api.nekro.ai/v1"
+              inputProps={{
+                ...params.inputProps,
+                ...noBrowserAutofillProps,
+              }}
             />
           )}
         />
@@ -1501,6 +1522,7 @@ function ModelDraft({
           type={showApiKey ? 'text' : 'password'}
           onChange={event => onChange({ ...model, API_KEY: event.target.value })}
           fullWidth
+          inputProps={noBrowserAutofillProps}
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">
@@ -1521,6 +1543,7 @@ function ModelDraft({
           onChange={event => onChange({ ...model, CHAT_PROXY: event.target.value })}
           placeholder="http://127.0.0.1:7890"
           fullWidth
+          inputProps={noBrowserAutofillProps}
         />
       </Box>
 
@@ -1530,6 +1553,9 @@ function ModelDraft({
             <Autocomplete
               freeSolo
               options={modelOptions}
+              autoComplete={false}
+              autoHighlight={false}
+              autoSelect={false}
               value={model.CHAT_MODEL}
               onChange={(_, value) => onChange({ ...model, CHAT_MODEL: value ?? '' })}
               onInputChange={(_, value) => onChange({ ...model, CHAT_MODEL: value })}
@@ -1539,6 +1565,10 @@ function ModelDraft({
                   {...params}
                   label={isChat ? t('oobe.model.chatModel') : t('oobe.model.embeddingModel')}
                   placeholder={isChat ? 'gpt-4o' : 'text-embedding-3-large'}
+                  inputProps={{
+                    ...params.inputProps,
+                    ...noBrowserAutofillProps,
+                  }}
                 />
               )}
             />
@@ -1623,18 +1653,21 @@ function ModelDraft({
                   type="number"
                   label="Temperature"
                   value={model.TEMPERATURE ?? ''}
+                  inputProps={noBrowserAutofillProps}
                   onChange={event => onChange({ ...model, TEMPERATURE: event.target.value === '' ? null : Number(event.target.value) })}
                 />
                 <TextField
                   type="number"
                   label="Top P"
                   value={model.TOP_P ?? ''}
+                  inputProps={noBrowserAutofillProps}
                   onChange={event => onChange({ ...model, TOP_P: event.target.value === '' ? null : Number(event.target.value) })}
                 />
                 <TextField
                   type="number"
                   label="Top K"
                   value={model.TOP_K ?? ''}
+                  inputProps={noBrowserAutofillProps}
                   onChange={event => onChange({ ...model, TOP_K: event.target.value === '' ? null : Number(event.target.value) })}
                 />
               </Box>
@@ -1644,6 +1677,7 @@ function ModelDraft({
                 onChange={event => onChange({ ...model, EXTRA_BODY: event.target.value || null })}
                 multiline
                 minRows={3}
+                inputProps={noBrowserAutofillProps}
                 error={!isValidJsonOrEmpty(model.EXTRA_BODY)}
                 helperText={!isValidJsonOrEmpty(model.EXTRA_BODY) ? t('oobe.validation.invalidJson') : t('oobe.model.extraBodyHint')}
               />
@@ -1739,12 +1773,14 @@ function EmbeddingStep({
               type="number"
               label={t('oobe.embedding.memoryDimension')}
               value={memoryDimension}
+              inputProps={noBrowserAutofillProps}
               onChange={event => onMemoryDimensionChange(Number(event.target.value) || 0)}
             />
             <TextField
               type="number"
               label={t('oobe.embedding.kbDimension')}
               value={kbDimension}
+              inputProps={noBrowserAutofillProps}
               onChange={event => onKbDimensionChange(Number(event.target.value) || 0)}
             />
           </Box>

--- a/frontend/src/pages/oobe/index.tsx
+++ b/frontend/src/pages/oobe/index.tsx
@@ -164,7 +164,7 @@ const defaultChatModel: OobeModelSettings = {
   FREQUENCY_PENALTY: null,
   EXTRA_BODY: null,
   ENABLE_VISION: true,
-  ENABLE_COT: true,
+  ENABLE_COT: false,
 }
 
 const defaultEmbeddingModel: OobeModelSettings = {

--- a/frontend/src/services/api/oobe.ts
+++ b/frontend/src/services/api/oobe.ts
@@ -29,6 +29,9 @@ const CHAT_GROUP_NAME = 'default'
 const EMBEDDING_GROUP_NAME = 'text-embedding'
 const UI_ONBOARDING_GUIDE_CONFIG_KEY = 'ENABLE_UI_ONBOARDING_GUIDE'
 
+const getOobeModelGroupName = (modelType: 'chat' | 'embedding'): string =>
+  modelType === 'chat' ? CHAT_GROUP_NAME : EMBEDDING_GROUP_NAME
+
 const getItem = (items: ConfigItem[], key: string): ConfigItem | undefined =>
   items.find(item => item.key === key)
 
@@ -153,8 +156,8 @@ export const oobeApi = {
     memoryEmbeddingDimension: number,
     kbEmbeddingDimension: number,
   ): Promise<void> => {
-    const chatGroupName = chatModel.groupName.trim() || CHAT_GROUP_NAME
-    const embeddingGroupName = embeddingModel.groupName.trim() || EMBEDDING_GROUP_NAME
+    const chatGroupName = CHAT_GROUP_NAME
+    const embeddingGroupName = EMBEDDING_GROUP_NAME
 
     await unifiedConfigApi.updateModelGroup(chatGroupName, serializeModelConfig(chatModel, 'chat'))
     await unifiedConfigApi.updateModelGroup(
@@ -184,7 +187,7 @@ export const buildOobeInlineTestRequest = (
   model: OobeModelSettings,
   modelType: 'chat' | 'embedding',
 ) => ({
-  group_name: model.groupName.trim() || (modelType === 'chat' ? CHAT_GROUP_NAME : EMBEDDING_GROUP_NAME),
+  group_name: getOobeModelGroupName(modelType),
   chat_model: model.CHAT_MODEL.trim(),
   base_url: model.BASE_URL.trim(),
   api_key: model.API_KEY.trim(),

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -979,7 +979,7 @@ class CoreConfig(ConfigBase):
                 API_KEY="",
                 MODEL_TYPE="chat",
                 ENABLE_VISION=True,
-                ENABLE_COT=True,
+                ENABLE_COT=False,
             ),
             "default-draw": ModelConfigGroup(
                 CHAT_MODEL="Kolors",


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [x] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
无新增类型忽略标记。

## 🔍 变更类型 (勾选所有适用项)

- [x] 🐛 Bug 修复 (修复一个问题)
- [ ] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [x] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [x] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [x] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [x] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

本 PR 调整 OOBE 中默认模型组的配置行为，避免用户在初始引导阶段修改默认模型组名称。

主要变更：
- OOBE 固定读取和写入 `default` 与 `text-embedding` 两个默认模型组。
- 禁用 OOBE 页面中的模型组名称输入框，并增加中英文提示文案。
- 禁用 OOBE 页面浏览器自动填充，减少 API Key 等字段被浏览器误填充的情况。
- 将默认聊天模型组的 `ENABLE_COT` 默认值从 `true` 调整为 `false`，前后端默认值保持一致。

## 🔗 相关 Issue

无。

## 📸 修改效果截图

本 PR 包含 OOBE 表单交互调整，模型组名称字段将显示为不可编辑状态，并展示锁定说明。

## 🛠️ 实现复杂度

- [x] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

- `frontend/src/services/api/oobe.ts` 中 OOBE 保存和 inline 测试逻辑固定使用默认模型组名称。
- `frontend/src/pages/oobe/index.tsx` 中模型组名称字段设为 disabled，并为 OOBE 表单输入统一关闭浏览器自动填充。
- `nekro_agent/core/config.py` 中 `MODEL_GROUPS.default.ENABLE_COT` 默认值调整为 `False`。
- 同步更新 `zh-CN` 与 `en-US` 文案。

## 🧪 测试步骤 (可选)

已执行：
1. `uv run poe frontend-check`
2. `uv run poe lint`

手动验证建议：
1. 进入 OOBE 页面。
2. 查看主聊天模型和 Embedding 模型步骤。
3. 确认模型组名称字段不可编辑。
4. 完成 OOBE 后确认保存到 `default` 与 `text-embedding`。
5. 确认默认聊天模型组的外置思维链开关默认关闭。

## Summary by Sourcery

将 OOBE 默认模型分组锁定为固定名称并统一其配置默认值，同时减少在引导表单中的浏览器自动填充问题。

Bug Fixes:
- 确保 OOBE 始终在预期的默认分组和 text-embedding 分组下保存并测试聊天模型和嵌入模型，而不是使用用户修改后的名称。
- 对齐前端和后端配置中主聊天模型分组的默认 `ENABLE_COT` 设置，避免出现行为不一致的问题。

Enhancements:
- 在 OOBE UI 中禁用模型分组名称的编辑功能，并添加说明性辅助文本，解释该名称已被锁定。
- 在 OOBE 表单中的所有输入项上禁用与浏览器自动填充相关的行为，防止 API 密钥和其他字段被意外自动填充。

Documentation:
- 更新 OOBE 模型分组名称锁定辅助文本及相关消息的英文和中文本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Lock OOBE default model groups to fixed names and align their configuration defaults, while reducing browser autofill issues in the onboarding form.

Bug Fixes:
- Ensure OOBE always saves and tests chat and embedding models under the intended default and text-embedding groups instead of user-edited names.
- Align the default ENABLE_COT setting for the main chat model group between frontend and backend configurations to avoid inconsistent behavior.

Enhancements:
- Disable editing of the model group name in the OOBE UI and add helper text explaining that the name is locked.
- Disable browser autofill-related behaviors across OOBE form inputs to prevent unintended autofill of API keys and other fields.

Documentation:
- Update English and Chinese localization strings for the OOBE model group name lock helper text and related messaging.

</details>