### PR TITLE
fix(cloud): 修正预设共享 API 路径

### DIFF
--- a/nekro_agent/systems/cloud/api/preset.py
+++ b/nekro_agent/systems/cloud/api/preset.py
@@ -16,7 +16,7 @@ from .client import get_client
 
 logger = get_sub_logger("cloud_api")
 
-PRESET_API = "/api/v2/preset"
+PRESET_API = "/api/preset"
 async def create_preset(preset_data: PresetCreate) -> PresetCreateResponse:
     """创建人设资源
 


### PR DESCRIPTION
@
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式

## 🔍 变更类型

- [x] 🐛 Bug 修复 (修复一个问题)

## 📄 PR 描述

云端 preset v2 路由（`/api/v2/preset`）仅支持 GET 查询，不支持写操作（POST/PUT/DELETE）。预设共享功能调用 POST 创建预设时命中 v2 路由返回 404，导致共享失败。

- v2 preset 路由：仅 GET（列表/详情/用户预设）
- v1 preset 路由：完整 CRUD（GET/POST/PUT/DELETE）

修改 `PRESET_API` 常量从 `/api/v2/preset` 改为 `/api/preset`，使写操作走 v1 路由。

## 🔗 相关 Issue

无

## 🛠️ 实现复杂度

- [x] 简单 (小改动，影响有限)

## 🧪 测试步骤

1. 启动后端，进入预设管理页面
2. 选择一个本地预设，点击「共享到云端」
3. 确认共享成功，不再报 404 错误
@

## Summary by Sourcery

Bug Fixes:
- 修复了由于向只读的 v2 预设 API 路由发送 POST 请求而导致的云预设共享失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix cloud preset sharing failures caused by POST requests being sent to a read-only v2 preset API route.

</details>