### PR TITLE
feat: 新增微信 iLink 多实例适配器 (wechat_ilink_multi)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -154,4 +154,11 @@ temp
 # upload files
 uploads
 
+# 运行时数据与无关大目录（不应进入构建上下文）
+data
+sandbox
+**/node_modules
+.git
+.sisyphus
+
 # End of https://www.toptal.com/developers/gitignore/api/python

--- a/nekro_agent/adapters/__init__.py
+++ b/nekro_agent/adapters/__init__.py
@@ -86,6 +86,14 @@ ADAPTER_REGISTRY: Dict[str, AdapterSpec] = {
         description="基于 OpenILink SDK 的微信适配器",
         tags=("wechat", "openilink"),
     ),
+    "wechat_ilink_multi": AdapterSpec(
+        key="wechat_ilink_multi",
+        adapter_path="nekro_agent.adapters.wechat_ilink_multi.adapter.WeChatILinkMultiAdapter",
+        config_path="nekro_agent.adapters.wechat_ilink_multi.config.WeChatILinkMultiConfig",
+        name="WeChat iLink Multi",
+        description="基于 OpenILink 的微信多账号实例适配器",
+        tags=("wechat", "openilink", "multi-instance"),
+    ),
     "telegram": AdapterSpec(
         key="telegram",
         adapter_path="nekro_agent.adapters.telegram.adapter.TelegramAdapter",
@@ -138,6 +146,22 @@ def _import_string(path: str):
     module_path, attr_name = path.rsplit(".", 1)
     module = importlib.import_module(module_path)
     return getattr(module, attr_name)
+
+
+# chat_key 前缀 -> adapter_key 别名映射。
+# 多数适配器的 build_chat_key 前缀即 adapter_key，故 `chat_key.split("-")[0]` 可直接得到 adapter_key。
+# 但个别适配器（如 wechat_ilink_multi，键名较长且 channel_id 带实例作用域）使用更短的 build_chat_key
+# 前缀以规避 chat_key 64 字符上限，导致按 "-" 切分得到的前缀不等于 adapter_key。此处登记这些短前缀，
+# 供按 chat_key 反查 adapter_key 的配置解析层（config_resolver / config_service）使用。
+CHAT_KEY_PREFIX_ALIASES: Dict[str, str] = {
+    "wxim": "wechat_ilink_multi",
+}
+
+
+def resolve_adapter_key_from_chat_key(chat_key: str) -> str:
+    """从 chat_key 反解析出真正的 adapter_key，自动处理短前缀别名。"""
+    prefix = chat_key.split("-", 1)[0]
+    return CHAT_KEY_PREFIX_ALIASES.get(prefix, prefix)
 
 
 def get_adapter_spec(adapter_key: str) -> AdapterSpec:

--- a/nekro_agent/adapters/interface/collector.py
+++ b/nekro_agent/adapters/interface/collector.py
@@ -27,11 +27,24 @@ async def collect_message(
 ) -> None:
     """适配器消息收集器"""
 
+    try:
+        chat_key = adapter.build_chat_key(platform_channel.channel_id)
+    except Exception:
+        # build_chat_key 默认为纯字符串拼接、正常不会抛错；若某适配器重写后异常，此处不打断消息收集，
+        # 回退到 DBChatChannel 的默认 chat_key。但必须记日志暴露问题，避免静默写入不一致的 chat_key。
+        logger.warning(
+            f"适配器 build_chat_key 失败，回退默认 chat_key: adapter={adapter.key}, "
+            f"channel_id={platform_channel.channel_id}",
+            exc_info=True,
+        )
+        chat_key = None
+
     db_chat_channel: DBChatChannel = await DBChatChannel.get_or_create(
         adapter_key=adapter.key,
         channel_id=platform_channel.channel_id,
         channel_type=platform_channel.channel_type,
         channel_name=platform_channel.channel_name,
+        chat_key=chat_key,
     )
 
     # 命令检测与执行（在 is_active 检查之前，确保 na_on 等命令在频道关闭时仍可用）

--- a/nekro_agent/adapters/wechat_ilink_multi/README.md
+++ b/nekro_agent/adapters/wechat_ilink_multi/README.md
@@ -1,0 +1,279 @@
+# WeChat OpenILink 多实例适配器
+
+基于 OpenILink 协议的微信多账号实例适配器。每个微信 Bot 作为独立实例管理，支持扫码绑定、消息收发、自动续期和状态观测。
+
+## 配置
+
+所有配置项定义在 `config.py` 的 `WeChatILinkMultiConfig` 中。
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `ENABLED` | `bool` | `False` | 是否启用适配器。默认关闭，等待具体协议传输实现接入后再开启。 |
+| `API_BASE_URL` | `str` | `https://ilinkai.weixin.qq.com` | OpenILink 协议服务基础地址，不含具体资源路径。 |
+| `DEFAULT_RENEW_BEFORE_MINUTES` | `int` | `60` | 会话凭据过期前多少分钟触发默认续期。可按实例单独覆盖。 |
+| `BIND_TIMEOUT_SECONDS` | `int` | `180` | 二维码绑定流程等待完成的最长时间（秒）。 |
+| `DEDUP_WINDOW_SECONDS` | `int` | `120` | 入站消息按 provider 消息 ID 去重的时间窗口（秒）。 |
+| `MEDIA_DOWNLOAD_MAX_BYTES` | `int` | `20971520` (20 MB) | 单个媒体文件允许下载的最大字节数。 |
+| `MEDIA_DOWNLOAD_TIMEOUT_SECONDS` | `int` | `60` | 单个媒体文件下载的超时时间（秒）。 |
+
+## 管理 API 示例
+
+所有 API 要求 admin 认证。先获取 token：
+
+```bash
+export NA_ADMIN_TOKEN=$(curl -s -X POST http://127.0.0.1:8021/api/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'username=admin&password=na-ilink-test-admin' | jq -r '.access_token')
+AUTH="Authorization: Bearer $NA_ADMIN_TOKEN"
+BASE="http://127.0.0.1:8021/api/adapters/wechat_ilink_multi/instances"
+```
+
+### 创建实例
+
+```bash
+curl -s -X POST "$BASE" -H "$AUTH" \
+  -H 'Content-Type: application/json' \
+  -d '{"instance_key":"my-bot-1","display_name":"客服 Bot","provider":"wechat"}'
+```
+
+首次创建返回 `201`，重复创建返回 `200` 且 `existing: true`。
+
+### 开始二维码绑定
+
+```bash
+curl -s -X POST "$BASE/my-bot-1/bind/start" -H "$AUTH"
+```
+
+响应包含 `bind_session_id`、`qr_url`、`bind_status: "qr_generated"`。
+
+### 轮询绑定状态
+
+```bash
+curl -s -X GET "$BASE/my-bot-1/bind/status/{bind_session_id}" -H "$AUTH"
+```
+
+`bind_status` 依次变化：`qr_generated` → `qr_scanned` → `login_confirmed` → `session_persisted`。状态为 `confirmed` 时提示 "绑定成功"。
+
+### 启动 / 停止实例
+
+```bash
+curl -s -X POST "$BASE/my-bot-1/start" -H "$AUTH"    # 204 No Content
+curl -s -X POST "$BASE/my-bot-1/stop" -H "$AUTH"     # 204 No Content
+```
+
+### 查看实例列表 / 详情
+
+```bash
+curl -s -X GET "$BASE" -H "$AUTH"                    # 实例列表
+curl -s -X GET "$BASE/my-bot-1" -H "$AUTH"           # 实例详情（不含凭据）
+```
+
+### 触发续期 / 更新续期策略
+
+```bash
+curl -s -X POST "$BASE/my-bot-1/renew" -H "$AUTH"              # 手动触发续期
+curl -s -X PATCH "$BASE/my-bot-1/renew-policy" -H "$AUTH" \
+  -H 'Content-Type: application/json' \
+  -d '{"renew_before_minutes":30}'                              # 修改提前续期分钟数
+```
+
+### 查看实例事件
+
+```bash
+curl -s -X GET "$BASE/my-bot-1/events" -H "$AUTH"
+```
+
+返回审计事件列表，含 `event_type`、`status_from`、`status_to`、`message`。
+
+### 删除实例
+
+```bash
+curl -s -X DELETE "$BASE/my-bot-1" -H "$AUTH"        # 204 No Content，软删除
+```
+
+## 状态机
+
+### 主生命周期状态
+
+```
+pending → binding → online ⟷ offline / renewing / session_expired / error
+                                                              ↓
+                                                           deleted
+```
+
+| 状态 | 说明 |
+|------|------|
+| `pending` | 实例已创建，尚未绑定 |
+| `binding` | 绑定进行中（二维码已生成） |
+| `online` | 监控连接已建立，可收发消息 |
+| `offline` | 实例已停止或连接断开 |
+| `renewing` | 会话续期中（临时状态） |
+| `session_expired` | 会话凭据已过期，需重新绑定 |
+| `error` | 运行异常，`last_error` 记录错误信息 |
+| `deleted` | 已软删除（`enabled=False`） |
+
+### 绑定成功定义
+
+绑定流程中，二维码绑定子状态依次为：
+
+```
+qr_generated → qr_scanned → login_confirmed → session_persisted
+```
+
+绑定成功的必要条件：
+
+1. `login_confirmed`：OpenILink 侧确认登录
+2. `session_persisted`：凭据与同步状态写入 `DBAdapterInstanceSession`
+3. `BotConnection` 监控任务成功启动
+4. 主生命周期状态切换为 `online`
+
+以上任一条件失败，绑定视为失败。`qr_scanned` 不等同于绑定成功。
+
+### QR 绑定子状态
+
+| 子状态 | 来源 | 说明 |
+|--------|------|------|
+| `qr_generated` | `start_bind()` | 二维码或授权 URL 已生成 |
+| `qr_scanned` | `poll_bind()` 返回 `scanned` | 用户在手机上已扫码 |
+| `login_confirmed` | `poll_bind()` 返回 `confirmed` | 绑定登录已确认 |
+| `session_persisted` | `_complete_bind()` | 凭据和同步状态已持久化 |
+| `expired` | `poll_bind()` 返回 `expired` | 绑定会话已过期 |
+| `failed` | `poll_bind()` 返回其他失败 | 绑定出错 |
+
+绑定子状态保存在 `DBAdapterInstanceSession.session_state` 中，通过 `set_session_state()` 更新。子状态变化时产生 `bind_state_change` 事件记录。
+
+## 续期策略
+
+### 默认行为
+
+- 默认在凭据过期前 **60 分钟** 触发自动续期（`DEFAULT_RENEW_BEFORE_MINUTES=60`）
+- 可按实例通过 `PATCH /instances/{key}/renew-policy` 单独覆盖
+- 实例的 `next_renew_at` 在每次凭据持久化时重新计算
+
+### 续期流程
+
+1. `BotConnection._run_renew_loop` 后台任务等待至 `next_renew_at`
+2. 到期时调用 `renew_once()`，主状态切换为 `renewing`
+3. 成功后更新凭据、同步状态和 `renewed_at`，主状态恢复为先前状态（`online` 或 `offline`）
+4. 重新计算 `next_renew_at`，继续等待下一轮
+
+### 失败恢复
+
+续期失败时：
+
+- 若凭据已过期 → 主状态设为 `session_expired`
+- 其他错误 → 主状态设为 `error`，`last_error` 记录异常信息
+- 凭据和会话行**保留不删除**，可手动调用 `POST /renew` 或 `POST /bind/start` 恢复
+- 后台续期任务在失败后**不会退出**，而是按指数退避（60s 起、上限 30min）继续重试，直至成功或实例被停止；避免 `next_renew_at` 处于过去时间时产生 1 秒紧循环
+
+## 消息支持矩阵
+
+| 消息类型 | 接收 | 发送 | 说明 |
+|----------|------|------|------|
+| 文本 (Text) | ✅ | ✅ | 双向支持 |
+| 图片 (Image) | ✅ | ✅ | 接收解析为 `ChatMessageSegmentImage`；发送通过 `send_file()` 上传 |
+| 文件 (File) | ✅ | ✅ | 接收解析为 `ChatMessageSegmentFile`；发送通过 `send_file()` 上传 |
+| 语音 (Voice) | ✅ | ❌ | 接收映射为 `ChatMessageSegmentFile`（`.mp3` / `.amr`），文本显示 `[Voice: filename]`。不新增 VOICE 段类型以保持序列化兼容。 |
+| 视频 (Video) | ❌ | ❌ | 不支持 |
+| 贴纸 (Stickers) | ❌ | ❌ | 不支持 |
+| 复杂撤回 | ❌ | ❌ | 不支持复杂撤回逻辑 |
+
+> **会话范围说明**：iLink 协议的微信 bot **不能加入群聊**，仅存在 1:1 私聊场景。所有入站消息均按私聊处理
+> （`channel_id = {instance_key}:private:{user_id}`，`ChatType.PRIVATE`，`is_tome=True`）。
+> 代码中保留的 group 作用域分支为防御性兜底，正常运行中不会被触发。
+
+### 消息去重
+
+每个 `BotConnection` 实例维护独立的去重缓存，按 `(instance_key, remote_message_id)` 去重，窗口默认 120 秒。重复消息不会传递到 `collect_message()` 管道。
+
+### 媒体下载限制
+
+- 超过 `MEDIA_DOWNLOAD_MAX_BYTES`（默认 20 MB）的媒体会被替换为可见错误文本段 `[媒体文件过大: ...]`
+- 下载失败的媒体返回错误文本 `[图片下载失败]` / `[语音下载失败]` / `[文件下载失败]`
+- 消息解析失败时使用兜底文本 `[OpenILink 消息解析失败: ...]`
+
+## 兼容性
+
+- 现有 `wechat_openilink` 适配器**未做任何修改**，行为保持不变
+- 新适配器使用独立 adapter key `wechat_ilink_multi`，与旧适配器并行存在
+- chat key 格式：`wxim-{instance_key}:private:{user_id}`。
+  本适配器 **重写了 `build_chat_key()`**，使用短前缀 `wxim-` 而非默认的 `wechat_ilink_multi-`：
+  因为 `wechat_ilink_multi`（18 字符）+ 实例作用域 channel_id 容易超出 `DBChatChannel.chat_key` 的 64 字符上限
+  （iLink 用户 id 形如 `xxxxxxxx@im.wechat`，较长）。
+- 由于短前缀 `wxim` ≠ adapter_key，配置解析层（`config_resolver` / `config_service`）改用
+  `nekro_agent.adapters.resolve_adapter_key_from_chat_key()` 经别名映射还原 adapter_key，保证适配器级配置覆盖生效。
+- channel ID 作用域：`{instance_id}:private:{user_id}`（iLink 仅 1:1 私聊，无群聊；详见“消息支持矩阵”）
+- message ID 作用域：`{instance_id}:{remote_message_id}`
+- chat_key 含 `:`、`@` 等字符，作为文件系统/Docker 卷路径片段时由 `sanitize_chat_key_for_path()`
+  统一清洗（写入、宿主机路径换算、沙盒挂载三处一致）；该函数对现有适配器的无特殊字符 chat_key 为恒等变换，零回归。
+- 为支持上述短前缀，`collector.py` 与 `DBChatChannel.get_or_create` 增加了透传 `adapter.build_chat_key()`
+  结果的能力（默认仍为 `{adapter_key}-{channel_id}`，对其它适配器无行为变化）。不修改 `DBUser`、`DBPluginData`。
+- 凭据不在任何 API 响应中暴露
+
+## 架构概览
+
+```
+WeChatILinkMultiAdapter (adapter.py)
+  └── BotManager (bot_manager.py)          ← 生命周期编排
+        ├── BotConnection × N               ← 每实例独立连接
+        │     ├── OpenILinkMultiClient       ← 协议边界（client.py）
+        │     ├── OpenILinkMultiMessageProcessor ← 消息解析
+        │     ├── monitor task               ← 消息监控
+        │     └── renew task                 ← 自动续期
+        └── AdapterInstanceService           ← 通用持久化底座
+              ├── DBAdapterInstance
+              ├── DBAdapterInstanceSession
+              └── DBAdapterInstanceEvent
+```
+
+## 本地开发
+
+### 依赖服务（OrbStack / Docker）
+
+NA 主服务从源码运行，依赖服务通过 Docker Compose 提供：
+
+```bash
+# 方式 A：全新构建（推荐）
+docker compose -f docker/docker-compose.dev.yml pull nekro_postgres nekro_qdrant nekro_napcat
+docker compose -f docker/docker-compose.dev.yml up -d nekro_postgres nekro_qdrant nekro_napcat
+```
+
+> 注意：如果之前使用过 `postgres:14`，需要先停止并移除旧容器，删除或重命名 `../data/dev_postgres_data`，再启动 `postgres:16`。不要将 PG14 数据目录直接挂载到 PG16。
+
+### 启动开发服务器
+
+```bash
+ADMIN_PASSWORD=na-ilink-test-admin poe dev-docs
+```
+
+服务默认运行在 `http://127.0.0.1:8022`。API 文档地址为 `http://127.0.0.1:8022/api/docs`。
+
+### 健康检查
+
+```bash
+curl -s http://127.0.0.1:8022/api/health          # → {"ok": true}
+```
+
+### 数据库迁移
+
+```bash
+poe db-revision <name>   # 生成迁移文件
+poe db-migrate           # 执行迁移
+```
+
+### 验证命令
+
+```bash
+poe check        # typecheck + lint
+poe load-test    # 适配器加载测试
+```
+
+## 重要说明
+
+- 适配器初始化不发出网络请求。监控连接仅在 `init()` 加载 DB 实例后启动。
+- 传输实现应继承 `OpenILinkMultiClient`（`client.py`），当前默认使用 `UnsupportedOpenILinkMultiClient` 占位。
+- 外部协议返回的原始字典只在 `schemas.py` 的 `parse_*_payload` 函数中读取，业务逻辑仅消费 Pydantic 模型。
+- 多账号场景下每个连接创建独立 client 实例，凭据与同步状态由上层持久化。
+- iLink bot 仅 1:1 私聊：私聊消息恒 `is_tome=True`。（保留的群聊 `is_tome` 分支为兜底，正常不触发。）
+- 停止实例会取消 monitor 和 renew 后台任务并等待完成。
+- 相同 `(adapter_key, provider_account_id)` 已绑定到其他非删除实例时，新绑定会返回 HTTP 409（`ProviderAccountAlreadyBound`）。

--- a/nekro_agent/adapters/wechat_ilink_multi/__init__.py
+++ b/nekro_agent/adapters/wechat_ilink_multi/__init__.py
@@ -1,0 +1,9 @@
+from .client import OpenILinkMonitorCallbacks, OpenILinkMultiClient, UnsupportedOpenILinkMultiClient
+from .config import WeChatILinkMultiConfig
+
+__all__ = [
+    "OpenILinkMonitorCallbacks",
+    "OpenILinkMultiClient",
+    "UnsupportedOpenILinkMultiClient",
+    "WeChatILinkMultiConfig",
+]

--- a/nekro_agent/adapters/wechat_ilink_multi/adapter.py
+++ b/nekro_agent/adapters/wechat_ilink_multi/adapter.py
@@ -1,0 +1,238 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import APIRouter
+
+from nekro_agent.adapters.interface.base import AdapterMetadata, BaseAdapter
+from nekro_agent.adapters.interface.schemas.platform import (
+    PlatformChannel,
+    PlatformSendRequest,
+    PlatformSendResponse,
+    PlatformSendSegmentType,
+    PlatformUser,
+)
+from nekro_agent.core.logger import get_sub_logger
+from nekro_agent.schemas.chat_message import ChatType
+
+from .bot_connection import BotConnection
+from .bot_manager import BotManager
+from .client import OpenILinkMultiClient
+from .config import WeChatILinkMultiConfig
+from .schemas import BindPollResult, BindStartResult, OpenILinkRecipient, RecipientKind
+from .sdk_client import WeChatBotSDKOpenILinkMultiClient
+
+logger = get_sub_logger("adapter.wechat_ilink_multi")
+
+
+class WeChatILinkMultiAdapter(BaseAdapter[WeChatILinkMultiConfig]):
+    """微信 OpenILink 多实例适配器。"""
+
+    def __init__(self, config_cls: type[WeChatILinkMultiConfig] = WeChatILinkMultiConfig):
+        super().__init__(config_cls)
+        self.bot_manager = BotManager(
+            adapter_key=self.key,
+            config=self.config,
+            adapter_getter=lambda: self,
+            client_factory=self._create_client,
+        )
+
+    @property
+    def key(self) -> str:
+        return "wechat_ilink_multi"
+
+    @property
+    def metadata(self) -> AdapterMetadata:
+        return AdapterMetadata(
+            name="WeChat iLink Multi",
+            description="基于 OpenILink 的微信多账号实例适配器",
+            version="0.1.0",
+            author="NekroAI",
+            tags=["wechat", "openilink", "multi-instance"],
+        )
+
+    @property
+    def chat_key_rules(self) -> list[str]:
+        return [
+            "群聊: `wxim-{instance_key}:group:{group_id}`",
+            "私聊: `wxim-{instance_key}:private:{user_id}`",
+        ]
+
+    def build_chat_key(self, channel_id: str) -> str:
+        """构建聊天标识，使用短前缀避免超过 64 字符限制。"""
+        return f"wxim-{channel_id}"
+
+    def parse_chat_key(self, chat_key: str) -> tuple[str, str]:
+        """解析聊天标识，适配短前缀。"""
+        if chat_key.startswith("wxim-"):
+            return self.key, chat_key[5:]
+        # Fallback to base implementation for legacy keys
+        parts = chat_key.split("-", 1)
+        if len(parts) != 2:
+            raise ValueError(f"无效的聊天标识: {chat_key}")
+        return parts[0], parts[1]
+
+    @property
+    def supports_webui_send(self) -> bool:
+        return True
+
+    def get_adapter_router(self) -> APIRouter:
+        from .routers import create_router
+
+        return create_router()
+
+    async def init(self) -> None:
+        await self.bot_manager.start()
+        logger.info("WeChat iLink Multi 适配器已启动")
+
+    async def cleanup(self) -> None:
+        await self.bot_manager.stop_all()
+        logger.info("WeChat iLink Multi 适配器已关闭")
+
+    async def start_bind(self, instance_key: str) -> BindStartResult:
+        return await self.bot_manager.start_bind(instance_key)
+
+    async def poll_bind(self, instance_key: str, session_id: str) -> BindPollResult:
+        return await self.bot_manager.poll_bind(instance_key, session_id)
+
+    async def renew_instance(self, instance_key: str) -> None:
+        await self.bot_manager.renew_instance(instance_key)
+
+    async def forward_message(self, request: PlatformSendRequest) -> PlatformSendResponse:
+        try:
+            adapter_key, channel_id = self.parse_chat_key(request.chat_key)
+            if adapter_key != self.key:
+                raise ValueError(f"聊天标识适配器不匹配: {adapter_key}")
+            scoped_channel = self._parse_scoped_channel_id(channel_id)
+        except ValueError as e:
+            return PlatformSendResponse(success=False, error_message=str(e))
+
+        connection = self.bot_manager.get_connection(scoped_channel.instance_key)
+        if connection is None or not connection.is_online:
+            return PlatformSendResponse(
+                success=False,
+                error_message=f"实例离线或不存在: {scoped_channel.instance_key}",
+            )
+
+        recipient = OpenILinkRecipient(
+            kind=RecipientKind.GROUP if scoped_channel.chat_type == ChatType.GROUP else RecipientKind.USER,
+            id=scoped_channel.target_id,
+        )
+        message_ids: list[str] = []
+        failed_segments: list[str] = []
+        text_parts: list[str] = []
+
+        for segment in request.segments:
+            if segment.type == PlatformSendSegmentType.TEXT:
+                if segment.content:
+                    text_parts.append(segment.content)
+                continue
+            if segment.type == PlatformSendSegmentType.AT:
+                if segment.at_info is not None:
+                    text_parts.append(f"@{segment.at_info.nickname or segment.at_info.platform_user_id}")
+                elif segment.content:
+                    text_parts.append(f"@{segment.content}")
+                continue
+
+            await self._flush_text(connection, recipient, request.ref_msg_id, text_parts, message_ids, failed_segments)
+            if segment.type in (PlatformSendSegmentType.IMAGE, PlatformSendSegmentType.FILE):
+                if not segment.file_path:
+                    failed_segments.append(f"{segment.type.value}:file_path 为空")
+                    continue
+                try:
+                    message_id = await connection.send_file(
+                        recipient=recipient,
+                        file_path=Path(segment.file_path),
+                        ref_msg_id=request.ref_msg_id,
+                    )
+                    message_ids.append(message_id)
+                except Exception as e:
+                    # 宽捕获：发送文件可能因网络/文件IO/协议等不可预见的异常失败，
+                    # 需要在收集段错误的循环中容错，避免单段发送失败中断后续段发送
+                    failed_segments.append(f"{segment.type.value}:{e}")
+                continue
+
+            failed_segments.append(f"{segment.type.value}:暂不支持")
+
+        await self._flush_text(connection, recipient, request.ref_msg_id, text_parts, message_ids, failed_segments)
+
+        if message_ids:
+            error_message = f"部分消息发送失败: {'; '.join(failed_segments)}" if failed_segments else None
+            return PlatformSendResponse(success=True, message_id=",".join(message_ids), error_message=error_message)
+        if failed_segments:
+            return PlatformSendResponse(success=False, error_message="; ".join(failed_segments))
+        return PlatformSendResponse(success=True, message_id="")
+
+    async def get_self_info(self) -> PlatformUser:
+        online_keys = [key for key, connection in self.bot_manager.connections.items() if connection.is_online]
+        if not online_keys:
+            return PlatformUser(platform_name=self.key, user_id="", user_name="WeChat iLink Multi (unavailable)")
+        first_key = online_keys[0]
+        return PlatformUser(
+            platform_name=self.key,
+            user_id=first_key,
+            user_name=f"WeChat iLink Multi ({len(online_keys)} online)",
+        )
+
+    async def get_user_info(self, user_id: str, channel_id: str) -> PlatformUser:
+        self._parse_scoped_channel_id(channel_id)
+        return PlatformUser(
+            platform_name=self.key,
+            user_id=user_id,
+            user_name=user_id,
+            user_avatar="",
+        )
+
+    async def get_channel_info(self, channel_id: str) -> PlatformChannel:
+        scoped_channel = self._parse_scoped_channel_id(channel_id)
+        return PlatformChannel(
+            channel_id=channel_id,
+            channel_name=f"{scoped_channel.instance_key}:{scoped_channel.target_id}",
+            channel_type=scoped_channel.chat_type,
+            channel_avatar="",
+        )
+
+    async def _flush_text(
+        self,
+        connection: BotConnection,
+        recipient: OpenILinkRecipient,
+        ref_msg_id: str | None,
+        text_parts: list[str],
+        message_ids: list[str],
+        failed_segments: list[str],
+    ) -> None:
+        text = "".join(text_parts).strip()
+        text_parts.clear()
+        if not text:
+            return
+        try:
+            message_id = await connection.send_text(recipient=recipient, text=text, ref_msg_id=ref_msg_id)
+            message_ids.append(message_id)
+        except Exception as e:
+            # 宽捕获：发送文本可能因网络/协议等不可预见的异常失败，
+            # 需要在收集段错误的循环中容错，避免单段发送失败中断流程
+            failed_segments.append(f"text:{e}")
+
+    def _create_client(self, config: WeChatILinkMultiConfig) -> OpenILinkMultiClient:
+        return WeChatBotSDKOpenILinkMultiClient(config)
+
+    def _parse_scoped_channel_id(self, channel_id: str) -> "ScopedChannelId":
+        parts = channel_id.split(":", 2)
+        if len(parts) != 3:
+            raise ValueError(f"无效的频道标识: {channel_id}")
+        instance_key, channel_type, target_id = parts
+        if not instance_key or not target_id:
+            raise ValueError(f"无效的频道标识: {channel_id}")
+        if channel_type == "private":
+            chat_type = ChatType.PRIVATE
+        elif channel_type == "group":
+            chat_type = ChatType.GROUP
+        else:
+            raise ValueError(f"不支持的频道类型: {channel_type}")
+        return ScopedChannelId(instance_key=instance_key, chat_type=chat_type, target_id=target_id)
+
+
+@dataclass(slots=True)
+class ScopedChannelId:
+    instance_key: str
+    chat_type: ChatType
+    target_id: str

--- a/nekro_agent/adapters/wechat_ilink_multi/bot_connection.py
+++ b/nekro_agent/adapters/wechat_ilink_multi/bot_connection.py
@@ -1,0 +1,490 @@
+import asyncio
+import time
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import aiofiles
+
+from nekro_agent.adapters.interface.collector import collect_message
+from nekro_agent.core.logger import get_sub_logger
+from nekro_agent.models.db_adapter_instance import DBAdapterInstance
+from nekro_agent.models.db_adapter_instance_session import DBAdapterInstanceSession
+from nekro_agent.services.adapter_instance_service import adapter_instance_service
+
+from .client import OpenILinkMonitorCallbacks, OpenILinkMultiClient
+from .config import WeChatILinkMultiConfig
+from .message_processor import OpenILinkMultiMessageProcessor
+from .schemas import (
+    ContextToken,
+    MediaKind,
+    OpenILinkCredentials,
+    OpenILinkMedia,
+    OpenILinkMessage,
+    OpenILinkRecipient,
+    RecipientKind,
+    SyncState,
+)
+
+if TYPE_CHECKING:
+    from .adapter import WeChatILinkMultiAdapter
+
+logger = get_sub_logger("adapter.wechat_ilink_multi.connection")
+
+ClientFactory = Callable[[WeChatILinkMultiConfig], OpenILinkMultiClient]
+DEDUP_MAX_SIZE = 2000
+
+
+class BotConnection:
+    """单个 OpenILink 多实例账号连接。"""
+
+    def __init__(
+        self,
+        *,
+        adapter: "WeChatILinkMultiAdapter",
+        instance: DBAdapterInstance,
+        session: DBAdapterInstanceSession,
+        config: WeChatILinkMultiConfig,
+        client_factory: ClientFactory,
+    ):
+        self.adapter = adapter
+        self.instance = instance
+        self.session = session
+        self.config = config
+        self.client = client_factory(config)
+        self.processor = OpenILinkMultiMessageProcessor(
+            instance_id=instance.instance_key,
+            adapter_key=adapter.key,
+            dedup_window_seconds=config.DEDUP_WINDOW_SECONDS,
+            build_chat_key=adapter.build_chat_key,
+        )
+        self._monitor_task: asyncio.Task[None] | None = None
+        self._renew_task: asyncio.Task[None] | None = None
+        self._stopped = asyncio.Event()
+        self._online_started = asyncio.Event()
+        self._startup_error: str | None = None
+        self._online = False
+        self._recent_remote_message_ids: dict[tuple[str, str], float] = {}
+        self._last_dedup_gc_ts = 0.0
+
+    @property
+    def instance_key(self) -> str:
+        return self.instance.instance_key
+
+    @property
+    def is_online(self) -> bool:
+        return self._online
+
+    async def start(self) -> None:
+        if self._monitor_task is not None and not self._monitor_task.done():
+            return
+
+        self._stopped.clear()
+        self._online_started.clear()
+        self._startup_error = None
+        self._monitor_task = asyncio.create_task(
+            self._run_monitor(),
+            name=f"wechat-ilink-monitor-{self.instance_key}",
+        )
+        self._renew_task = asyncio.create_task(
+            self._run_renew_loop(),
+            name=f"wechat-ilink-renew-{self.instance_key}",
+        )
+
+    async def wait_until_online(self, timeout_seconds: float | None = None) -> None:
+        if self._online:
+            return
+        if self._monitor_task is None:
+            raise RuntimeError(f"实例 {self.instance_key} 尚未启动监控任务")
+
+        online_waiter = asyncio.create_task(self._online_started.wait())
+        done, pending = await asyncio.wait(
+            {online_waiter, self._monitor_task},
+            timeout=timeout_seconds,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if online_waiter in pending:
+            online_waiter.cancel()
+        if online_waiter in done and self._online:
+            return
+        if self._startup_error:
+            raise RuntimeError(self._startup_error)
+        if self._monitor_task.done():
+            raise RuntimeError(f"实例 {self.instance_key} 监控任务已退出")
+        raise TimeoutError(f"实例 {self.instance_key} 监控启动超时")
+
+    async def stop(self) -> None:
+        self._stopped.set()
+        tasks = [task for task in (self._renew_task, self._monitor_task) if task is not None]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._renew_task = None
+        self._monitor_task = None
+        await self._stop_client_monitor()
+        self._online = False
+
+    async def send_text(
+        self,
+        *,
+        recipient: OpenILinkRecipient,
+        text: str,
+        ref_msg_id: str | None = None,
+    ) -> str:
+        result = await self.client.send_text(
+            recipient=recipient,
+            text=text,
+            context_token=self._build_context_token(recipient, ref_msg_id),
+        )
+        return result.message_id
+
+    async def send_file(
+        self,
+        *,
+        recipient: OpenILinkRecipient,
+        file_path: Path,
+        ref_msg_id: str | None = None,
+    ) -> str:
+        result = await self.client.send_file(
+            recipient=recipient,
+            file_path=file_path,
+            context_token=self._build_context_token(recipient, ref_msg_id),
+        )
+        return result.message_id
+
+    async def download_media(self, media: OpenILinkMedia) -> bytes | Path:
+        if media.size_bytes is not None and media.size_bytes > self.config.MEDIA_DOWNLOAD_MAX_BYTES:
+            raise ValueError(f"媒体文件过大: {media.size_bytes} bytes")
+        return await asyncio.wait_for(
+            self.client.download_media(media),
+            timeout=self.config.MEDIA_DOWNLOAD_TIMEOUT_SECONDS,
+        )
+
+    async def renew_once(self) -> None:
+        previous_status = self.instance.status
+        self.instance = await adapter_instance_service.set_status(
+            self.instance,
+            "renewing",
+            "实例会话续期中",
+        )
+        try:
+            credentials = self._load_credentials()
+            sync_state = self._load_sync_state()
+            result = await self.client.renew_session(credentials, sync_state)
+        except Exception as e:
+            await self._mark_renew_failure(e)
+            raise
+
+        self.session = await adapter_instance_service.upsert_session(
+            instance=self.instance,
+            credentials_json=result.credentials.model_dump_json(),
+            sync_state_json=result.sync_state.model_dump_json(),
+            expires_at=result.credentials.expires_at,
+            last_cursor=result.sync_state.cursor or "",
+        )
+        self.session.renewed_at = datetime.now(timezone.utc)
+        await self.session.save()
+        if result.credentials.expires_at is not None:
+            self.instance = await adapter_instance_service.schedule_renew(
+                instance=self.instance,
+                expires_at=result.credentials.expires_at,
+                renew_before_minutes=self.instance.renew_before_minutes or self.config.DEFAULT_RENEW_BEFORE_MINUTES,
+            )
+        restored_status = previous_status if previous_status not in ("renewing", "error") else "online"
+        self.instance = await adapter_instance_service.set_status(
+            self.instance,
+            restored_status,
+            "实例会话续期完成",
+        )
+        logger.info(f"OpenILink 多实例会话续期完成: instance={self.instance_key}")
+
+    async def _run_monitor(self) -> None:
+        try:
+            await self.client.start_monitor(
+                credentials=self._load_credentials(),
+                sync_state=self._load_sync_state(),
+                callbacks=OpenILinkMonitorCallbacks(
+                    on_message=self._handle_message,
+                    on_sync_state=self._handle_sync_state,
+                    on_error=self._handle_monitor_error,
+                ),
+            )
+            # 必须先持久化 online 状态并发出 SSE 事件，再放行 wait_until_online，
+            # 否则等待方可能在 DB 仍为 binding、online 事件尚未广播时就返回（竞态）。
+            self._online = True
+            self.instance = await adapter_instance_service.set_status(
+                self.instance,
+                "online",
+                "实例监控已启动",
+            )
+            self._online_started.set()
+            await self._stopped.wait()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self._online = False
+            self._startup_error = str(e)
+            self._online_started.set()
+            self.instance = await adapter_instance_service.set_status(
+                self.instance,
+                "error",
+                str(e),
+            )
+            logger.warning(f"OpenILink 多实例监控失败: instance={self.instance_key}, error={e}")
+        finally:
+            self._online = False
+            await self._stop_client_monitor()
+
+    async def _run_renew_loop(self) -> None:
+        consecutive_failures = 0
+        try:
+            while not self._stopped.is_set():
+                if self.instance.next_renew_at is None and self.session.expires_at is None:
+                    # 无任何过期信息（如 iLink token 无 TTL）-> 无需续期，休眠至停止；
+                    # 避免对无过期会话每小时空转 renew_once 产生 renewing<->online 抖动与 SSE 噪声。
+                    await self._stopped.wait()
+                    return
+                wait_seconds = self._seconds_until_next_renew()
+                if consecutive_failures > 0:
+                    # 续期失败后指数退避，避免 next_renew_at 处于过去时间时产生 1s 紧循环
+                    backoff = min(60.0 * (2 ** (consecutive_failures - 1)), 1800.0)
+                    wait_seconds = max(wait_seconds, backoff)
+                try:
+                    await asyncio.wait_for(self._stopped.wait(), timeout=wait_seconds)
+                    return
+                except TimeoutError:
+                    pass
+                try:
+                    await self.renew_once()
+                    consecutive_failures = 0
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    # 单次续期失败不应终止续期循环（否则失败后再也不会自动重试）；
+                    # renew_once 已记录 session_expired/error 与 last_error。
+                    # 若凭据已确定过期(session_expired)，自动续期无法挽救，需人工重新绑定 ->
+                    # 停止自动重试，避免 renewing<->session_expired 状态抖动与日志/SSE 噪声；
+                    # 仅对瞬时 error 做指数退避重试。
+                    if self.instance.status == "session_expired":
+                        logger.warning(
+                            f"OpenILink 多实例会话已过期，停止自动续期，等待重新绑定: instance={self.instance_key}, error={e}",
+                        )
+                        return
+                    consecutive_failures += 1
+                    logger.warning(
+                        f"OpenILink 多实例续期失败(第 {consecutive_failures} 次)，将退避后重试: "
+                        f"instance={self.instance_key}, error={e}",
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"OpenILink 多实例续期任务异常退出: instance={self.instance_key}, error={e}")
+
+    async def _handle_message(self, message: OpenILinkMessage) -> None:
+        if self._is_duplicate_message(message.message_id):
+            logger.debug(f"重复 OpenILink 消息已过滤: instance={self.instance_key}, message_id={message.message_id}")
+            return
+
+        try:
+            parsed = await self.processor.parse(await self._message_to_processor_payload(message))
+        except Exception as e:
+            logger.exception(f"OpenILink 消息解析失败，使用错误文本兜底: instance={self.instance_key}, message_id={message.message_id}")
+            parsed = await self.processor.parse(
+                self._message_to_fallback_payload(message, f"[OpenILink 消息解析失败: {e}]")
+            )
+        if parsed is None:
+            await self._persist_message_cursor(message)
+            return
+        await collect_message(
+            adapter=self.adapter,
+            platform_channel=parsed.channel,
+            platform_user=parsed.user,
+            platform_message=parsed.message,
+        )
+        await self._persist_message_cursor(message)
+
+    async def _handle_sync_state(self, sync_state: SyncState) -> None:
+        self.session.sync_state_json = sync_state.model_dump_json()
+        self.session.last_cursor = sync_state.cursor or ""
+        await self.session.save()
+
+    async def _handle_monitor_error(self, error: Exception) -> None:
+        logger.warning(f"OpenILink 多实例监控回调错误: instance={self.instance_key}, error={error}")
+
+    async def _mark_renew_failure(self, error: Exception) -> None:
+        status = "session_expired" if self._credentials_expired() else "error"
+        self.instance = await adapter_instance_service.set_status(
+            self.instance,
+            status,
+            f"实例会话续期失败: {error}",
+        )
+
+    async def _stop_client_monitor(self) -> None:
+        try:
+            await self.client.stop_monitor()
+        except NotImplementedError:
+            logger.debug(f"OpenILink 多实例 stop_monitor 未实现: instance={self.instance_key}")
+        except Exception as e:
+            logger.warning(f"停止 OpenILink 多实例监控失败: instance={self.instance_key}, error={e}")
+
+    def _load_credentials(self) -> OpenILinkCredentials:
+        if not self.session.credentials_json:
+            raise ValueError(f"实例 {self.instance_key} 缺少会话凭据")
+        return OpenILinkCredentials.model_validate_json(self.session.credentials_json)
+
+    def _credentials_expired(self) -> bool:
+        try:
+            expires_at = self._load_credentials().expires_at or self.session.expires_at
+        except ValueError:
+            expires_at = self.session.expires_at
+        if expires_at is None:
+            return False
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        return expires_at <= datetime.now(timezone.utc)
+
+    def _load_sync_state(self) -> SyncState:
+        if not self.session.sync_state_json:
+            return SyncState()
+        return SyncState.model_validate_json(self.session.sync_state_json)
+
+    def _seconds_until_next_renew(self) -> float:
+        renew_at = self.instance.next_renew_at
+        if renew_at is None:
+            expires_at = self.session.expires_at
+            if expires_at is None:
+                return 3600.0
+            renew_at = expires_at
+
+        now = datetime.now(timezone.utc)
+        if renew_at.tzinfo is None:
+            renew_at = renew_at.replace(tzinfo=timezone.utc)
+        return max((renew_at - now).total_seconds(), 1.0)
+
+    async def _message_to_processor_payload(self, message: OpenILinkMessage) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "message_id": message.message_id,
+            "sender_id": message.sender_id,
+            "timestamp": message.timestamp,
+            "type": message.raw_type or ("text" if message.text else "file"),
+            "content": message.text or "",
+            "conversation_id": message.context_token.conversation_id,
+            "sync_cursor": message.context_token.sync_cursor or "",
+        }
+        if message.recipient.kind == RecipientKind.GROUP:
+            payload["group_id"] = message.recipient.id
+        if message.media:
+            first_media = message.media[0]
+            payload["type"] = first_media.kind.value
+            payload["file_name"] = first_media.file_name or first_media.media_id
+            if first_media.size_bytes is not None and first_media.size_bytes > self.config.MEDIA_DOWNLOAD_MAX_BYTES:
+                error = ValueError(f"媒体文件过大: {first_media.size_bytes} bytes")
+                logger.warning(
+                    f"OpenILink 媒体超过下载限制: instance={self.instance_key}, "
+                    f"message_id={message.message_id}, media_id={first_media.media_id}, size={first_media.size_bytes}",
+                )
+                payload["type"] = "text"
+                payload["content"] = self._media_download_failure_text(first_media, error)
+                return payload
+            if first_media.url:
+                if first_media.kind.value == "image":
+                    payload["image_url"] = first_media.url
+                elif first_media.kind.value == "voice":
+                    payload["voice_url"] = first_media.url
+                else:
+                    payload["file_url"] = first_media.url
+            else:
+                try:
+                    media_bytes = await self._download_media_as_bytes(first_media)
+                except Exception as e:
+                    logger.exception(
+                        f"OpenILink 媒体下载失败: instance={self.instance_key}, "
+                        f"message_id={message.message_id}, media_id={first_media.media_id}",
+                    )
+                    payload["type"] = "text"
+                    payload["content"] = self._media_download_failure_text(first_media, e)
+                    return payload
+                if first_media.kind == MediaKind.IMAGE:
+                    payload["image_data"] = media_bytes
+                elif first_media.kind == MediaKind.VOICE:
+                    payload["voice_data"] = media_bytes
+                else:
+                    payload["file_data"] = media_bytes
+        return payload
+
+    async def _download_media_as_bytes(self, media: OpenILinkMedia) -> bytes:
+        result = await self.download_media(media)
+        if isinstance(result, bytes):
+            return result
+        async with aiofiles.open(result, "rb") as file:
+            data = await file.read()
+        if len(data) > self.config.MEDIA_DOWNLOAD_MAX_BYTES:
+            raise ValueError(f"媒体文件过大: {len(data)} bytes")
+        return data
+
+    def _is_duplicate_message(self, remote_message_id: str) -> bool:
+        now = time.time()
+        ttl = max(self.config.DEDUP_WINDOW_SECONDS, 1)
+        cutoff = now - ttl
+        gc_interval = max(min(ttl // 4, 30), 5)
+        if now - self._last_dedup_gc_ts >= gc_interval:
+            self._recent_remote_message_ids = {
+                key: ts for key, ts in self._recent_remote_message_ids.items() if ts >= cutoff
+            }
+            self._last_dedup_gc_ts = now
+
+        dedup_key = (self.instance_key, remote_message_id)
+        if dedup_key in self._recent_remote_message_ids:
+            return True
+
+        self._recent_remote_message_ids[dedup_key] = now
+        if len(self._recent_remote_message_ids) > DEDUP_MAX_SIZE:
+            overflow_count = len(self._recent_remote_message_ids) - DEDUP_MAX_SIZE
+            oldest_keys = sorted(
+                self._recent_remote_message_ids,
+                key=self._recent_remote_message_ids.__getitem__,
+            )[:overflow_count]
+            for key in oldest_keys:
+                self._recent_remote_message_ids.pop(key, None)
+        return False
+
+    async def _persist_message_cursor(self, message: OpenILinkMessage) -> None:
+        sync_cursor = message.context_token.sync_cursor
+        if sync_cursor:
+            self.session.last_cursor = sync_cursor
+        self.session.last_message_remote_id = message.message_id
+        await self.session.save()
+        # 记录实例最近活跃时间（轻量 update，避免重载整行）
+        await DBAdapterInstance.filter(id=self.instance.id).update(last_active_at=datetime.now(timezone.utc))
+
+    def _message_to_fallback_payload(self, message: OpenILinkMessage, text: str) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "message_id": message.message_id,
+            "sender_id": message.sender_id,
+            "timestamp": message.timestamp,
+            "type": "text",
+            "content": text,
+            "conversation_id": message.context_token.conversation_id,
+            "sync_cursor": message.context_token.sync_cursor or "",
+        }
+        if message.recipient.kind == RecipientKind.GROUP:
+            payload["group_id"] = message.recipient.id
+        return payload
+
+    def _media_download_failure_text(self, media: OpenILinkMedia, error: Exception) -> str:
+        if media.kind == MediaKind.IMAGE:
+            media_label = "图片"
+        elif media.kind == MediaKind.VOICE:
+            media_label = "语音"
+        else:
+            media_label = "文件"
+        return f"[{media_label}下载失败: {error}]"
+
+    def _build_context_token(self, recipient: OpenILinkRecipient, ref_msg_id: str | None) -> ContextToken:
+        return ContextToken(
+            conversation_id=recipient.id,
+            message_id=ref_msg_id,
+            sync_cursor=self.session.last_cursor or None,
+        )

--- a/nekro_agent/adapters/wechat_ilink_multi/bot_manager.py
+++ b/nekro_agent/adapters/wechat_ilink_multi/bot_manager.py
@@ -1,0 +1,269 @@
+import asyncio
+import json
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, cast
+
+from nekro_agent.core.logger import get_sub_logger
+from nekro_agent.models.db_adapter_instance import DBAdapterInstance
+from nekro_agent.models.db_adapter_instance_session import DBAdapterInstanceSession
+from nekro_agent.schemas.errors import ConflictError, NotFoundError, ValidationError
+from nekro_agent.services.adapter_instance_service import adapter_instance_service
+
+from .bot_connection import BotConnection, ClientFactory
+from .client import OpenILinkMultiClient, UnsupportedOpenILinkMultiClient
+from .config import WeChatILinkMultiConfig
+from .schemas import BindPollResult, BindStartResult, BindStatus, SyncState
+
+if TYPE_CHECKING:
+    from .adapter import WeChatILinkMultiAdapter
+
+logger = get_sub_logger("adapter.wechat_ilink_multi.manager")
+
+
+class BotManager:
+    """微信 OpenILink 多实例生命周期管理器。"""
+
+    def __init__(
+        self,
+        *,
+        adapter_key: str,
+        config: WeChatILinkMultiConfig,
+        adapter_getter: Callable[[], object],
+        client_factory: ClientFactory | None = None,
+    ):
+        self.adapter_key = adapter_key
+        self.config = config
+        self._adapter_getter = adapter_getter
+        self._client_factory = client_factory or UnsupportedOpenILinkMultiClient
+        self._connections: dict[str, BotConnection] = {}
+        self._bind_clients: dict[str, OpenILinkMultiClient] = {}
+
+    @property
+    def connections(self) -> dict[str, BotConnection]:
+        return dict(self._connections)
+
+    async def start(self) -> None:
+        instances = await adapter_instance_service.list_instances(adapter_key=self.adapter_key)
+        for instance in instances:
+            if not self._should_autostart(instance):
+                continue
+            await self.start_instance(instance.instance_key, manual=False)
+
+    async def stop_all(self) -> None:
+        for instance_key in list(self._connections):
+            await self.stop_instance(instance_key)
+
+    def get_connection(self, instance_key: str) -> BotConnection | None:
+        return self._connections.get(instance_key)
+
+    async def start_bind(self, instance_key: str) -> BindStartResult:
+        instance = await self._get_active_instance(instance_key)
+        await self.stop_instance(instance_key, update_status=False)
+        client = self._client_factory(self.config)
+        try:
+            # 绑定动作会发起真实网络调用（生成二维码等），加超时避免 API 请求无限挂起
+            result = await asyncio.wait_for(client.start_bind(), timeout=self.config.BIND_TIMEOUT_SECONDS)
+        except (TimeoutError, asyncio.TimeoutError) as e:
+            raise ValidationError(reason=f"实例 {instance_key} 绑定二维码生成超时") from e
+        self._bind_clients[instance_key] = client
+
+        instance = await adapter_instance_service.set_status(
+            instance,
+            "binding",
+            "绑定二维码已生成",
+            payload={"bind_session_id": result.session_id, "expires_at": result.expires_at.isoformat()},
+        )
+        await self._set_bind_state(
+            instance,
+            "qr_generated",
+            "绑定二维码已生成",
+            payload={"bind_session_id": result.session_id, "qr_url": result.qr_url},
+        )
+        return result
+
+    async def poll_bind(self, instance_key: str, session_id: str) -> BindPollResult:
+        instance = await self._get_active_instance(instance_key)
+        client = self._bind_clients.get(instance_key)
+        if client is None:
+            client = self._client_factory(self.config)
+            self._bind_clients[instance_key] = client
+
+        result = await client.poll_bind(session_id)
+        if result.status == BindStatus.PENDING:
+            await self._set_bind_state(instance, "qr_generated", "等待扫码确认")
+            return result
+        if result.status == BindStatus.SCANNED:
+            await self._set_bind_state(instance, "qr_scanned", "二维码已扫描")
+            return result
+        if result.status == BindStatus.CONFIRMED:
+            await self._complete_bind(instance, result)
+            self._bind_clients.pop(instance_key, None)
+            return result
+        if result.status == BindStatus.EXPIRED:
+            await self._set_bind_state(instance, "expired", "绑定会话已过期")
+            await adapter_instance_service.set_status(instance, "session_expired", "绑定会话已过期")
+            self._bind_clients.pop(instance_key, None)
+            return result
+
+        message = result.error_message or "绑定失败"
+        await self._set_bind_state(instance, "failed", message)
+        await adapter_instance_service.set_status(instance, "error", message)
+        self._bind_clients.pop(instance_key, None)
+        return result
+
+    async def renew_instance(self, instance_key: str) -> DBAdapterInstance:
+        connection = self._connections.get(instance_key)
+        if connection is None:
+            await self.start_instance(instance_key, manual=True)
+            connection = self._connections.get(instance_key)
+        if connection is None:
+            raise ValidationError(reason=f"实例 {instance_key} 缺少有效会话，无法续期")
+        await connection.renew_once()
+        return connection.instance
+
+    async def start_instance(self, instance_key: str, *, manual: bool = True) -> BotConnection | None:
+        existing = self._connections.get(instance_key)
+        if existing is not None and existing.is_online:
+            return existing
+
+        instance = await adapter_instance_service.get_instance(self.adapter_key, instance_key)
+        if instance is None:
+            logger.warning(f"OpenILink 多实例不存在，无法启动: instance={instance_key}")
+            return None
+        if instance.status == "deleted":
+            logger.warning(f"OpenILink 多实例已删除，无法启动: instance={instance_key}")
+            return None
+        if not instance.enabled and not manual:
+            return None
+
+        session = await DBAdapterInstanceSession.get_or_none(instance_id=instance.id)
+        if session is None or not session.credentials_json:
+            if manual:
+                await adapter_instance_service.set_status(instance, "session_expired", "实例缺少有效会话凭据")
+            return None
+        if self._is_session_expired(session) and not manual:
+            await adapter_instance_service.set_status(instance, "session_expired", "实例会话已过期")
+            return None
+
+        await self.stop_instance(instance_key)
+        adapter_obj = cast("WeChatILinkMultiAdapter", self._adapter_getter())
+
+        connection = BotConnection(
+            adapter=adapter_obj,
+            instance=instance,
+            session=session,
+            config=self.config,
+            client_factory=self._client_factory,
+        )
+        self._connections[instance_key] = connection
+        # 不写入设计状态机之外的 "starting" 子状态；monitor 成功后由 BotConnection 落地 "online"，
+        # 失败则落地 "error"，避免引入未文档化的中间态。
+        await connection.start()
+        return connection
+
+    async def stop_instance(self, instance_key: str, *, update_status: bool = True) -> None:
+        connection = self._connections.pop(instance_key, None)
+        if connection is not None:
+            await connection.stop()
+
+        instance = await adapter_instance_service.get_instance(self.adapter_key, instance_key)
+        if update_status and instance is not None and instance.status not in ("deleted", "session_expired"):
+            await adapter_instance_service.set_status(instance, "offline", "实例已停止")
+
+    async def restart_instance(self, instance_key: str) -> BotConnection | None:
+        await self.stop_instance(instance_key)
+        return await self.start_instance(instance_key, manual=True)
+
+    def _should_autostart(self, instance: DBAdapterInstance) -> bool:
+        return instance.enabled and instance.status not in ("deleted", "session_expired")
+
+    def _is_session_expired(self, session: DBAdapterInstanceSession) -> bool:
+        expires_at = session.expires_at
+        if expires_at is None:
+            return False
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        return expires_at <= datetime.now(timezone.utc)
+
+    async def _get_active_instance(self, instance_key: str) -> DBAdapterInstance:
+        instance = await adapter_instance_service.get_instance(self.adapter_key, instance_key)
+        if instance is None:
+            raise NotFoundError(resource=f"OpenILink 实例 {instance_key}")
+        if instance.status == "deleted":
+            raise ValidationError(reason=f"实例 {instance_key} 已删除")
+        return instance
+
+    async def _complete_bind(self, instance: DBAdapterInstance, result: BindPollResult) -> None:
+        if result.credentials is None:
+            raise ValidationError(reason="绑定确认结果缺少会话凭据")
+        provider_account_id = result.provider_account_id or result.credentials.provider_account_id
+        await self._ensure_provider_account_available(instance, provider_account_id)
+
+        await self._set_bind_state(instance, "login_confirmed", "绑定登录已确认")
+        instance.provider_account_id = provider_account_id
+        await instance.save()
+        sync_state = SyncState()
+        session = await adapter_instance_service.upsert_session(
+            instance=instance,
+            credentials_json=result.credentials.model_dump_json(),
+            sync_state_json=sync_state.model_dump_json(),
+            expires_at=result.credentials.expires_at,
+            last_cursor="",
+        )
+        if result.credentials.expires_at is not None:
+            instance = await adapter_instance_service.schedule_renew(
+                instance=instance,
+                expires_at=result.credentials.expires_at,
+                renew_before_minutes=instance.renew_before_minutes or self.config.DEFAULT_RENEW_BEFORE_MINUTES,
+            )
+        await self._set_bind_state(instance, "session_persisted", "绑定会话已持久化")
+
+        await self.stop_instance(instance.instance_key, update_status=False)
+        adapter_obj = cast("WeChatILinkMultiAdapter", self._adapter_getter())
+        connection = BotConnection(
+            adapter=adapter_obj,
+            instance=instance,
+            session=session,
+            config=self.config,
+            client_factory=self._client_factory,
+        )
+        self._connections[instance.instance_key] = connection
+        await connection.start()
+        try:
+            await connection.wait_until_online(timeout_seconds=30.0)
+        except (RuntimeError, TimeoutError):
+            self._connections.pop(instance.instance_key, None)
+            await connection.stop()
+            raise
+
+    async def _ensure_provider_account_available(self, instance: DBAdapterInstance, provider_account_id: str) -> None:
+        if not provider_account_id:
+            raise ValidationError(reason="绑定确认结果缺少 provider_account_id")
+        conflict = await DBAdapterInstance.filter(
+            adapter_key=self.adapter_key,
+            provider_account_id=provider_account_id,
+        ).exclude(instance_key=instance.instance_key).exclude(status="deleted").first()
+        if conflict is not None:
+            raise ConflictError(resource=f"OpenILink 账号 {provider_account_id}")
+
+    async def _set_bind_state(
+        self,
+        instance: DBAdapterInstance,
+        bind_status: str,
+        message: str,
+        payload: dict[str, object] | None = None,
+    ) -> None:
+        previous_session = await DBAdapterInstanceSession.get_or_none(instance_id=instance.id)
+        previous_state = previous_session.session_state if previous_session is not None else ""
+        await adapter_instance_service.set_session_state(instance, bind_status, payload=payload)
+        if previous_state == bind_status:
+            return
+        await adapter_instance_service.record_event(
+            instance=instance,
+            event_type="bind_state_change",
+            status_from=previous_state,
+            status_to=bind_status,
+            message=message,
+            payload_json=json.dumps(payload, ensure_ascii=False) if payload else "",
+        )

--- a/nekro_agent/adapters/wechat_ilink_multi/client.py
+++ b/nekro_agent/adapters/wechat_ilink_multi/client.py
@@ -1,0 +1,138 @@
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeAlias
+
+from .config import WeChatILinkMultiConfig
+from .schemas import (
+    BindPollResult,
+    BindStartResult,
+    ContextToken,
+    OpenILinkCredentials,
+    OpenILinkMedia,
+    OpenILinkMessage,
+    OpenILinkRecipient,
+    RenewResult,
+    SendMessageResult,
+    SyncState,
+)
+
+MediaDownloadResult: TypeAlias = bytes | Path
+MessageCallback: TypeAlias = Callable[[OpenILinkMessage], Awaitable[None]]
+SyncStateCallback: TypeAlias = Callable[[SyncState], Awaitable[None]]
+ErrorCallback: TypeAlias = Callable[[Exception], Awaitable[None]]
+
+
+@dataclass(slots=True)
+class OpenILinkMonitorCallbacks:
+    """OpenILink 监控连接回调集合。"""
+
+    on_message: MessageCallback
+    on_sync_state: SyncStateCallback | None = None
+    on_error: ErrorCallback | None = None
+
+
+class OpenILinkMultiClient(ABC):
+    """OpenILink 多实例协议客户端边界。"""
+
+    def __init__(self, config: WeChatILinkMultiConfig):
+        self.config = config
+
+    @abstractmethod
+    async def start_bind(self) -> BindStartResult:
+        """启动一次账号绑定流程。"""
+
+    @abstractmethod
+    async def poll_bind(self, session_id: str) -> BindPollResult:
+        """轮询绑定会话状态。"""
+
+    @abstractmethod
+    async def start_monitor(
+        self,
+        credentials: OpenILinkCredentials,
+        sync_state: SyncState,
+        callbacks: OpenILinkMonitorCallbacks,
+    ) -> None:
+        """基于指定账号凭据启动一条消息监控连接。"""
+
+    @abstractmethod
+    async def stop_monitor(self) -> None:
+        """停止当前客户端实例持有的监控连接。"""
+
+    @abstractmethod
+    async def send_text(
+        self,
+        recipient: OpenILinkRecipient,
+        text: str,
+        context_token: ContextToken,
+    ) -> SendMessageResult:
+        """发送文本消息。"""
+
+    @abstractmethod
+    async def send_file(
+        self,
+        recipient: OpenILinkRecipient,
+        file_path: Path,
+        context_token: ContextToken,
+    ) -> SendMessageResult:
+        """发送本地文件。"""
+
+    @abstractmethod
+    async def download_media(self, media: OpenILinkMedia) -> MediaDownloadResult:
+        """下载媒体，返回内存字节或本地缓存路径。"""
+
+    @abstractmethod
+    async def renew_session(
+        self,
+        credentials: OpenILinkCredentials,
+        sync_state: SyncState,
+    ) -> RenewResult:
+        """续期账号会话并返回新的同步状态。"""
+
+
+class UnsupportedOpenILinkMultiClient(OpenILinkMultiClient):
+    """尚未绑定具体传输实现时使用的显式占位客户端。"""
+
+    async def start_bind(self) -> BindStartResult:
+        raise NotImplementedError("OpenILink multi-instance transport is not configured")
+
+    async def poll_bind(self, session_id: str) -> BindPollResult:
+        raise NotImplementedError("OpenILink multi-instance transport is not configured")
+
+    async def start_monitor(
+        self,
+        credentials: OpenILinkCredentials,
+        sync_state: SyncState,
+        callbacks: OpenILinkMonitorCallbacks,
+    ) -> None:
+        raise NotImplementedError("OpenILink multi-instance transport is not configured")
+
+    async def stop_monitor(self) -> None:
+        raise NotImplementedError("OpenILink multi-instance transport is not configured")
+
+    async def send_text(
+        self,
+        recipient: OpenILinkRecipient,
+        text: str,
+        context_token: ContextToken,
+    ) -> SendMessageResult:
+        raise NotImplementedError("OpenILink multi-instance transport is not configured")
+
+    async def send_file(
+        self,
+        recipient: OpenILinkRecipient,
+        file_path: Path,
+        context_token: ContextToken,
+    ) -> SendMessageResult:
+        raise NotImplementedError("OpenILink multi-instance transport is not configured")
+
+    async def download_media(self, media: OpenILinkMedia) -> MediaDownloadResult:
+        raise NotImplementedError("OpenILink multi-instance transport is not configured")
+
+    async def renew_session(
+        self,
+        credentials: OpenILinkCredentials,
+        sync_state: SyncState,
+    ) -> RenewResult:
+        raise NotImplementedError("OpenILink multi-instance transport is not configured")

--- a/nekro_agent/adapters/wechat_ilink_multi/config.py
+++ b/nekro_agent/adapters/wechat_ilink_multi/config.py
@@ -1,0 +1,113 @@
+from pydantic import Field
+
+from nekro_agent.adapters.interface.base import BaseAdapterConfig
+from nekro_agent.core.core_utils import ExtraField
+from nekro_agent.schemas.i18n import i18n_text
+
+
+class WeChatILinkMultiConfig(BaseAdapterConfig):
+    """微信 OpenILink 多实例适配器配置。"""
+
+    ENABLED: bool = Field(
+        default=False,
+        title="启用 OpenILink 多实例适配器",
+        description="是否启用微信 OpenILink 多实例适配器。默认关闭，等待具体协议实现接入。",
+        json_schema_extra=ExtraField(
+            i18n_category=i18n_text(zh_CN="OpenILink 多实例", en_US="OpenILink Multi"),
+            i18n_title=i18n_text(zh_CN="启用适配器", en_US="Enable Adapter"),
+            i18n_description=i18n_text(
+                zh_CN="是否启用微信 OpenILink 多实例适配器。默认关闭，等待具体协议实现接入。",
+                en_US="Whether to enable the WeChat OpenILink multi-instance adapter. Disabled by default until a concrete protocol transport is wired.",
+            ),
+        ).model_dump(),
+    )
+
+    API_BASE_URL: str = Field(
+        default="https://ilinkai.weixin.qq.com",
+        title="OpenILink API 地址",
+        description="OpenILink 协议服务基础地址，不包含具体资源路径。",
+        json_schema_extra=ExtraField(
+            placeholder="https://ilinkai.weixin.qq.com",
+            i18n_category=i18n_text(zh_CN="OpenILink 多实例", en_US="OpenILink Multi"),
+            i18n_title=i18n_text(zh_CN="API 地址", en_US="API Base URL"),
+            i18n_description=i18n_text(
+                zh_CN="OpenILink 协议服务基础地址，不包含具体资源路径。",
+                en_US="Base URL for the OpenILink protocol service, without concrete resource paths.",
+            ),
+        ).model_dump(),
+    )
+
+    DEFAULT_RENEW_BEFORE_MINUTES: int = Field(
+        default=60,
+        title="默认续期提前量（分钟）",
+        description="会话凭据过期前多少分钟触发默认续期。",
+        json_schema_extra=ExtraField(
+            placeholder="60",
+            i18n_category=i18n_text(zh_CN="会话", en_US="Session"),
+            i18n_title=i18n_text(zh_CN="默认续期提前量", en_US="Default Renew Lead Time"),
+            i18n_description=i18n_text(
+                zh_CN="会话凭据过期前多少分钟触发默认续期。",
+                en_US="How many minutes before credential expiry the default renewal should be triggered.",
+            ),
+        ).model_dump(),
+    )
+
+    BIND_TIMEOUT_SECONDS: int = Field(
+        default=180,
+        title="绑定超时（秒）",
+        description="二维码或外部绑定流程等待完成的最长时间。",
+        json_schema_extra=ExtraField(
+            placeholder="180",
+            i18n_category=i18n_text(zh_CN="绑定", en_US="Binding"),
+            i18n_title=i18n_text(zh_CN="绑定超时", en_US="Bind Timeout"),
+            i18n_description=i18n_text(
+                zh_CN="二维码或外部绑定流程等待完成的最长时间。",
+                en_US="Maximum wait time for QR-code or external binding flow completion.",
+            ),
+        ).model_dump(),
+    )
+
+    DEDUP_WINDOW_SECONDS: int = Field(
+        default=120,
+        title="消息去重窗口（秒）",
+        description="入站消息按 provider 消息 ID 去重的时间窗口。",
+        json_schema_extra=ExtraField(
+            placeholder="120",
+            i18n_category=i18n_text(zh_CN="消息", en_US="Messages"),
+            i18n_title=i18n_text(zh_CN="消息去重窗口", en_US="Dedup Window"),
+            i18n_description=i18n_text(
+                zh_CN="入站消息按 provider 消息 ID 去重的时间窗口。",
+                en_US="Time window for deduplicating inbound messages by provider message ID.",
+            ),
+        ).model_dump(),
+    )
+
+    MEDIA_DOWNLOAD_MAX_BYTES: int = Field(
+        default=20 * 1024 * 1024,
+        title="媒体下载大小上限（字节）",
+        description="单个媒体文件允许下载的最大字节数。",
+        json_schema_extra=ExtraField(
+            placeholder="20971520",
+            i18n_category=i18n_text(zh_CN="媒体", en_US="Media"),
+            i18n_title=i18n_text(zh_CN="媒体下载大小上限", en_US="Media Download Limit"),
+            i18n_description=i18n_text(
+                zh_CN="单个媒体文件允许下载的最大字节数。",
+                en_US="Maximum allowed bytes for a single media download.",
+            ),
+        ).model_dump(),
+    )
+
+    MEDIA_DOWNLOAD_TIMEOUT_SECONDS: int = Field(
+        default=60,
+        title="媒体下载超时（秒）",
+        description="单个媒体文件下载的超时时间。",
+        json_schema_extra=ExtraField(
+            placeholder="60",
+            i18n_category=i18n_text(zh_CN="媒体", en_US="Media"),
+            i18n_title=i18n_text(zh_CN="媒体下载超时", en_US="Media Download Timeout"),
+            i18n_description=i18n_text(
+                zh_CN="单个媒体文件下载的超时时间。",
+                en_US="Timeout in seconds for downloading a single media item.",
+            ),
+        ).model_dump(),
+    )

--- a/nekro_agent/adapters/wechat_ilink_multi/message_processor.py
+++ b/nekro_agent/adapters/wechat_ilink_multi/message_processor.py
@@ -1,0 +1,553 @@
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from nekro_agent.adapters.interface.schemas.platform import (
+    PlatformChannel,
+    PlatformMessage,
+    PlatformUser,
+)
+from nekro_agent.core.logger import get_sub_logger
+from nekro_agent.schemas.chat_message import (
+    ChatMessageSegment,
+    ChatMessageSegmentFile,
+    ChatMessageSegmentImage,
+    ChatMessageSegmentType,
+    ChatType,
+)
+
+logger = get_sub_logger("adapter.wechat_ilink_multi")
+
+TEXT_KEYS = ("text", "content", "content_text")
+GROUP_ID_KEYS = ("group_id", "room_id", "chatroom_id")
+MESSAGE_ID_KEYS = ("message_id", "msg_id", "id")
+MEDIA_TYPE_KEYS = ("type", "msg_type", "message_type")
+DEDUP_MAX_SIZE = 2000
+
+
+@dataclass(slots=True)
+class ParsedOpenILinkMessage:
+    channel: PlatformChannel
+    user: PlatformUser
+    message: PlatformMessage
+
+
+class OpenILinkMultiMessageProcessor:
+    """OpenILink 多实例消息处理器
+
+    将 OpenILink 入站消息映射为 Nekro Agent 平台 schema。
+    支持多实例作用域，通过 instance_id 隔离不同微信实例的消息。
+    """
+
+    def __init__(
+        self,
+        *,
+        instance_id: str,
+        adapter_key: str,
+        dedup_window_seconds: int = 120,
+        self_user_id: str = "",
+        build_chat_key: Callable[[str], str] | None = None,
+    ):
+        self.instance_id = instance_id
+        self.adapter_key = adapter_key
+        self.dedup_window_seconds = max(dedup_window_seconds, 1)
+        self.self_user_id = self_user_id
+        # 用于将作用域 channel_id 还原为完整 chat_key（媒体落盘目录需与 DBChatChannel.chat_key 一致）
+        self._build_chat_key = build_chat_key
+        self._recent_keys: Dict[tuple[str, str, str], float] = {}
+        self._last_gc_ts = 0.0
+
+    def _resolve_chat_key(self, channel_id: str) -> str:
+        """将作用域 channel_id 还原为完整 chat_key，确保媒体落盘目录与频道 chat_key 一致。"""
+        if self._build_chat_key is not None:
+            return self._build_chat_key(channel_id)
+        return f"{self.adapter_key}-{channel_id}"
+
+    def set_self_user_id(self, user_id: str) -> None:
+        self.self_user_id = user_id
+
+    async def parse(self, raw_message: Any) -> Optional[ParsedOpenILinkMessage]:
+        """解析入站消息
+
+        Args:
+            raw_message: OpenILink 原始消息对象或字典
+
+        Returns:
+            解析后的平台消息，如果是重复消息则返回 None
+        """
+        sender_id = self._extract_sender_id(raw_message)
+        if not sender_id:
+            logger.warning("无法提取 sender_id，跳过消息")
+            return None
+
+        group_id = self._extract_group_id(raw_message)
+        channel = self._build_channel(sender_id, group_id)
+        user = self._build_user(sender_id, raw_message)
+
+        # 解析消息内容（异步，可能涉及媒体下载）
+        # 媒体落盘使用完整 chat_key（而非裸 channel_id），与 DBChatChannel.chat_key 及沙盒挂载目录一致
+        try:
+            content_data, content_text = await self._build_content(
+                raw_message=raw_message,
+                sender_id=sender_id,
+                chat_key=self._resolve_chat_key(channel.channel_id),
+            )
+        except Exception:
+            logger.exception("解析消息内容失败")
+            return None
+
+        if not content_data:
+            logger.debug("消息内容为空，跳过")
+            return None
+
+        message = self._build_platform_message(
+            raw_message=raw_message,
+            sender_id=sender_id,
+            content_data=content_data,
+            content_text=content_text,
+            is_group=bool(group_id),
+        )
+        parsed = ParsedOpenILinkMessage(channel=channel, user=user, message=message)
+
+        if self._is_duplicate(parsed):
+            logger.debug(f"重复消息已过滤: {message.message_id}")
+            return None
+        return parsed
+
+    def _extract_sender_id(self, raw_message: Any) -> str:
+        return self._first_non_empty(raw_message, ("user_id", "sender_id", "from_user"))
+
+    def _extract_group_id(self, raw_message: Any) -> str:
+        return self._first_non_empty(raw_message, GROUP_ID_KEYS)
+
+    def _build_channel(self, sender_id: str, group_id: str) -> PlatformChannel:
+        """构建平台频道
+
+        私聊: {instance_id}:private:{sender_id_or_peer_id}
+        群聊: {instance_id}:group:{group_id}
+        """
+        is_group = bool(group_id)
+        if is_group:
+            channel_id = f"{self.instance_id}:group:{group_id}"
+        else:
+            channel_id = f"{self.instance_id}:private:{sender_id}"
+
+        return PlatformChannel(
+            channel_id=channel_id,
+            channel_name=channel_id,
+            channel_type=ChatType.GROUP if is_group else ChatType.PRIVATE,
+        )
+
+    def _build_user(self, sender_id: str, raw_message: Any) -> PlatformUser:
+        """构建平台用户"""
+        # 尝试获取发送者昵称
+        sender_name = (
+            self._first_non_empty(raw_message, ("sender_name", "nickname", "user_name"))
+            or sender_id
+        )
+
+        return PlatformUser(
+            platform_name=self.adapter_key,
+            user_id=sender_id,
+            user_name=sender_name,
+        )
+
+    async def _build_content(
+        self,
+        *,
+        raw_message: Any,
+        sender_id: str,
+        chat_key: str,
+    ) -> tuple[List[ChatMessageSegment], str]:
+        """构建消息内容（支持文本+媒体混合）"""
+        segments: List[ChatMessageSegment] = []
+        texts: List[str] = []
+
+        # 提取文本
+        text = self._extract_text(raw_message)
+        if text:
+            segments.append(ChatMessageSegment(type=ChatMessageSegmentType.TEXT, text=text))
+            texts.append(text)
+
+        # 检测并处理媒体
+        msg_type = self._detect_message_type(raw_message)
+        if msg_type == "image":
+            media_segments, media_text = await self._build_image_content(raw_message, chat_key)
+            segments.extend(media_segments)
+            if media_text:
+                texts.append(media_text)
+        elif msg_type == "voice":
+            media_segments, media_text = await self._build_voice_content(raw_message, chat_key)
+            segments.extend(media_segments)
+            if media_text:
+                texts.append(media_text)
+        elif msg_type == "file":
+            media_segments, media_text = await self._build_file_content(raw_message, chat_key)
+            segments.extend(media_segments)
+            if media_text:
+                texts.append(media_text)
+
+        return segments, " ".join(texts) if texts else ""
+
+    def _detect_message_type(self, raw_message: Any) -> str:
+        """检测消息类型"""
+        # 检查显式类型字段
+        type_value = self._first_non_empty(raw_message, MEDIA_TYPE_KEYS)
+        if type_value:
+            type_lower = type_value.lower()
+            if type_lower in ("image", "img", "picture", "photo"):
+                return "image"
+            if type_lower in ("voice", "audio", "sound"):
+                return "voice"
+            if type_lower in ("file", "document", "attachment"):
+                return "file"
+            if type_lower in ("text", "plain", "string"):
+                return "text"
+
+        # 通过内容字段推断
+        if self._has_image_fields(raw_message):
+            return "image"
+
+        if self._has_voice_fields(raw_message):
+            return "voice"
+
+        if self._has_file_fields(raw_message):
+            return "file"
+
+        return "text"
+
+    def _has_image_fields(self, raw_message: Any) -> bool:
+        """检查是否有图片相关字段（含 wechatbot-sdk item_list）"""
+        raw = self._get_raw_dict(raw_message)
+        if not raw:
+            return False
+        image_keys = ("image_url", "img_url", "pic_url", "image_data", "image")
+        for key in image_keys:
+            if raw.get(key):
+                return True
+        for item in raw.get("item_list", []):
+            if "image_item" in item:
+                return True
+        return False
+
+    def _has_voice_fields(self, raw_message: Any) -> bool:
+        """检查是否有语音相关字段（含 wechatbot-sdk item_list）"""
+        raw = self._get_raw_dict(raw_message)
+        if not raw:
+            return False
+        voice_keys = ("voice_url", "audio_url", "voice_data", "audio_data", "voice", "audio")
+        for key in voice_keys:
+            if raw.get(key):
+                return True
+        for item in raw.get("item_list", []):
+            if "voice_item" in item:
+                return True
+        return False
+
+    def _has_file_fields(self, raw_message: Any) -> bool:
+        """检查是否有文件相关字段（含 wechatbot-sdk item_list）"""
+        raw = self._get_raw_dict(raw_message)
+        if not raw:
+            return False
+        file_keys = ("file_url", "file_data", "file_name", "file", "attachment_url")
+        for key in file_keys:
+            if raw.get(key):
+                return True
+        for item in raw.get("item_list", []):
+            if "file_item" in item:
+                return True
+        return False
+
+    async def _build_image_content(
+        self,
+        raw_message: Any,
+        chat_key: str,
+    ) -> tuple[List[ChatMessageSegment], str]:
+        """构建图片内容（从 wechatbot-sdk item_list 提取 URL）"""
+        raw = self._get_raw_dict(raw_message)
+        if raw:
+            for item in raw.get("item_list", []):
+                if "image_item" in item:
+                    ii = item["image_item"]
+                    url = ii.get("url") or (ii.get("media") or {}).get("full_url")
+                    if url:
+                        file_name = ii.get("file_name") or "image.jpg"
+                        try:
+                            segment = await ChatMessageSegmentImage.create_from_url(
+                                url=url,
+                                from_chat_key=chat_key,
+                                file_name=file_name,
+                                use_suffix=".jpg",
+                            )
+                            return [segment], segment.text
+                        except Exception:
+                            logger.exception("下载图片失败")
+                            error_text = "[图片下载失败]"
+                            return [ChatMessageSegment(type=ChatMessageSegmentType.TEXT, text=error_text)], error_text
+        # fallback: 从 URL 读取
+        image_url = raw.get("image_url") if raw else None
+        if image_url:
+            try:
+                segment = await ChatMessageSegmentImage.create_from_url(
+                    url=image_url,
+                    from_chat_key=chat_key,
+                    file_name="image.jpg",
+                    use_suffix=".jpg",
+                )
+                return [segment], segment.text
+            except Exception:
+                logger.exception("下载图片失败")
+                error_text = "[图片下载失败]"
+                return [ChatMessageSegment(type=ChatMessageSegmentType.TEXT, text=error_text)], error_text
+        # fallback: 从已下载的字节数据读取（无直链时由 BotConnection 下载后注入 image_data）
+        image_data = raw.get("image_data") if raw else None
+        if image_data:
+            try:
+                segment = await ChatMessageSegmentImage.create_from_bytes(
+                    image_data,
+                    from_chat_key=chat_key,
+                    file_name="image.jpg",
+                    use_suffix=".jpg",
+                )
+                return [segment], segment.text
+            except Exception:
+                logger.exception("从字节数据构建图片失败")
+                error_text = "[图片下载失败]"
+                return [ChatMessageSegment(type=ChatMessageSegmentType.TEXT, text=error_text)], error_text
+        return [], ""
+
+    async def _build_voice_content(
+        self,
+        raw_message: Any,
+        chat_key: str,
+    ) -> tuple[List[ChatMessageSegment], str]:
+        raw = self._get_raw_dict(raw_message)
+        if raw:
+            for item in raw.get("item_list", []):
+                if "voice_item" in item:
+                    vi = item["voice_item"]
+                    url = (vi.get("media") or {}).get("full_url")
+                    if url:
+                        file_name = vi.get("file_name") or "voice.mp3"
+                        use_suffix = ".amr" if file_name.lower().endswith(".amr") else ".mp3"
+                        try:
+                            segment = await ChatMessageSegmentFile.create_from_url(
+                                url=url,
+                                from_chat_key=chat_key,
+                                file_name=file_name,
+                                use_suffix=use_suffix,
+                            )
+                            segment.text = f"[Voice: {segment.file_name}]"
+                            return [segment], segment.text
+                        except Exception:
+                            logger.exception("下载语音失败")
+                            error_text = "[语音下载失败]"
+                            return [ChatMessageSegment(type=ChatMessageSegmentType.TEXT, text=error_text)], error_text
+        voice_url = raw.get("voice_url") if raw else None
+        if voice_url:
+            try:
+                segment = await ChatMessageSegmentFile.create_from_url(
+                    url=voice_url,
+                    from_chat_key=chat_key,
+                    file_name="voice.mp3",
+                    use_suffix=".mp3",
+                )
+                segment.text = f"[Voice: {segment.file_name}]"
+                return [segment], segment.text
+            except Exception:
+                logger.exception("下载语音失败")
+                error_text = "[语音下载失败]"
+                return [ChatMessageSegment(type=ChatMessageSegmentType.TEXT, text=error_text)], error_text
+        # fallback: 从已下载的字节数据读取（无直链时由 BotConnection 下载后注入 voice_data）
+        voice_data = raw.get("voice_data") if raw else None
+        if voice_data:
+            try:
+                segment = await ChatMessageSegmentFile.create_from_bytes(
+                    voice_data,
+                    from_chat_key=chat_key,
+                    file_name="voice.mp3",
+                    use_suffix=".mp3",
+                )
+                segment.text = f"[Voice: {segment.file_name}]"
+                return [segment], segment.text
+            except Exception:
+                logger.exception("从字节数据构建语音失败")
+                error_text = "[语音下载失败]"
+                return [ChatMessageSegment(type=ChatMessageSegmentType.TEXT, text=error_text)], error_text
+        return [], ""
+
+    async def _build_file_content(
+        self,
+        raw_message: Any,
+        chat_key: str,
+    ) -> tuple[List[ChatMessageSegment], str]:
+        raw = self._get_raw_dict(raw_message)
+        if raw:
+            for item in raw.get("item_list", []):
+                if "file_item" in item:
+                    fi = item["file_item"]
+                    url = (fi.get("media") or {}).get("full_url")
+                    if url:
+                        file_name = fi.get("file_name") or "file"
+                        try:
+                            segment = await ChatMessageSegmentFile.create_from_url(
+                                url=url,
+                                from_chat_key=chat_key,
+                                file_name=file_name,
+                            )
+                            return [segment], segment.text
+                        except Exception:
+                            logger.exception("下载文件失败")
+                            error_text = "[文件下载失败]"
+                            return [ChatMessageSegment(type=ChatMessageSegmentType.TEXT, text=error_text)], error_text
+        file_url = raw.get("file_url") if raw else None
+        if file_url:
+            try:
+                segment = await ChatMessageSegmentFile.create_from_url(
+                    url=file_url,
+                    from_chat_key=chat_key,
+                    file_name="file",
+                )
+                return [segment], segment.text
+            except Exception:
+                logger.exception("下载文件失败")
+                error_text = "[文件下载失败]"
+                return [ChatMessageSegment(type=ChatMessageSegmentType.TEXT, text=error_text)], error_text
+        # fallback: 从已下载的字节数据读取（无直链时由 BotConnection 下载后注入 file_data）
+        file_data = raw.get("file_data") if raw else None
+        if file_data:
+            try:
+                segment = await ChatMessageSegmentFile.create_from_bytes(
+                    file_data,
+                    from_chat_key=chat_key,
+                    file_name="file",
+                )
+                return [segment], segment.text
+            except Exception:
+                logger.exception("从字节数据构建文件失败")
+                error_text = "[文件下载失败]"
+                return [ChatMessageSegment(type=ChatMessageSegmentType.TEXT, text=error_text)], error_text
+        return [], ""
+
+    def _extract_text(self, raw_message: Any) -> str:
+        return self._first_non_empty(raw_message, TEXT_KEYS)
+
+    def _build_platform_message(
+        self,
+        *,
+        raw_message: Any,
+        sender_id: str,
+        content_data: List[ChatMessageSegment],
+        content_text: str,
+        is_group: bool,
+    ) -> PlatformMessage:
+        """构建平台消息"""
+        is_self = bool(self.self_user_id and sender_id == self.self_user_id)
+
+        return PlatformMessage(
+            message_id=self._build_message_id(raw_message),
+            sender_id=sender_id,
+            sender_name=sender_id,
+            sender_nickname=sender_id,
+            content_data=content_data,
+            content_text=content_text,
+            is_tome=self._is_tome(raw_message=raw_message, text=content_text, is_group=is_group),
+            is_self=is_self,
+            timestamp=self._extract_timestamp(raw_message),
+        )
+
+    def _build_message_id(self, raw_message: Any) -> str:
+        """构建消息 ID: {instance_id}:{remote_message_id}"""
+        msg_id = self._first_non_empty(raw_message, MESSAGE_ID_KEYS)
+        if msg_id:
+            return f"{self.instance_id}:{msg_id}"
+        return f"{self.instance_id}:{int(time.time() * 1000)}"
+
+    def _extract_timestamp(self, raw_message: Any) -> int:
+        ts = getattr(raw_message, "timestamp", None)
+        if ts is not None:
+            try:
+                return int(ts.timestamp())
+            except Exception:
+                pass
+        raw_ts = self._get_raw_field(raw_message, "timestamp")
+        if raw_ts is not None:
+            try:
+                return int(raw_ts)
+            except Exception:
+                pass
+        return int(time.time())
+
+    def _is_tome(self, *, raw_message: Any, text: str, is_group: bool) -> bool:
+        if not is_group:
+            return True
+
+        mention_flag = bool(self._get_raw_field(raw_message, "is_mention_bot"))
+        if mention_flag:
+            return True
+
+        self_id = self.self_user_id.strip() if self.self_user_id else ""
+        if not self_id:
+            return False
+
+        return f"@{self_id}" in text
+
+    def _first_non_empty(self, raw_message: Any, keys: tuple[str, ...]) -> str:
+        raw = self._get_raw_dict(raw_message)
+        for key in keys:
+            value = str(getattr(raw_message, key, "") or "").strip()
+            if value:
+                return value
+            if raw is not None:
+                raw_value = str(raw.get(key, "") or "").strip()
+                if raw_value:
+                    return raw_value
+        return ""
+
+    def _get_raw_dict(self, raw_message: Any) -> Optional[Dict[str, Any]]:
+        """获取原始字典数据"""
+        if isinstance(raw_message, dict):
+            return raw_message
+        raw = getattr(raw_message, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        return None
+
+    def _get_raw_field(self, raw_message: Any, key: str) -> Any:
+        raw = self._get_raw_dict(raw_message)
+        if raw is None:
+            return None
+        return raw.get(key)
+
+    def _is_duplicate(self, parsed: ParsedOpenILinkMessage) -> bool:
+        """检查消息是否重复"""
+        now = time.time()
+        ttl = self.dedup_window_seconds
+        cutoff = now - ttl
+        gc_interval = max(min(ttl // 4, 30), 5)
+
+        self._gc_recent_keys(now, cutoff, gc_interval)
+
+        dedup_key = (parsed.channel.channel_id, parsed.message.message_id, parsed.user.user_id)
+        if dedup_key in self._recent_keys:
+            return True
+
+        self._recent_keys[dedup_key] = now
+        if len(self._recent_keys) > DEDUP_MAX_SIZE:
+            self._trim_recent_keys()
+        return False
+
+    def _gc_recent_keys(self, now: float, cutoff: float, gc_interval: int) -> None:
+        if now - self._last_gc_ts < gc_interval:
+            return
+        self._recent_keys = {k: ts for k, ts in self._recent_keys.items() if ts >= cutoff}
+        self._last_gc_ts = now
+
+    def _trim_recent_keys(self) -> None:
+        overflow_count = len(self._recent_keys) - DEDUP_MAX_SIZE
+        if overflow_count <= 0:
+            return
+        oldest_keys = sorted(self._recent_keys, key=self._recent_keys.__getitem__)[:overflow_count]
+        for key in oldest_keys:
+            self._recent_keys.pop(key, None)

--- a/nekro_agent/adapters/wechat_ilink_multi/routers.py
+++ b/nekro_agent/adapters/wechat_ilink_multi/routers.py
@@ -1,0 +1,268 @@
+from typing import cast
+
+from fastapi import APIRouter, Depends, Response
+
+from nekro_agent.adapters import loaded_adapters
+from nekro_agent.models.db_adapter_instance import DBAdapterInstance
+from nekro_agent.models.db_adapter_instance_event import DBAdapterInstanceEvent
+from nekro_agent.models.db_adapter_instance_session import DBAdapterInstanceSession
+from nekro_agent.models.db_user import DBUser
+from nekro_agent.schemas.errors import NotFoundError, ValidationError
+from nekro_agent.services.adapter_instance_service import adapter_instance_service
+from nekro_agent.services.user.deps import get_current_active_user
+from nekro_agent.services.user.perm import Role, require_role
+
+from .adapter import WeChatILinkMultiAdapter
+from .bot_manager import BotManager
+from .schemas import (
+    BindStartResponse,
+    BindStatusResponse,
+    EventResponse,
+    InstanceCreateRequest,
+    InstanceCreateResponse,
+    InstanceDetailResponse,
+    InstanceListResponse,
+    RenewPolicyRequest,
+)
+
+ADAPTER_KEY = "wechat_ilink_multi"
+
+
+def _get_bot_manager() -> BotManager:
+    """获取当前加载的 BotManager 实例。"""
+    adapter = loaded_adapters.get(ADAPTER_KEY)
+    if adapter is None or not isinstance(adapter, WeChatILinkMultiAdapter):
+        raise ValidationError(reason=f"适配器 {ADAPTER_KEY} 未加载或不可用")
+    return cast(WeChatILinkMultiAdapter, adapter).bot_manager
+
+
+def _to_detail_response(instance: DBAdapterInstance) -> InstanceDetailResponse:
+    """将 DBAdapterInstance 转换为 InstanceDetailResponse（不包含凭据）。"""
+    return InstanceDetailResponse(
+        instance_key=instance.instance_key,
+        display_name=instance.display_name,
+        status=instance.status,
+        enabled=instance.enabled,
+        is_default=instance.is_default,
+        provider=instance.provider,
+        provider_account_id=instance.provider_account_id,
+        metadata_json=instance.metadata_json,
+        last_error=instance.last_error or None,
+        last_active_at=instance.last_active_at,
+        next_renew_at=instance.next_renew_at,
+        renew_before_minutes=instance.renew_before_minutes,
+        create_time=instance.create_time,
+        update_time=instance.update_time,
+    )
+
+
+def create_router() -> APIRouter:
+    """创建适配器管理路由"""
+    router = APIRouter(prefix="/instances", tags=["WeChat iLink Multi Instance Management"])
+
+    @router.get("", response_model=InstanceListResponse)
+    @require_role(Role.Admin)
+    async def list_instances(
+        _current_user: DBUser = Depends(get_current_active_user),
+    ) -> InstanceListResponse:
+        """获取所有实例"""
+        instances = await adapter_instance_service.list_instances(adapter_key=ADAPTER_KEY)
+        return InstanceListResponse(instances=[_to_detail_response(inst) for inst in instances])
+
+    @router.post("", response_model=InstanceCreateResponse, status_code=201)
+    @require_role(Role.Admin)
+    async def create_instance(
+        body: InstanceCreateRequest,
+        response: Response,
+        _current_user: DBUser = Depends(get_current_active_user),
+    ) -> InstanceCreateResponse:
+        """创建实例（幂等）"""
+        if not body.instance_key:
+            raise ValidationError(reason="instance_key 不能为空")
+
+        existing = await adapter_instance_service.get_instance(
+            adapter_key=ADAPTER_KEY,
+            instance_key=body.instance_key,
+        )
+        # 已存在且未软删 -> 幂等返回；软删实例走下方 create_instance 复活流程（避免 instance_key 永久占用为僵尸）
+        if existing is not None and existing.status != "deleted":
+            response.status_code = 200
+            return InstanceCreateResponse(
+                instance_key=existing.instance_key,
+                status=existing.status,
+                renew_before_minutes=existing.renew_before_minutes,
+                created_at=existing.create_time,
+                existing=True,
+            )
+
+        instance = await adapter_instance_service.create_instance(
+            adapter_key=ADAPTER_KEY,
+            instance_key=body.instance_key,
+            display_name=body.display_name,
+            provider=body.provider,
+        )
+        return InstanceCreateResponse(
+            instance_key=instance.instance_key,
+            status=instance.status,
+            renew_before_minutes=instance.renew_before_minutes,
+            created_at=instance.create_time,
+            existing=False,
+        )
+
+    @router.get("/{instance_key}", response_model=InstanceDetailResponse)
+    @require_role(Role.Admin)
+    async def get_instance(
+        instance_key: str,
+        _current_user: DBUser = Depends(get_current_active_user),
+    ) -> InstanceDetailResponse:
+        """获取实例详情"""
+        instance = await adapter_instance_service.get_instance(
+            adapter_key=ADAPTER_KEY,
+            instance_key=instance_key,
+        )
+        if instance is None:
+            raise NotFoundError(resource=f"实例 {instance_key}")
+        return _to_detail_response(instance)
+
+    @router.delete("/{instance_key}", status_code=204)
+    @require_role(Role.Admin)
+    async def delete_instance(
+        instance_key: str,
+        _current_user: DBUser = Depends(get_current_active_user),
+    ) -> None:
+        """软删除实例"""
+        instance = await adapter_instance_service.get_instance(
+            adapter_key=ADAPTER_KEY,
+            instance_key=instance_key,
+        )
+        if instance is None:
+            raise NotFoundError(resource=f"实例 {instance_key}")
+        await adapter_instance_service.soft_delete_instance(instance)
+
+    @router.post("/{instance_key}/bind/start", response_model=BindStartResponse)
+    @require_role(Role.Admin)
+    async def start_bind(
+        instance_key: str,
+        _current_user: DBUser = Depends(get_current_active_user),
+    ) -> BindStartResponse:
+        """开始二维码绑定"""
+        bot_manager = _get_bot_manager()
+        result = await bot_manager.start_bind(instance_key)
+        return BindStartResponse(
+            bind_session_id=result.session_id,
+            qr_url=result.qr_url,
+            status="ok",
+            bind_status="qr_generated",
+            expires_at=result.expires_at,
+        )
+
+    @router.get("/{instance_key}/bind/status/{bind_session_id}", response_model=BindStatusResponse)
+    @require_role(Role.Admin)
+    async def get_bind_status(
+        instance_key: str,
+        bind_session_id: str,
+        _current_user: DBUser = Depends(get_current_active_user),
+    ) -> BindStatusResponse:
+        """轮询绑定状态"""
+        bot_manager = _get_bot_manager()
+        result = await bot_manager.poll_bind(instance_key, bind_session_id)
+        message = result.error_message
+        if result.status.value == "confirmed":
+            message = "绑定成功"
+        elif result.status.value == "pending":
+            message = "等待扫码"
+        elif result.status.value == "scanned":
+            message = "二维码已扫描"
+        elif result.status.value == "expired":
+            message = "绑定会话已过期"
+        # 返回规范的绑定子状态（qr_generated/qr_scanned/login_confirmed/session_persisted）与主生命周期状态。
+        # poll_bind 已将 session.session_state 推进到对应子状态；无会话时回退到原始 poll 状态。
+        instance = await adapter_instance_service.get_instance(ADAPTER_KEY, instance_key)
+        session = await DBAdapterInstanceSession.get_or_none(instance_id=instance.id) if instance is not None else None
+        bind_substate = session.session_state if session is not None and session.session_state else result.status.value
+        return BindStatusResponse(
+            status="ok",
+            instance_status=instance.status if instance is not None else "",
+            bind_status=bind_substate,
+            message=message,
+        )
+
+    @router.post("/{instance_key}/start", status_code=204)
+    @require_role(Role.Admin)
+    async def start_instance(
+        instance_key: str,
+        _current_user: DBUser = Depends(get_current_active_user),
+    ) -> None:
+        """启动实例"""
+        bot_manager = _get_bot_manager()
+        connection = await bot_manager.start_instance(instance_key)
+        if connection is None:
+            raise ValidationError(reason=f"实例 {instance_key} 启动失败，请检查会话凭据")
+
+    @router.post("/{instance_key}/stop", status_code=204)
+    @require_role(Role.Admin)
+    async def stop_instance(
+        instance_key: str,
+        _current_user: DBUser = Depends(get_current_active_user),
+    ) -> None:
+        """停止实例"""
+        bot_manager = _get_bot_manager()
+        await bot_manager.stop_instance(instance_key)
+
+    @router.post("/{instance_key}/renew", response_model=InstanceDetailResponse)
+    @require_role(Role.Admin)
+    async def renew_instance(
+        instance_key: str,
+        _current_user: DBUser = Depends(get_current_active_user),
+    ) -> InstanceDetailResponse:
+        """触发续期"""
+        bot_manager = _get_bot_manager()
+        instance = await bot_manager.renew_instance(instance_key)
+        return _to_detail_response(instance)
+
+    @router.patch("/{instance_key}/renew-policy", response_model=InstanceDetailResponse)
+    @require_role(Role.Admin)
+    async def update_renew_policy(
+        instance_key: str,
+        body: RenewPolicyRequest,
+        _current_user: DBUser = Depends(get_current_active_user),
+    ) -> InstanceDetailResponse:
+        """更新续期策略"""
+        instance = await adapter_instance_service.get_instance(
+            adapter_key=ADAPTER_KEY,
+            instance_key=instance_key,
+        )
+        if instance is None:
+            raise NotFoundError(resource=f"实例 {instance_key}")
+
+        instance.renew_before_minutes = body.renew_before_minutes
+        await instance.save()
+        return _to_detail_response(instance)
+
+    @router.get("/{instance_key}/events", response_model=list[EventResponse])
+    @require_role(Role.Admin)
+    async def list_instance_events(
+        instance_key: str,
+        _current_user: DBUser = Depends(get_current_active_user),
+    ) -> list[EventResponse]:
+        """获取实例事件列表"""
+        instance = await adapter_instance_service.get_instance(
+            adapter_key=ADAPTER_KEY,
+            instance_key=instance_key,
+        )
+        if instance is None:
+            raise NotFoundError(resource=f"实例 {instance_key}")
+
+        events = await DBAdapterInstanceEvent.filter(instance_id=instance.id).order_by("-create_time")
+        return [
+            EventResponse(
+                event_type=e.event_type,
+                status_from=e.status_from or None,
+                status_to=e.status_to or None,
+                message=e.message or None,
+                create_time=e.create_time,
+            )
+            for e in events
+        ]
+
+    return router

--- a/nekro_agent/adapters/wechat_ilink_multi/schemas.py
+++ b/nekro_agent/adapters/wechat_ilink_multi/schemas.py
@@ -1,0 +1,374 @@
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class OpenILinkSchema(BaseModel):
+    """OpenILink 协议模型基类。"""
+
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+
+class BindStatus(str, Enum):
+    PENDING = "pending"
+    SCANNED = "scanned"
+    CONFIRMED = "confirmed"
+    EXPIRED = "expired"
+    FAILED = "failed"
+
+
+class RecipientKind(str, Enum):
+    USER = "user"
+    GROUP = "group"
+
+
+class MediaKind(str, Enum):
+    IMAGE = "image"
+    FILE = "file"
+    VOICE = "voice"
+    VIDEO = "video"
+
+
+class BindStartResult(OpenILinkSchema):
+    session_id: str = Field(..., description="绑定会话 ID")
+    qr_url: str = Field(..., description="绑定二维码或授权 URL")
+    expires_at: datetime = Field(..., description="绑定会话过期时间")
+
+
+class OpenILinkCredentials(OpenILinkSchema):
+    provider_account_id: str = Field(..., description="OpenILink 侧账号 ID")
+    access_token: str = Field(..., description="访问令牌")
+    refresh_token: str | None = Field(default=None, description="刷新令牌")
+    expires_at: datetime | None = Field(default=None, description="访问令牌过期时间")
+    device_id: str | None = Field(default=None, description="绑定设备 ID")
+    scope: list[str] = Field(default_factory=list, description="授权范围")
+
+
+class BindPollResult(OpenILinkSchema):
+    status: BindStatus = Field(..., description="绑定状态")
+    credentials: OpenILinkCredentials | None = Field(default=None, description="绑定成功后的凭据")
+    provider_account_id: str | None = Field(default=None, description="OpenILink 侧账号 ID")
+    error_message: str | None = Field(default=None, description="失败原因")
+
+
+class SyncState(OpenILinkSchema):
+    cursor: str | None = Field(default=None, description="增量同步游标")
+    sequence: int | None = Field(default=None, description="同步序列号")
+    last_sync_at: datetime | None = Field(default=None, description="最近同步时间")
+    watermark: str | None = Field(default=None, description="服务端水位标记")
+
+
+class OpenILinkRecipient(OpenILinkSchema):
+    kind: RecipientKind = Field(..., description="接收者类型")
+    id: str = Field(..., description="接收者 OpenILink ID")
+    display_name: str | None = Field(default=None, description="展示名称")
+
+
+class ContextToken(OpenILinkSchema):
+    conversation_id: str = Field(..., description="会话 ID")
+    message_id: str | None = Field(default=None, description="用于回复或引用的消息 ID")
+    sync_cursor: str | None = Field(default=None, description="消息对应的同步游标")
+
+
+class OpenILinkMedia(OpenILinkSchema):
+    media_id: str = Field(..., description="媒体 ID")
+    kind: MediaKind = Field(..., description="媒体类型")
+    url: str | None = Field(default=None, description="临时下载 URL")
+    file_name: str | None = Field(default=None, description="文件名")
+    mime_type: str | None = Field(default=None, description="MIME 类型")
+    size_bytes: int | None = Field(default=None, description="文件大小")
+    checksum: str | None = Field(default=None, description="内容校验值")
+
+
+class OpenILinkMessage(OpenILinkSchema):
+    message_id: str = Field(..., description="OpenILink 消息 ID")
+    sender_id: str = Field(..., description="发送者 ID")
+    recipient: OpenILinkRecipient = Field(..., description="消息所属会话或接收者")
+    timestamp: datetime = Field(..., description="消息时间")
+    text: str | None = Field(default=None, description="文本内容")
+    media: list[OpenILinkMedia] = Field(default_factory=list, description="媒体内容")
+    context_token: ContextToken = Field(..., description="发送回复所需上下文")
+    raw_type: str | None = Field(default=None, description="OpenILink 原始消息类型")
+    raw: dict[str, Any] = Field(default_factory=dict, description="原始消息字典（用于媒体下载）")
+
+
+class SendMessageResult(OpenILinkSchema):
+    message_id: str = Field(..., description="发送后获得的消息 ID")
+    accepted_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="服务端接受时间")
+
+
+class RenewResult(OpenILinkSchema):
+    credentials: OpenILinkCredentials = Field(..., description="续期后的凭据")
+    sync_state: SyncState = Field(..., description="续期后的同步状态")
+    renew_at: datetime | None = Field(default=None, description="建议下次续期时间")
+
+
+def parse_bind_start_payload(payload: Mapping[str, object]) -> BindStartResult:
+    return BindStartResult(
+        session_id=_require_str(payload, "session_id"),
+        qr_url=_require_str(payload, "qr_url"),
+        expires_at=_require_datetime(payload, "expires_at"),
+    )
+
+
+def parse_bind_poll_payload(payload: Mapping[str, object]) -> BindPollResult:
+    credentials_payload = _optional_mapping(payload, "credentials")
+    credentials = parse_credentials_payload(credentials_payload) if credentials_payload is not None else None
+    provider_account_id = _optional_str(payload, "provider_account_id")
+    return BindPollResult(
+        status=BindStatus(_require_str(payload, "status")),
+        credentials=credentials,
+        provider_account_id=provider_account_id or (credentials.provider_account_id if credentials else None),
+        error_message=_optional_str(payload, "error_message"),
+    )
+
+
+def parse_credentials_payload(payload: Mapping[str, object]) -> OpenILinkCredentials:
+    return OpenILinkCredentials(
+        provider_account_id=_require_str(payload, "provider_account_id"),
+        access_token=_require_str(payload, "access_token"),
+        refresh_token=_optional_str(payload, "refresh_token"),
+        expires_at=_optional_datetime(payload, "expires_at"),
+        device_id=_optional_str(payload, "device_id"),
+        scope=_optional_str_list(payload, "scope"),
+    )
+
+
+def parse_sync_state_payload(payload: Mapping[str, object]) -> SyncState:
+    return SyncState(
+        cursor=_optional_str(payload, "cursor"),
+        sequence=_optional_int(payload, "sequence"),
+        last_sync_at=_optional_datetime(payload, "last_sync_at"),
+        watermark=_optional_str(payload, "watermark"),
+    )
+
+
+def parse_media_payload(payload: Mapping[str, object]) -> OpenILinkMedia:
+    return OpenILinkMedia(
+        media_id=_require_str(payload, "media_id"),
+        kind=MediaKind(_require_str(payload, "kind")),
+        url=_optional_str(payload, "url"),
+        file_name=_optional_str(payload, "file_name"),
+        mime_type=_optional_str(payload, "mime_type"),
+        size_bytes=_optional_int(payload, "size_bytes"),
+        checksum=_optional_str(payload, "checksum"),
+    )
+
+
+def parse_message_payload(payload: Mapping[str, object]) -> OpenILinkMessage:
+    media_payloads = _optional_mapping_list(payload, "media")
+    return OpenILinkMessage(
+        message_id=_require_str(payload, "message_id"),
+        sender_id=_require_str(payload, "sender_id"),
+        recipient=parse_recipient_payload(_require_mapping(payload, "recipient")),
+        timestamp=_require_datetime(payload, "timestamp"),
+        text=_optional_str(payload, "text"),
+        media=[parse_media_payload(item) for item in media_payloads],
+        context_token=parse_context_token_payload(_require_mapping(payload, "context_token")),
+        raw_type=_optional_str(payload, "raw_type"),
+    )
+
+
+def parse_recipient_payload(payload: Mapping[str, object]) -> OpenILinkRecipient:
+    return OpenILinkRecipient(
+        kind=RecipientKind(_require_str(payload, "kind")),
+        id=_require_str(payload, "id"),
+        display_name=_optional_str(payload, "display_name"),
+    )
+
+
+def parse_context_token_payload(payload: Mapping[str, object]) -> ContextToken:
+    return ContextToken(
+        conversation_id=_require_str(payload, "conversation_id"),
+        message_id=_optional_str(payload, "message_id"),
+        sync_cursor=_optional_str(payload, "sync_cursor"),
+    )
+
+
+def parse_renew_payload(payload: Mapping[str, object]) -> RenewResult:
+    return RenewResult(
+        credentials=parse_credentials_payload(_require_mapping(payload, "credentials")),
+        sync_state=parse_sync_state_payload(_require_mapping(payload, "sync_state")),
+        renew_at=_optional_datetime(payload, "renew_at"),
+    )
+
+
+def _require_str(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    if isinstance(value, str) and value:
+        return value
+    raise ValueError(f"OpenILink payload missing non-empty string field: {key}")
+
+
+def _optional_str(payload: Mapping[str, object], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    raise ValueError(f"OpenILink payload field must be a string: {key}")
+
+
+def _optional_int(payload: Mapping[str, object], key: str) -> int | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    raise ValueError(f"OpenILink payload field must be an integer: {key}")
+
+
+def _require_datetime(payload: Mapping[str, object], key: str) -> datetime:
+    value = _optional_datetime(payload, key)
+    if value is None:
+        raise ValueError(f"OpenILink payload missing datetime field: {key}")
+    return value
+
+
+def _optional_datetime(payload: Mapping[str, object], key: str) -> datetime | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, int | float):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    if isinstance(value, str):
+        normalized = value.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalized)
+    raise ValueError(f"OpenILink payload field must be datetime-compatible: {key}")
+
+
+def _require_mapping(payload: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = _optional_mapping(payload, key)
+    if value is None:
+        raise ValueError(f"OpenILink payload missing object field: {key}")
+    return value
+
+
+def _optional_mapping(payload: Mapping[str, object], key: str) -> Mapping[str, object] | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return _normalize_mapping(value)
+    raise ValueError(f"OpenILink payload field must be an object: {key}")
+
+
+def _optional_mapping_list(payload: Mapping[str, object], key: str) -> list[Mapping[str, object]]:
+    value = payload.get(key)
+    if value is None:
+        return []
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        raise ValueError(f"OpenILink payload field must be an object list: {key}")
+    return [_normalize_mapping(item) for item in value]
+
+
+def _optional_str_list(payload: Mapping[str, object], key: str) -> list[str]:
+    value = payload.get(key)
+    if value is None:
+        return []
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        raise ValueError(f"OpenILink payload field must be a string list: {key}")
+
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"OpenILink payload field must contain only strings: {key}")
+        result.append(item)
+    return result
+
+
+def _normalize_mapping(value: Mapping[Any, Any]) -> Mapping[str, object]:
+    normalized: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise ValueError("OpenILink payload object keys must be strings")
+        normalized[key] = item
+    return normalized
+
+
+# ============================================================
+# Management API Schemas
+# ============================================================
+
+
+class InstanceCreateRequest(OpenILinkSchema):
+    """创建实例请求"""
+
+    instance_key: str = Field(..., description="实例唯一标识")
+    display_name: str = Field(default="", description="实例显示名称")
+    provider: str = Field(default="", description="服务提供方")
+
+
+class InstanceCreateResponse(OpenILinkSchema):
+    """创建实例响应"""
+
+    instance_key: str = Field(..., description="实例唯一标识")
+    status: str = Field(default="pending", description="实例状态")
+    renew_before_minutes: int = Field(default=60, description="提前续期分钟数")
+    created_at: datetime = Field(..., description="创建时间")
+    existing: bool = Field(default=False, description="是否为已存在实例")
+
+
+class InstanceDetailResponse(OpenILinkSchema):
+    """实例详情响应（不含凭据信息）"""
+
+    instance_key: str = Field(..., description="实例唯一标识")
+    display_name: str = Field(..., description="实例显示名称")
+    status: str = Field(..., description="实例状态")
+    enabled: bool = Field(..., description="是否启用")
+    is_default: bool = Field(..., description="是否默认实例")
+    provider: str = Field(..., description="服务提供方")
+    provider_account_id: str = Field(..., description="服务提供方账号标识")
+    metadata_json: str = Field(default="", description="实例元数据(JSON)")
+    last_error: str | None = Field(default=None, description="最近错误信息")
+    last_active_at: datetime | None = Field(default=None, description="最近活跃时间")
+    next_renew_at: datetime | None = Field(default=None, description="下次续期时间")
+    renew_before_minutes: int = Field(..., description="提前续期分钟数")
+    create_time: datetime = Field(..., description="创建时间")
+    update_time: datetime = Field(..., description="更新时间")
+
+
+class InstanceListResponse(OpenILinkSchema):
+    """实例列表响应"""
+
+    instances: list[InstanceDetailResponse] = Field(..., description="实例列表")
+
+
+class BindStartResponse(OpenILinkSchema):
+    """开始绑定响应"""
+
+    bind_session_id: str = Field(..., description="绑定会话 ID")
+    qr_url: str = Field(..., description="绑定二维码或授权 URL")
+    status: str = Field(default="ok", description="操作状态")
+    bind_status: str = Field(..., description="绑定子状态")
+    expires_at: datetime = Field(..., description="绑定会话过期时间")
+
+
+class BindStatusResponse(OpenILinkSchema):
+    """绑定状态响应"""
+
+    status: str = Field(..., description="操作状态")
+    instance_status: str = Field(default="", description="实例主生命周期状态")
+    bind_status: str = Field(..., description="绑定子状态")
+    message: str | None = Field(default=None, description="提示信息")
+
+
+class EventResponse(OpenILinkSchema):
+    """事件记录响应"""
+
+    event_type: str = Field(..., description="事件类型")
+    status_from: str | None = Field(default=None, description="状态变更前")
+    status_to: str | None = Field(default=None, description="状态变更后")
+    message: str | None = Field(default=None, description="事件消息")
+    create_time: datetime = Field(..., description="事件发生时间")
+
+
+class RenewPolicyRequest(OpenILinkSchema):
+    """更新续期策略请求"""
+
+    renew_before_minutes: int = Field(..., ge=1, description="提前续期分钟数（分钟）")

--- a/nekro_agent/adapters/wechat_ilink_multi/sdk_client.py
+++ b/nekro_agent/adapters/wechat_ilink_multi/sdk_client.py
@@ -1,0 +1,323 @@
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+from nekro_agent.core.os_env import OsEnv
+
+from .client import MediaDownloadResult, OpenILinkMonitorCallbacks, OpenILinkMultiClient
+from .config import WeChatILinkMultiConfig
+from .schemas import (
+    BindPollResult,
+    BindStartResult,
+    BindStatus,
+    ContextToken,
+    MediaKind,
+    OpenILinkCredentials,
+    OpenILinkMedia,
+    OpenILinkMessage,
+    OpenILinkRecipient,
+    RecipientKind,
+    RenewResult,
+    SendMessageResult,
+    SyncState,
+)
+
+
+class WeChatBotSDKOpenILinkMultiClient(OpenILinkMultiClient):
+    """基于 wechatbot-sdk 的 OpenILink 多实例传输实现。"""
+
+    def __init__(self, config: WeChatILinkMultiConfig):
+        super().__init__(config)
+        self._bot: Any | None = None
+        self._login_task: asyncio.Task[Any] | None = None
+        self._monitor_task: asyncio.Task[None] | None = None
+        self._bind_status = BindStatus.PENDING
+        self._bind_session_id = ""
+        self._bind_qr_url = ""
+        self._bind_error = ""
+        self._bind_credentials: OpenILinkCredentials | None = None
+        self._bind_cred_path: Path | None = None
+        self._media_messages: dict[str, Any] = {}
+
+    async def start_bind(self) -> BindStartResult:
+        self._bind_session_id = f"wechatbot-{int(datetime.now(timezone.utc).timestamp() * 1000)}"
+        self._bind_status = BindStatus.PENDING
+        self._bind_error = ""
+        self._bind_credentials = None
+        self._bind_qr_url = ""
+        self._bind_cred_path = self._credential_path(self._bind_session_id)
+        self._bot = self._create_bot(self._bind_cred_path)
+        self._login_task = asyncio.create_task(self._login_for_bind(), name=f"wechat-ilink-bind-{self._bind_session_id}")
+
+        deadline = asyncio.get_running_loop().time() + 20.0
+        while not self._bind_qr_url and not self._bind_error:
+            if asyncio.get_running_loop().time() >= deadline:
+                raise TimeoutError("等待 OpenILink 二维码生成超时")
+            await asyncio.sleep(0.2)
+
+        if self._bind_error:
+            raise RuntimeError(self._bind_error)
+        return BindStartResult(
+            session_id=self._bind_session_id,
+            qr_url=self._bind_qr_url,
+            expires_at=datetime.now(timezone.utc) + timedelta(seconds=self.config.BIND_TIMEOUT_SECONDS),
+        )
+
+    async def poll_bind(self, session_id: str) -> BindPollResult:
+        if session_id != self._bind_session_id:
+            return BindPollResult(status=BindStatus.FAILED, error_message="绑定会话不存在或已失效")
+
+        if self._login_task is not None and self._login_task.done() and self._bind_credentials is None and not self._bind_error:
+            try:
+                await self._login_task
+            except Exception as exc:  # 登录任务错误需要转为绑定失败状态返回给 API 调用方
+                self._bind_error = str(exc)
+                self._bind_status = BindStatus.FAILED
+
+        return BindPollResult(
+            status=self._bind_status,
+            credentials=self._bind_credentials,
+            provider_account_id=self._bind_credentials.provider_account_id if self._bind_credentials else None,
+            error_message=self._bind_error or None,
+        )
+
+    async def start_monitor(
+        self,
+        credentials: OpenILinkCredentials,
+        sync_state: SyncState,
+        callbacks: OpenILinkMonitorCallbacks,
+    ) -> None:
+        from nekro_agent.core.logger import get_sub_logger
+
+        sdk_logger = get_sub_logger("adapter.wechat_ilink_multi.sdk")
+        cred_path = self._credential_path(credentials.provider_account_id)
+        self._write_credentials_file(credentials, cred_path)
+        self._bot = self._create_bot(cred_path)
+        self._hook_wechatbot_logger(type(self._bot))
+        await self._bot.login(force=False)
+        sdk_logger.info(f"[wechatbot-sdk] OpenILink monitor login success: {credentials.provider_account_id}")
+
+        @self._bot.on_message
+        async def _handler(message: Any) -> None:
+            converted = self._convert_message(message)
+            await callbacks.on_message(converted)
+            if callbacks.on_sync_state is not None:
+                await callbacks.on_sync_state(
+                    SyncState(cursor=converted.context_token.sync_cursor, last_sync_at=datetime.now(timezone.utc))
+                )
+
+        self._monitor_task = asyncio.create_task(self._bot.start(), name=f"wechat-ilink-sdk-monitor-{credentials.provider_account_id}")
+        sdk_logger.info("[wechatbot-sdk] OpenILink monitor task created")
+        # Wait briefly to confirm the task didn't immediately fail
+        await asyncio.sleep(0.5)
+        if self._monitor_task.done():
+            exc = self._monitor_task.exception()
+            if exc is not None:
+                raise exc
+        sdk_logger.info("[wechatbot-sdk] OpenILink monitor task running")
+
+    async def stop_monitor(self) -> None:
+        if self._bot is not None:
+            stop = getattr(self._bot, "stop", None)
+            if callable(stop):
+                stop()
+        if self._monitor_task is not None and not self._monitor_task.done():
+            self._monitor_task.cancel()
+            try:
+                await self._monitor_task
+            except asyncio.CancelledError:
+                pass
+        self._monitor_task = None
+
+    def _hook_wechatbot_logger(self, bot_cls: Any) -> None:
+        from nekro_agent.core.logger import get_sub_logger
+
+        sdk_logger = get_sub_logger("adapter.wechat_ilink_multi.sdk")
+        if getattr(bot_cls, "_nekro_log_hooked", False):
+            return
+        original_log = getattr(bot_cls, "_log", None)
+        if not callable(original_log):
+            return
+
+        def _nekro_log(instance: Any, msg: str) -> None:  # noqa: ARG001
+            sdk_logger.info(f"[wechatbot-sdk] {msg}")
+
+        setattr(bot_cls, "_log", _nekro_log)
+        setattr(bot_cls, "_nekro_log_hooked", True)
+
+    async def send_text(
+        self,
+        recipient: OpenILinkRecipient,
+        text: str,
+        context_token: ContextToken,
+    ) -> SendMessageResult:
+        if self._bot is None:
+            raise RuntimeError("OpenILink client monitor is not started")
+        await self._bot.send(recipient.id, text)
+        return SendMessageResult(message_id=f"local-{int(datetime.now(timezone.utc).timestamp() * 1000)}")
+
+    async def send_file(
+        self,
+        recipient: OpenILinkRecipient,
+        file_path: Path,
+        context_token: ContextToken,
+    ) -> SendMessageResult:
+        if self._bot is None:
+            raise RuntimeError("OpenILink client monitor is not started")
+        data = await asyncio.to_thread(file_path.read_bytes)
+        await self._bot.send_media(recipient.id, {"file": data, "file_name": file_path.name or "file.bin"})
+        return SendMessageResult(message_id=f"local-{int(datetime.now(timezone.utc).timestamp() * 1000)}")
+
+    async def download_media(self, media: OpenILinkMedia) -> MediaDownloadResult:
+        if media.url:
+            timeout = aiohttp.ClientTimeout(total=self.config.MEDIA_DOWNLOAD_TIMEOUT_SECONDS)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(media.url) as resp:
+                    resp.raise_for_status()
+                    return await resp.read()
+        if self._bot is None:
+            raise RuntimeError("OpenILink client monitor is not started")
+        message = self._media_messages.get(media.media_id)
+        if message is None:
+            raise RuntimeError(f"媒体上下文不存在: {media.media_id}")
+        downloaded = await self._bot.download(message)
+        if downloaded is None:
+            raise RuntimeError(f"媒体下载结果为空: {media.media_id}")
+        return bytes(downloaded.data)
+
+    async def renew_session(
+        self,
+        credentials: OpenILinkCredentials,
+        sync_state: SyncState,
+    ) -> RenewResult:
+        return RenewResult(credentials=credentials, sync_state=sync_state, renew_at=None)
+
+    async def _login_for_bind(self) -> None:
+        if self._bot is None:
+            raise RuntimeError("OpenILink bind client is not initialized")
+        try:
+            raw_credentials = await self._bot.login(force=True)
+        except Exception as exc:
+            self._bind_error = str(exc)
+            self._bind_status = BindStatus.FAILED
+            raise
+        # iLink bot_token 无 TTL：SDK 的 Credentials 不含过期字段，token 也无刷新机制；
+        # 失效仅由服务器在 API 返回 errcode==-14 时反应式暴露，并由 WeChatBot.start() 长连接
+        # 自动重新登录。此处不再伪造 24h 过期，置 None 表示“无已知过期”——使续期调度休眠、
+        # 重启不再把仍有效的会话误判为 session_expired。真到期需重新扫码绑定。
+        self._bind_credentials = OpenILinkCredentials(
+            provider_account_id=str(raw_credentials.account_id),
+            access_token=str(raw_credentials.token),
+            refresh_token=None,
+            expires_at=None,
+            device_id=str(raw_credentials.user_id),
+            scope=[],
+        )
+        if self._bind_cred_path is not None:
+            final_path = self._credential_path(self._bind_credentials.provider_account_id)
+            final_path.parent.mkdir(parents=True, exist_ok=True)
+            self._bind_cred_path.replace(final_path)
+        self._bind_status = BindStatus.CONFIRMED
+
+    def _create_bot(self, cred_path: Path) -> Any:
+        try:
+            from wechatbot import WeChatBot
+        except Exception as exc:
+            raise RuntimeError("未安装 wechatbot-sdk，请先执行 uv run poe sync-dev") from exc
+
+        return WeChatBot(
+            base_url=self.config.API_BASE_URL,
+            cred_path=str(cred_path),
+            on_qr_url=self._on_qr_url,
+            on_scanned=self._on_scanned,
+            on_expired=self._on_expired,
+            on_error=self._on_error,
+        )
+
+    def _on_qr_url(self, url: str) -> None:
+        self._bind_qr_url = url
+        self._bind_status = BindStatus.PENDING
+
+    def _on_scanned(self) -> None:
+        self._bind_status = BindStatus.SCANNED
+
+    def _on_expired(self) -> None:
+        self._bind_status = BindStatus.EXPIRED
+
+    def _on_error(self, error: Exception) -> None:
+        self._bind_error = str(error)
+        self._bind_status = BindStatus.FAILED
+
+    def _credential_path(self, key: str) -> Path:
+        safe_key = "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in key)
+        return Path(OsEnv.DATA_DIR) / "configs" / "wechat_ilink_multi" / "credentials" / f"{safe_key}.json"
+
+    def _write_credentials_file(self, credentials: OpenILinkCredentials, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        payload = {
+            "token": credentials.access_token,
+            "baseUrl": self.config.API_BASE_URL,
+            "accountId": credentials.provider_account_id,
+            "userId": credentials.device_id or credentials.provider_account_id,
+            "savedAt": datetime.now(timezone.utc).isoformat(),
+        }
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        path.chmod(0o600)
+
+    def _convert_message(self, message: Any) -> OpenILinkMessage:
+        raw = getattr(message, "raw", None)
+        raw_dict = raw if isinstance(raw, dict) else {}
+        message_id = self._first_non_empty(message, raw_dict, ("message_id", "msg_id", "id"))
+        if not message_id:
+            message_id = f"msg-{int(datetime.now(timezone.utc).timestamp() * 1000)}"
+        sender_id = str(getattr(message, "user_id", "") or raw_dict.get("from_user_id") or raw_dict.get("user_id") or "")
+        timestamp = getattr(message, "timestamp", None)
+        if not isinstance(timestamp, datetime):
+            timestamp = datetime.now(timezone.utc)
+        context_token = str(getattr(message, "_context_token", "") or raw_dict.get("context_token") or "")
+        media = self._extract_media(message_id, message)
+        return OpenILinkMessage(
+            message_id=message_id,
+            sender_id=sender_id,
+            recipient=OpenILinkRecipient(kind=RecipientKind.USER, id=sender_id),
+            timestamp=timestamp,
+            text=str(getattr(message, "text", "") or "") or None,
+            media=media,
+            context_token=ContextToken(conversation_id=sender_id, message_id=message_id, sync_cursor=context_token),
+            raw_type=str(getattr(message, "type", "") or "") or None,
+            raw=raw_dict,
+        )
+
+    def _extract_media(self, message_id: str, message: Any) -> list[OpenILinkMedia]:
+        media_items: list[OpenILinkMedia] = []
+        for attr, kind, default_name in (
+            ("images", MediaKind.IMAGE, "image.jpg"),
+            ("files", MediaKind.FILE, "file.bin"),
+            ("voices", MediaKind.VOICE, "voice.silk"),
+        ):
+            values = getattr(message, attr, None) or []
+            if not values:
+                continue
+            item = values[0]
+            media_id = f"{message_id}:{kind.value}"
+            self._media_messages[media_id] = message
+            file_name = str(getattr(item, "file_name", "") or default_name)
+            size = getattr(item, "size", None)
+            # 不暴露 url：iLink CDN 媒体（图片/文件/语音）是 AES 加密内容，CDNMedia.full_url 指向的是密文，
+            # 裸 HTTP 下载得到的是加密字节（图片会被识别为 application/octet-stream 而被 LLM 拒收）。
+            # 置 url=None 可强制走 download_media -> WeChatBot.download() 的下载+AES 解密路径（按 media_id
+            # 从 self._media_messages 取回原始 IncomingMessage 后由 SDK 解密），得到有效文件字节。
+            media_items.append(OpenILinkMedia(media_id=media_id, kind=kind, url=None, file_name=file_name, size_bytes=size))
+            break
+        return media_items
+
+    def _first_non_empty(self, message: Any, raw: dict[str, Any], keys: tuple[str, ...]) -> str:
+        for key in keys:
+            value = str(getattr(message, key, "") or raw.get(key) or "").strip()
+            if value:
+                return value
+        return ""

--- a/nekro_agent/models/db_chat_channel.py
+++ b/nekro_agent/models/db_chat_channel.py
@@ -82,6 +82,7 @@ class DBChatChannel(Model):
         channel_id: str,
         channel_type: ChatType,
         channel_name: str = "",
+        chat_key: str | None = None,
     ) -> "DBChatChannel":
         """获取或创建聊天频道"""
         channel = await cls.get_or_none(adapter_key=adapter_key, channel_id=channel_id)
@@ -92,7 +93,7 @@ class DBChatChannel(Model):
                 channel_id=channel_id,
                 channel_type=channel_type.value,
                 channel_name=channel_name,
-                chat_key=f"{adapter_key}-{channel_id}",
+                chat_key=chat_key if chat_key is not None else f"{adapter_key}-{channel_id}",
                 is_active=default_status != ChannelStatus.DISABLED,
                 observe_mode=default_status == ChannelStatus.OBSERVE,
                 data=json.dumps({}),

--- a/nekro_agent/routers/chat_channel.py
+++ b/nekro_agent/routers/chat_channel.py
@@ -27,6 +27,7 @@ from nekro_agent.services.config_resolver import config_resolver
 from nekro_agent.services.message_service import message_service
 from nekro_agent.services.user.deps import get_current_active_user
 from nekro_agent.services.user.perm import Role, require_role
+from nekro_agent.tools.path_convertor import sanitize_chat_key_for_path
 
 router = APIRouter(prefix="/chat-channel", tags=["ChatChannel"])
 
@@ -775,7 +776,7 @@ async def _send_message_via_webui(
 
         is_file_mode = False
         if file and file.filename:
-            safe_chat_key = Path(chat_key).name
+            safe_chat_key = sanitize_chat_key_for_path(Path(chat_key).name)
             safe_filename = Path(file.filename).name
             upload_dir = Path(USER_UPLOAD_DIR) / safe_chat_key
             upload_dir.mkdir(parents=True, exist_ok=True)
@@ -1003,8 +1004,8 @@ async def get_channel_delete_preview(
         DBMemEpisode.filter(origin_chat_key=chat_key).count(),
     )
 
-    upload_dir = Path(USER_UPLOAD_DIR) / chat_key
-    sandbox_dir = Path(SANDBOX_SHARED_HOST_DIR) / f"sandbox_{chat_key}"
+    upload_dir = Path(USER_UPLOAD_DIR) / sanitize_chat_key_for_path(chat_key)
+    sandbox_dir = Path(SANDBOX_SHARED_HOST_DIR) / f"sandbox_{sanitize_chat_key_for_path(chat_key)}"
 
     return ChannelDeletePreview(
         message_count=msg_count,
@@ -1046,14 +1047,14 @@ async def delete_chat_channel(
     await DBChatChannel.filter(chat_key=chat_key).delete()
 
     # 6. 清理文件系统（容错处理）
-    upload_dir = Path(USER_UPLOAD_DIR) / chat_key
+    upload_dir = Path(USER_UPLOAD_DIR) / sanitize_chat_key_for_path(chat_key)
     if upload_dir.exists():
         try:
             shutil.rmtree(upload_dir)
         except Exception as e:
             logger.warning(f"清理频道上传目录失败 {upload_dir}: {e}")
 
-    sandbox_dir = Path(SANDBOX_SHARED_HOST_DIR) / f"sandbox_{chat_key}"
+    sandbox_dir = Path(SANDBOX_SHARED_HOST_DIR) / f"sandbox_{sanitize_chat_key_for_path(chat_key)}"
     if sandbox_dir.exists():
         try:
             shutil.rmtree(sandbox_dir)

--- a/nekro_agent/services/config_resolver.py
+++ b/nekro_agent/services/config_resolver.py
@@ -19,7 +19,10 @@ class ConfigResolver:
             CoreConfig: 一个包含已解析配置的新 CoreConfig 实例
         """
         # 1. 获取所有配置层
-        adapter_key = chat_key.split("-")[0]
+        # 通过别名感知的解析获取 adapter_key（部分适配器的 chat_key 短前缀 != adapter_key）
+        from nekro_agent.adapters import resolve_adapter_key_from_chat_key
+
+        adapter_key = resolve_adapter_key_from_chat_key(chat_key)
 
         # 系统配置是基础
         effective_config_data = system_config.model_dump()

--- a/nekro_agent/services/config_service.py
+++ b/nekro_agent/services/config_service.py
@@ -264,7 +264,9 @@ class UnifiedConfigService:
 
             elif config_key.startswith("channel_config_"):
                 chat_key = config_key.replace("channel_config_", "")
-                adapter_key = chat_key.split("-")[0]
+                from nekro_agent.adapters import resolve_adapter_key_from_chat_key
+
+                adapter_key = resolve_adapter_key_from_chat_key(chat_key)
                 path = CHANNEL_CONFIG_DIR / adapter_key / f"{chat_key}.yaml"
                 instance = OverridableConfig.load_from_path(path)
 

--- a/nekro_agent/services/sandbox/runner.py
+++ b/nekro_agent/services/sandbox/runner.py
@@ -225,7 +225,7 @@ async def run_code_in_sandbox(
                         f"{HOST_PIP_CACHE_DIR}:{CONTAINER_PIP_CACHE_DIR}:rw",
                         f"{HOST_PACKAGE_DIR}:{CONTAINER_PACKAGE_DIR}:rw",
                         f"{host_shared_dir}:{CONTAINER_SHARE_DIR}:rw",
-                        f"{USER_UPLOAD_DIR}/{from_chat_key}:{CONTAINER_UPLOAD_DIR}:ro",
+                        f"{USER_UPLOAD_DIR}/{_sanitize_docker_name_part(from_chat_key)}:{CONTAINER_UPLOAD_DIR}:ro",
                     ],
                     "Memory": 512 * 1024 * 1024,  # 内存限制 (512MB)
                     "NanoCPUs": 1000000000,  # CPU 限制 (1 core)

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -16,7 +16,7 @@ from PIL import Image
 from nekro_agent.core import logger
 from nekro_agent.core.config import CoreConfig
 from nekro_agent.core.os_env import USER_UPLOAD_DIR
-from nekro_agent.tools.path_convertor import is_url_path
+from nekro_agent.tools.path_convertor import is_url_path, sanitize_chat_key_for_path
 
 _APP_VERSION: str = ""
 
@@ -108,7 +108,7 @@ async def download_file(
             if not file_path:
                 file_name = file_name or f"{hashlib.md5(response.content).hexdigest()}{use_suffix}"
                 if from_chat_key:
-                    save_path = Path(USER_UPLOAD_DIR) / from_chat_key / Path(file_name)
+                    save_path = Path(USER_UPLOAD_DIR) / sanitize_chat_key_for_path(from_chat_key) / Path(file_name)
                 else:
                     save_path = Path(USER_UPLOAD_DIR) / Path(file_name)
                 save_path.parent.mkdir(parents=True, exist_ok=True)
@@ -150,7 +150,7 @@ async def download_file_from_bytes(
     if not file_path:
         file_name = file_name or f"{hashlib.md5(bytes_data).hexdigest()}{use_suffix}"
         if from_chat_key:
-            save_path = Path(USER_UPLOAD_DIR) / from_chat_key / Path(file_name)
+            save_path = Path(USER_UPLOAD_DIR) / sanitize_chat_key_for_path(from_chat_key) / Path(file_name)
         else:
             save_path = Path(USER_UPLOAD_DIR) / Path(file_name)
         save_path.parent.mkdir(parents=True, exist_ok=True)
@@ -186,7 +186,7 @@ async def download_file_from_base64(
     if not file_path:
         file_name = file_name or f"{hashlib.md5(base64_str.encode()).hexdigest()}{use_suffix}"
         if from_chat_key:
-            save_path = Path(USER_UPLOAD_DIR) / from_chat_key / Path(file_name)
+            save_path = Path(USER_UPLOAD_DIR) / sanitize_chat_key_for_path(from_chat_key) / Path(file_name)
         else:
             save_path = Path(USER_UPLOAD_DIR) / Path(file_name)
         save_path.parent.mkdir(parents=True, exist_ok=True)
@@ -214,7 +214,7 @@ async def copy_to_upload_dir(
     if not file_name:
         file_name = f"{hashlib.md5(Path(file_path).read_bytes()).hexdigest()}{use_suffix}"
     if from_chat_key:
-        save_path = Path(USER_UPLOAD_DIR) / from_chat_key / Path(file_name)
+        save_path = Path(USER_UPLOAD_DIR) / sanitize_chat_key_for_path(from_chat_key) / Path(file_name)
     else:
         save_path = Path(USER_UPLOAD_DIR) / Path(file_name)
     save_path.parent.mkdir(parents=True, exist_ok=True)

--- a/nekro_agent/tools/file_utils.py
+++ b/nekro_agent/tools/file_utils.py
@@ -15,6 +15,7 @@ from .path_convertor import (
     convert_filepath_to_sandbox_upload_path,
     convert_to_host_path,
     get_upload_file_path,
+    sanitize_chat_key_for_path,
 )
 
 
@@ -114,7 +115,7 @@ class FileSystem:
     @property
     def upload_path(self) -> Path:
         """获取当前频道的文件上传目录"""
-        return Path(USER_UPLOAD_DIR) / self.chat_key
+        return Path(USER_UPLOAD_DIR) / sanitize_chat_key_for_path(self.chat_key)
 
     def get_file(self, file_path: Path | str) -> Path:
         """从 AI 提供的沙盒内互通路径获取可访问的文件对象

--- a/nekro_agent/tools/path_convertor.py
+++ b/nekro_agent/tools/path_convertor.py
@@ -1,4 +1,5 @@
 import hashlib
+import re
 import uuid
 from enum import Enum
 from pathlib import Path
@@ -6,6 +7,21 @@ from typing import Optional
 
 from nekro_agent.core.logger import logger
 from nekro_agent.core.os_env import SANDBOX_SHARED_HOST_DIR, USER_UPLOAD_DIR
+
+
+def sanitize_chat_key_for_path(chat_key: str) -> str:
+    """将 chat_key 规整为文件系统 / Docker 卷路径安全的目录名。
+
+    多数适配器的 chat_key 仅含 ``[a-zA-Z0-9_.-]``，此函数对其为恒等变换；
+    但部分适配器（如 wechat_ilink_multi）的 chat_key 含 ``:`` 等字符，直接作为
+    Docker 卷 ``源:目标:模式`` 的路径片段会破坏挂载语义，且与已做清洗的挂载源不一致，
+    导致写入目录与沙盒挂载目录错位、入站文件在沙盒内不可见。
+
+    注意：此处的正则必须与 ``services/sandbox/runner.py:_sanitize_docker_name_part``
+    保持一致，否则上传写入路径与沙盒挂载源会再次错位。
+    """
+    sanitized = re.sub(r"[^a-zA-Z0-9_.-]", "_", chat_key)
+    return sanitized or "unknown"
 
 
 class PathLocation(Enum):
@@ -113,7 +129,7 @@ def convert_to_host_path(
 
     # 根据位置类型构建宿主机路径
     if location == PathLocation.UPLOADS:
-        return uploads_dir / chat_key / relative_path
+        return uploads_dir / sanitize_chat_key_for_path(chat_key) / relative_path
     if location == PathLocation.SHARED:
         _validate_shared_path(container_key)
         return shared_dir / str(container_key) / relative_path
@@ -193,7 +209,7 @@ def convert_filename_to_access_path(filename: str | Path, chat_key: str) -> Path
     Returns:
         Path: 访问路径
     """
-    return Path(USER_UPLOAD_DIR) / chat_key / Path(filename).name
+    return Path(USER_UPLOAD_DIR) / sanitize_chat_key_for_path(chat_key) / Path(filename).name
 
 
 def get_upload_file_path(from_chat_key: str, file_name: str = "", use_suffix: str = "", seed: str = "") -> str:
@@ -208,6 +224,6 @@ def get_upload_file_path(from_chat_key: str, file_name: str = "", use_suffix: st
         if not seed:
             seed = str(uuid.uuid4())
         file_name = f"{hashlib.md5(seed.encode()).hexdigest()}{use_suffix}"
-    save_path = Path(USER_UPLOAD_DIR) / from_chat_key / Path(file_name)
+    save_path = Path(USER_UPLOAD_DIR) / sanitize_chat_key_for_path(from_chat_key) / Path(file_name)
     save_path.parent.mkdir(parents=True, exist_ok=True)
     return str(save_path)

--- a/plugins/builtin/basic.py
+++ b/plugins/builtin/basic.py
@@ -83,7 +83,7 @@ plugin = NekroPlugin(
         en_US="Provides basic chat messaging, image/file sending and other fundamental features",
     ),
     # 开放给各适配器使用（文本/文件发送可用，头像工具仅在 OneBot 下提供）
-    support_adapter=["onebot_v11", "minecraft", "sse", "discord", "wechatpad", "telegram", "feishu", "wxwork", "wxwork_corp_app", "wechat_openilink"],
+    support_adapter=["onebot_v11", "minecraft", "sse", "discord", "wechatpad", "telegram", "feishu", "wxwork", "wxwork_corp_app", "wechat_openilink", "wechat_ilink_multi"],
     allow_sleep=False,
     sleep_brief="提供发送文本、文件和基础互动能力，是多数对话都会依赖的基础插件。",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,8 @@ extend-exclude = [
     "plugins",
     "scripts",
     "nekro_agent_doc",
+    "sandbox/agentscope_ref",
+    ".sisyphus",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
> **本 PR 已拆分。** 原单 PR 体积过大（超出部分 CI 审查 bot 的 15 万字符上限），现拆为两个：
> - **#308 通用适配器多实例底座**（前置依赖，需先合并）
> - **本 PR：微信 iLink 多实例适配器**（堆叠在 #308 之上）
>
> ⚠️ 在 #308 合并进 `main` 之前，本 PR 的 diff 仍会包含底座那个 commit（`343e635`）。待 #308 合并后，我会将本 PR rebase 到最新 `main`，届时底座 commit 自动移出，本 PR 仅剩适配器自身改动。已转为 Draft，待 #308 合并后再转正。

## 简介

新增**微信 iLink 多实例适配器**（`wechat_ilink_multi`），基于 OpenILink / `wechatbot-sdk`，支持将多个微信 Bot 作为独立实例统一管理：扫码绑定、消息收发（文本/图片/文件/语音）、会话自动续期与状态观测，多实例并行运行。与既有单实例 `wechat_openilink` 适配器并存、互不影响。

复用 #308 提供的通用适配器实例底座。

## 主要内容（本 PR 自身 commit `1b0fbf2`）

- **新增适配器** `wechat_ilink_multi`：`adapter` / `bot_manager` / `bot_connection` / `client` / `sdk_client` / `message_processor` / `schemas` / `routers` / `config` / `README`。
- **chat_key 短前缀**：使用 `wxim-` 前缀规避 `DBChatChannel.chat_key` 64 字符上限（iLink 用户 id 形如 `xxx@im.wechat` 较长）；配置解析层（`config_resolver` / `config_service`）经 `resolve_adapter_key_from_chat_key()` 别名映射还原 `adapter_key`。**该函数对非 `wxim` 前缀的 chat_key 与旧 `split("-")[0]` 逐字节等价，对其它适配器为无操作。**
- **入站媒体下载并 AES 解密**：iLink CDN 媒体为加密内容，`CDNMedia.full_url` 指向密文，必须经 `WeChatBot.download()` 下载并解密。修复了"裸下载 full_url 导致图片 MIME 为 `application/octet-stream` 而被多模态 LLM 以 400 拒收"的问题（同时修复文件/语音接收）。
- **basic 内置插件** `support_adapter` 收录本适配器，启用 `send_msg_text` / `send_msg_file`。
- **collector 与 `DBChatChannel.get_or_create`** 增加透传 `adapter.build_chat_key()` 结果的能力（默认仍回退 `{adapter_key}-{channel_id}`，对其它适配器零影响）。
- **路径清洗** `sanitize_chat_key_for_path` 兼容含 `:` `@` 的 chat_key（与 `runner.py:_sanitize_docker_name_part` 正则一致，写入与挂载源对齐；对普通 chat_key 为恒等变换，零回归）。
- 依赖新增 `wechatbot-sdk`。

## 兼容性

- 现有 `wechat_openilink` 与其它适配器**未做行为变更**；新增能力均为可选参数/默认回退，向后兼容。
- iLink bot 仅 1:1 私聊，入站消息恒 `is_tome=True`；凭据不在任何 API 响应中暴露。

## 测试情况

生产环境实测通过：扫码绑定 → 实例上线 → 收消息 → AI **文字**与**图片**回复全链路（图片经 SDK 解密后由 LLM 正常识别）。文件/语音接收走同一解密路径。

## 已知限制（后续可单独完善）

- 绑定流程为两阶段（`bind/start` 出码 + 轮询 `bind/status` 驱动 `_complete_bind`），目前无前端绑定页/后端自驱动；微信侧二维码 TTL 较短、SDK 旋转的新码未通过 API 回传。

## Summary by Sourcery

添加一个新的多实例 WeChat OpenILink 适配器，并将其接入适配器注册表、配置解析、文件系统路径以及基础工具链。

New Features:
- 引入 `wechat_ilink_multi` 适配器，基于 OpenILink / 类 OpenILink 客户端，支持多账号生命周期管理、绑定、续期以及消息收发。
- 暴露管理 WeChat iLink 实例的管理型 HTTP API，包括实例创建、通过二维码绑定、启动/停止、续期、策略更新以及事件检查。

Bug Fixes:
- 确保基于 `chat_key` 派生的文件系统路径在上传与沙箱挂载时统一进行清理与规范化，避免 `:`、`@` 等字符导致的问题。
- 修复加密 iLink CDN 媒体内容的处理逻辑，将图片/文件/语音的下载流程改为经由 SDK 解密路径而非直接使用原始 URL。

Enhancements:
- 允许适配器通过 `build_chat_key` 提供自定义 `chat_key`，并将其传递到 `DBChatChannel.get_or_create` 和采集器中，从而支持作用域化的多实例键。
- 增加 `chat_key` 前缀别名映射及解析器，在配置解析时，能够从缩写的 `chat_key` 前缀正确推导出适配器键。
- 更新基础内置插件，使其支持在 `wechat_ilink_multi` 适配器上发送文本和文件。
- 对齐沙箱上传卷挂载路径与已清理规范化的 `chat_key` 名称，保证宿主机与容器路径保持一致。

Build:
- 添加 `wechatbot-sdk` 依赖，并针对新的沙箱与工作流目录调整工具链排除配置（`ruff`、`.dockerignore`）。

Documentation:
- 在专门的 README 中记录新的 WeChat OpenILink 多实例适配器的配置方法、管理 API、生命周期、消息支持矩阵以及开发说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new multi-instance WeChat OpenILink adapter and wire it into adapter registry, config resolution, filesystem paths, and basic tooling.

New Features:
- Introduce the wechat_ilink_multi adapter with multi-account lifecycle management, binding, renewal, and messaging support based on OpenILink/OpenILink-like clients.
- Expose admin HTTP APIs to manage WeChat iLink instances, including creation, binding via QR code, start/stop, renewal, policy updates, and event inspection.

Bug Fixes:
- Ensure chat_key-derived filesystem paths are sanitized consistently for uploads and sandbox mounts, preventing issues with characters like ':' and '@'.
- Fix media handling for encrypted iLink CDN content by routing image/file/voice downloads through the SDK decryption path instead of raw URLs.

Enhancements:
- Allow adapters to provide custom chat_key values via build_chat_key and propagate them into DBChatChannel.get_or_create and collector, enabling scoped multi-instance keys.
- Add a chat_key prefix alias map and resolver to correctly derive adapter keys from shortened chat_key prefixes in config resolution.
- Update the basic builtin plugin to support the new wechat_ilink_multi adapter for text and file sending.
- Align sandbox upload volume mounts with sanitized chat_key names to keep host and container paths in sync.

Build:
- Add wechatbot-sdk as a dependency and adjust tooling exclusions (ruff, dockerignore) for new sandbox and workflow directories.

Documentation:
- Document configuration, management APIs, lifecycle, message support matrix, and development notes for the new WeChat OpenILink multi-instance adapter in a dedicated README.

</details>