### PR TITLE
添加部署更新控制面板

### DIFF
--- a/frontend/src/config/navigation.tsx
+++ b/frontend/src/config/navigation.tsx
@@ -197,12 +197,6 @@ export const getPageConfigs = (): (PageConfig | MenuGroup)[] => [
     icon: <CodeIcon />,
   },
   {
-    path: '/settings/deployment',
-    text: t('menu.deployment'),
-    translationKey: 'menu.deployment',
-    icon: <SystemUpdateAltIcon />,
-  },
-  {
     path: '/adapters',
     text: t('menu.adapters'),
     translationKey: 'menu.adapters',
@@ -219,6 +213,13 @@ export const getPageConfigs = (): (PageConfig | MenuGroup)[] => [
         text: t('menu.systemSettings'),
         translationKey: 'menu.systemSettings',
         icon: <TuneIcon />,
+        parent: 'settings',
+      },
+      {
+        path: '/settings/deployment',
+        text: t('menu.deployment'),
+        translationKey: 'menu.deployment',
+        icon: <SystemUpdateAltIcon />,
         parent: 'settings',
       },
       {

--- a/frontend/src/config/navigation.tsx
+++ b/frontend/src/config/navigation.tsx
@@ -264,7 +264,7 @@ export const getPageConfigs = (): (PageConfig | MenuGroup)[] => [
 export const PAGE_CONFIGS = getPageConfigs()
 
 // 转换配置为菜单项的工具函数
-export const createMenuItems = (_locale?: string) => {
+export const createMenuItems = () => {
   return getPageConfigs()
     .map(config => {
       if ('children' in config) {

--- a/frontend/src/config/navigation.tsx
+++ b/frontend/src/config/navigation.tsx
@@ -18,6 +18,7 @@ import {
   Workspaces as WorkspacesIcon,
   ListAlt as ListAltIcon,
   Schedule as ScheduleIcon,
+  SystemUpdateAlt as SystemUpdateAltIcon,
 } from '@mui/icons-material'
 import i18next from './i18n'
 
@@ -196,6 +197,12 @@ export const getPageConfigs = (): (PageConfig | MenuGroup)[] => [
     icon: <CodeIcon />,
   },
   {
+    path: '/settings/deployment',
+    text: t('menu.deployment'),
+    translationKey: 'menu.deployment',
+    icon: <SystemUpdateAltIcon />,
+  },
+  {
     path: '/adapters',
     text: t('menu.adapters'),
     translationKey: 'menu.adapters',
@@ -256,27 +263,29 @@ export const getPageConfigs = (): (PageConfig | MenuGroup)[] => [
 export const PAGE_CONFIGS = getPageConfigs()
 
 // 转换配置为菜单项的工具函数
-export const createMenuItems = () => {
-  return getPageConfigs().map(config => {
-    if ('children' in config) {
+export const createMenuItems = (_locale?: string) => {
+  return getPageConfigs()
+    .map(config => {
+      if ('children' in config) {
+        return {
+          text: config.text,
+          icon: config.icon,
+          path: undefined,
+          key: config.key,
+          children: config.children.map(child => ({
+            text: child.text,
+            icon: child.icon,
+            path: child.path,
+          })),
+        }
+      }
       return {
         text: config.text,
         icon: config.icon,
-        path: undefined,
-        key: config.key,
-        children: config.children.map(child => ({
-          text: child.text,
-          icon: child.icon,
-          path: child.path,
-        })),
+        path: config.path,
       }
-    }
-    return {
-      text: config.text,
-      icon: config.icon,
-      path: config.path,
-    }
-  })
+    })
+    .filter(item => !item.children || item.children.length > 0)
 }
 
 // 获取当前页面信息的工具函数

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -128,7 +128,7 @@ function MainLayoutContent() {
   // 侧边栏宽度：英文模式需要更宽以容纳较长的文本
   const drawerWidth = currentLocale === 'en-US' ? 260 : 240
 
-  const menuItems = useMemo(() => createMenuItems(currentLocale), [currentLocale])
+  const menuItems = useMemo(() => createMenuItems(), [])
 
   // 使用壁纸store
   const { mainWallpaper, mainWallpaperMode, mainWallpaperBlur, mainWallpaperDim } =

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -55,6 +55,7 @@ import { useLocaleStore } from '../stores/locale'
 import ActionButton from '../components/common/ActionButton'
 import IconActionButton from '../components/common/IconActionButton'
 import { oobeApi } from '../services/api/oobe'
+import { authApi } from '../services/api/auth'
 
 const DEV_MODE_SEQUENCE = ['nekro', 'nekro', 'nekro', 'agent', 'nekro', 'nekro', 'agent', 'agent']
 let initialLocaleSyncPromise: Promise<void> | null = null
@@ -63,7 +64,7 @@ let initialVersionPromise: Promise<string> | null = null
 function MainLayoutContent() {
   const navigate = useNavigate()
   const location = useLocation()
-  const { userInfo, logout } = useAuthStore()
+  const { token, userInfo, logout, setUserInfo } = useAuthStore()
   const theme = useTheme()
   const [starCount, setStarCount] = useState<number | null>(null)
   const [version, setVersion] = useState('0.0.0')
@@ -102,12 +103,32 @@ function MainLayoutContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  useEffect(() => {
+    if (!token || userInfo) {
+      return
+    }
+
+    let cancelled = false
+    authApi
+      .getUserInfo()
+      .then(nextUserInfo => {
+        if (!cancelled) {
+          setUserInfo(nextUserInfo)
+        }
+      })
+      .catch(() => {
+        // axios 拦截器会处理失效登录；这里不阻塞主布局渲染。
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [token, userInfo, setUserInfo])
+
   // 侧边栏宽度：英文模式需要更宽以容纳较长的文本
   const drawerWidth = currentLocale === 'en-US' ? 260 : 240
 
-  // 动态生成菜单项（响应语言变化）
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const menuItems = useMemo(() => createMenuItems(), [currentLocale])
+  const menuItems = useMemo(() => createMenuItems(currentLocale), [currentLocale])
 
   // 使用壁纸store
   const { mainWallpaper, mainWallpaperMode, mainWallpaperBlur, mainWallpaperDim } =

--- a/frontend/src/locales/en-US/deployment.json
+++ b/frontend/src/locales/en-US/deployment.json
@@ -1,0 +1,162 @@
+{
+  "common": {
+    "available": "Available",
+    "unavailable": "Unavailable",
+    "unknown": "Unknown",
+    "ready": "Ready"
+  },
+  "status": {
+    "title": "Deployment Status",
+    "subtitle": "Current instance, update capabilities, and runtime health",
+    "daemon": "NA-Tools daemon",
+    "provider": "Provider",
+    "platform": "Platform",
+    "protocol": "Protocol",
+    "channel": "Current Channel",
+    "image": "Service Image",
+    "container": "Container",
+    "health": "Application Health",
+    "docker": "Docker",
+    "compose": "Docker Compose",
+    "agentVersion": "Current Version",
+    "latestVersion": "Latest Version",
+    "alreadyLatest": "Up to date",
+    "updateAvailable": "Update to {{version}}",
+    "versionCheckFailed": "Check failed",
+    "unavailableHint": "Check the daemon configuration on the host or run na-tools status."
+  },
+  "operations": {
+    "title": "Update Operations",
+    "subtitle": "Every update restarts the main service. Keep this page open so the task can recover automatically."
+  },
+  "backup": {
+    "title": "Backup and Restore",
+    "subtitle": "Create a manual backup or restore this instance from a saved backup",
+    "nameLabel": "Backup name",
+    "namePlaceholder": "For example before-upgrade",
+    "empty": "No backups yet",
+    "loading": "Loading backups",
+    "unnamed": "Automatic",
+    "displayTitle": "{{name}} backup · {{time}}",
+    "meta": "Name: {{name}} · Time: {{time}} · Size: {{size}}"
+  },
+  "options": {
+    "backup": "Back up before updating",
+    "updateSandbox": "Update sandbox image",
+    "updateCcSandbox": "Update CC sandbox image"
+  },
+  "actions": {
+    "refresh": "Refresh",
+    "updateStable": "Update to Latest",
+    "switchPreview": "Switch to Preview",
+    "updatePreview": "Update Preview",
+    "rollbackStable": "Switch to Stable Only",
+    "rollbackAndRestore": "Switch to Stable and Restore",
+    "refreshBackups": "Refresh Backups",
+    "createBackup": "Create Backup",
+    "restoreBackup": "Restore",
+    "cancelJob": "Cancel Job",
+    "clearResult": "Clear Result",
+    "close": "Cancel",
+    "confirm": "Confirm"
+  },
+  "confirm": {
+    "restartWarning": "The service will restart and the WebUI may disconnect temporarily. This page will wait for the backend and resume tracking.",
+    "noBackupTitle": "Update without a backup?",
+    "noBackupMessage": "This Stable update will not create a backup, so it cannot rely on a new pre-update snapshot for recovery.",
+    "previewTitle": "Switch to Preview?",
+    "previewMessage": "The main service will switch to the Preview channel and the daemon will create a pre-preview backup when required.",
+    "updatePreviewTitle": "Update Preview?",
+    "updatePreviewMessage": "The current Preview channel will be updated and the daemon will create an update job.",
+    "rollbackTitle": "Switch to Stable only?",
+    "rollbackMessage": "The main service will switch to the Stable image without restoring the pre-preview data backup.",
+    "restoreTitle": "Switch to Stable and restore the backup?",
+    "restoreMessage": "The service will switch to Stable and restore the latest pre-preview backup. This overwrites the current data state.",
+    "manualBackupTitle": "Create a manual backup?",
+    "manualBackupMessage": "The service will stop briefly to create a consistent backup, then restart automatically.",
+    "manualRestoreTitle": "Restore this backup?",
+    "manualRestoreMessage": "This will restore {{filename}}, overwrite the current data, and start the service afterwards."
+  },
+  "connection": {
+    "idle": "Disconnected",
+    "connecting": "Connecting",
+    "live": "Live",
+    "waiting_for_backend": "Waiting for Service",
+    "polling": "Polling",
+    "job_missing": "Job Missing"
+  },
+  "job": {
+    "title": "Job Status",
+    "empty": "No job has been created",
+    "noActiveTask": "There is no active deployment job",
+    "progressPending": "Waiting for progress",
+    "succeededHint": "The update completed. Refresh deployment status to confirm the current channel and health.",
+    "status": {
+      "queued": "Queued",
+      "running": "Running",
+      "succeeded": "Succeeded",
+      "failed": "Failed",
+      "cancel_requested": "Cancelling",
+      "cancelled": "Cancelled"
+    },
+    "phase": {
+      "validate_instance": "Validate Instance",
+      "backup": "Back Up Data",
+      "switch_channel": "Switch Channel",
+      "pull_images": "Pull Images",
+      "restart_services": "Restart Services",
+      "pull_sandbox": "Update Sandbox",
+      "verify": "Health Check",
+      "finished": "Finished"
+    },
+    "phaseDescription": {
+      "validate_instance": "Checking the instance, Docker, and Compose",
+      "backup": "Creating the pre-update backup",
+      "switch_channel": "Switching the image channel",
+      "pull_images": "Pulling the latest images",
+      "restart_services": "Restarting services; the connection may be interrupted",
+      "pull_sandbox": "Updating sandbox images",
+      "verify": "Waiting for the application to become healthy",
+      "finished": "The update workflow has finished"
+    }
+  },
+  "recovery": {
+    "waiting": "The connection was interrupted. This does not mean the job failed. Waiting for Nekro Agent to recover.",
+    "jobMissing": "The job was not found after the backend recovered. Check daemon logs on the host or run na-tools status."
+  },
+  "logs": {
+    "title": "Live Logs",
+    "lineCount": "Showing the latest {{count}} lines, up to 750 lines",
+    "autoScroll": "Auto-scroll",
+    "pause": "Pause auto-scroll",
+    "resume": "Resume auto-scroll",
+    "copy": "Copy logs",
+    "empty": "Job logs will appear here"
+  },
+  "notifications": {
+    "jobCreated": "Deployment update job created",
+    "updateJobCreated": "Deployment update job created",
+    "backupJobCreated": "Backup job created",
+    "restoreJobCreated": "Restore job created",
+    "logsCopied": "Logs copied",
+    "cancelRequested": "Job cancellation requested"
+  },
+  "errors": {
+    "NetworkError": "The service is temporarily unreachable; waiting for recovery",
+    "UnknownError": "The request failed. Try again shortly.",
+    "unknown": "The request failed. Try again shortly.",
+    "copyFailed": "Could not copy the logs",
+    "daemon_disabled": "Online updates are not enabled",
+    "daemon_instance_missing": "Daemon instance binding is missing. Run na-tools bind again.",
+    "daemon_token_missing": "The daemon token is missing. Run na-tools bind again or check the daemon configuration.",
+    "daemon_unavailable": "The NA-Tools daemon is unreachable",
+    "stream_disconnected": "The live connection was interrupted; waiting for the service to recover",
+    "job_conflict": "Another update job is already running",
+    "job_not_found": "The deployment job was not found",
+    "backup_not_found": "No pre-preview backup was found",
+    "invalid_backup_name": "Backup names may only contain letters, numbers, dot, underscore, and dash",
+    "invalid_backup_id": "The selected backup is invalid",
+    "docker_unavailable": "Docker or Docker Compose is unavailable",
+    "unsupported_operation": "The current daemon does not support this operation"
+  }
+}

--- a/frontend/src/locales/en-US/navigation.json
+++ b/frontend/src/locales/en-US/navigation.json
@@ -24,6 +24,7 @@
     "commandCenter": "Command Center",
     "theme": "Theme",
     "spaceCleanup": "Space Cleanup",
+    "deployment": "Deployment Update",
     "commands": "Commands",
     "commandSystem": "Command System",
     "commandOutput": "Command Execute",

--- a/frontend/src/locales/zh-CN/deployment.json
+++ b/frontend/src/locales/zh-CN/deployment.json
@@ -1,0 +1,162 @@
+{
+  "common": {
+    "available": "可用",
+    "unavailable": "不可用",
+    "unknown": "未知",
+    "ready": "正常"
+  },
+  "status": {
+    "title": "部署状态",
+    "subtitle": "当前实例、更新能力与运行环境",
+    "daemon": "NA-Tools daemon",
+    "provider": "Provider",
+    "platform": "平台",
+    "protocol": "协议版本",
+    "channel": "当前频道",
+    "image": "主服务镜像",
+    "container": "容器状态",
+    "health": "应用健康",
+    "docker": "Docker",
+    "compose": "Docker Compose",
+    "agentVersion": "当前版本",
+    "latestVersion": "最新版本",
+    "alreadyLatest": "已是最新",
+    "updateAvailable": "可更新至 {{version}}",
+    "versionCheckFailed": "检测失败",
+    "unavailableHint": "请在宿主机检查 daemon 配置，或运行 na-tools status。"
+  },
+  "operations": {
+    "title": "更新操作",
+    "subtitle": "每次更新都会重启主服务，请保留当前任务页面以便自动恢复。"
+  },
+  "backup": {
+    "title": "备份与还原",
+    "subtitle": "创建手动备份，或选择历史备份还原当前实例",
+    "nameLabel": "备份名称",
+    "namePlaceholder": "例如 before-upgrade",
+    "empty": "暂无历史备份",
+    "loading": "正在加载备份",
+    "unnamed": "自动备份",
+    "displayTitle": "{{name}} 备份 · {{time}}",
+    "meta": "名称: {{name}} · 时间: {{time}} · 大小: {{size}}"
+  },
+  "options": {
+    "backup": "更新前备份",
+    "updateSandbox": "同时更新沙盒镜像",
+    "updateCcSandbox": "同时更新 CC 沙盒镜像"
+  },
+  "actions": {
+    "refresh": "刷新",
+    "updateStable": "更新到最新版",
+    "switchPreview": "切换 Preview",
+    "updatePreview": "更新 Preview",
+    "rollbackStable": "仅切回 稳定版",
+    "rollbackAndRestore": "切回 稳定版 并恢复备份",
+    "refreshBackups": "刷新备份",
+    "createBackup": "创建备份",
+    "restoreBackup": "还原",
+    "cancelJob": "取消任务",
+    "clearResult": "清除结果",
+    "close": "取消",
+    "confirm": "确认执行"
+  },
+  "confirm": {
+    "restartWarning": "服务会重启，WebUI 可能暂时断开。页面会等待后端恢复并继续查询任务。",
+    "noBackupTitle": "不备份直接更新？",
+    "noBackupMessage": "本次 稳定版 更新不会创建备份，失败后无法依赖本次更新前快照恢复。",
+    "previewTitle": "切换到 Preview？",
+    "previewMessage": "将切换主服务到 Preview 频道，并按 daemon 规则创建 pre-preview 备份。",
+    "updatePreviewTitle": "更新 Preview？",
+    "updatePreviewMessage": "将更新当前 Preview 频道，并按 daemon 规则创建更新任务。",
+    "rollbackTitle": "仅切回 Stable？",
+    "rollbackMessage": "将主服务切回 稳定版 镜像，不恢复 pre-preview 数据备份。",
+    "restoreTitle": "切回 稳定版 并恢复备份？",
+    "restoreMessage": "将切回 Stable，并恢复最近的 pre-preview 备份。该操作会覆盖当前数据状态。",
+    "manualBackupTitle": "创建手动备份？",
+    "manualBackupMessage": "将短暂停止服务以创建一致性备份，完成后自动重启服务。",
+    "manualRestoreTitle": "还原这个备份？",
+    "manualRestoreMessage": "将使用 {{filename}} 覆盖当前数据，并在完成后启动服务。"
+  },
+  "connection": {
+    "idle": "未连接",
+    "connecting": "正在连接",
+    "live": "实时连接",
+    "waiting_for_backend": "等待服务恢复",
+    "polling": "轮询模式",
+    "job_missing": "任务不存在"
+  },
+  "job": {
+    "title": "任务状态",
+    "empty": "尚未创建任务",
+    "noActiveTask": "当前没有部署任务",
+    "progressPending": "等待进度",
+    "succeededHint": "更新已完成，可刷新部署状态确认当前频道和健康状态。",
+    "status": {
+      "queued": "排队中",
+      "running": "运行中",
+      "succeeded": "成功",
+      "failed": "失败",
+      "cancel_requested": "取消中",
+      "cancelled": "已取消"
+    },
+    "phase": {
+      "validate_instance": "校验实例",
+      "backup": "备份数据",
+      "switch_channel": "切换频道",
+      "pull_images": "拉取镜像",
+      "restart_services": "重启服务",
+      "pull_sandbox": "更新沙盒",
+      "verify": "健康检查",
+      "finished": "完成"
+    },
+    "phaseDescription": {
+      "validate_instance": "正在检查实例、Docker 与 Compose 状态",
+      "backup": "正在创建更新前备份",
+      "switch_channel": "正在切换镜像频道",
+      "pull_images": "正在拉取最新镜像",
+      "restart_services": "正在重启服务，连接可能暂时中断",
+      "pull_sandbox": "正在更新沙盒镜像",
+      "verify": "正在等待应用恢复健康",
+      "finished": "更新流程已完成"
+    }
+  },
+  "recovery": {
+    "waiting": "连接已中断，这不代表任务失败。正在等待 Nekro Agent 恢复。",
+    "jobMissing": "后端恢复后未找到该任务。请在宿主机查看 daemon 日志或运行 na-tools status。"
+  },
+  "logs": {
+    "title": "实时日志",
+    "lineCount": "显示最近 {{count}} 行，最多保留 750 行",
+    "autoScroll": "自动滚动",
+    "pause": "暂停自动滚动",
+    "resume": "恢复自动滚动",
+    "copy": "复制日志",
+    "empty": "任务日志将在这里显示"
+  },
+  "notifications": {
+    "jobCreated": "部署更新任务已创建",
+    "updateJobCreated": "部署更新任务已创建",
+    "backupJobCreated": "备份任务已创建",
+    "restoreJobCreated": "还原任务已创建",
+    "logsCopied": "日志已复制",
+    "cancelRequested": "已请求取消任务"
+  },
+  "errors": {
+    "NetworkError": "服务暂时不可达，正在等待恢复",
+    "UnknownError": "请求失败，请稍后重试",
+    "unknown": "请求失败，请稍后重试",
+    "copyFailed": "复制日志失败",
+    "daemon_disabled": "在线更新未启用",
+    "daemon_instance_missing": "未找到 daemon 实例绑定信息，请重新运行 na-tools bind",
+    "daemon_token_missing": "未找到 daemon token，请重新运行 na-tools bind 或检查 daemon 配置",
+    "daemon_unavailable": "NA-Tools daemon 当前不可达",
+    "stream_disconnected": "实时连接已中断，正在等待服务恢复",
+    "job_conflict": "已有更新任务正在运行",
+    "job_not_found": "部署任务不存在",
+    "backup_not_found": "未找到 pre-preview 备份",
+    "invalid_backup_name": "备份名称只能包含字母、数字、点、下划线和短横线",
+    "invalid_backup_id": "备份文件无效",
+    "docker_unavailable": "Docker 或 Docker Compose 当前不可用",
+    "unsupported_operation": "当前 daemon 不支持此操作"
+  }
+}

--- a/frontend/src/locales/zh-CN/navigation.json
+++ b/frontend/src/locales/zh-CN/navigation.json
@@ -24,6 +24,7 @@
     "commandCenter": "命令中心",
     "theme": "调色盘",
     "spaceCleanup": "空间回收",
+    "deployment": "部署更新",
     "commands": "命令管理",
     "commandSystem": "命令系统",
     "commandOutput": "命令执行",

--- a/frontend/src/pages/settings/deployment/index.tsx
+++ b/frontend/src/pages/settings/deployment/index.tsx
@@ -1,0 +1,988 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  Divider,
+  FormControlLabel,
+  LinearProgress,
+  Paper,
+  Stack,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material'
+import {
+  CancelOutlined as CancelIcon,
+  BackupOutlined as BackupIcon,
+  CheckCircleOutline as SuccessIcon,
+  CloudDoneOutlined as ConnectedIcon,
+  CloudOffOutlined as DisconnectedIcon,
+  ContentCopyOutlined as CopyIcon,
+  ErrorOutline as ErrorIcon,
+  PauseOutlined as PauseIcon,
+  PlayArrowOutlined as PlayIcon,
+  RefreshOutlined as RefreshIcon,
+  RestartAltOutlined as RollbackIcon,
+  RestoreOutlined as RestoreIcon,
+  ScienceOutlined as PreviewIcon,
+  SystemUpdateAltOutlined as UpdateIcon,
+  WarningAmberOutlined as WarningIcon,
+} from '@mui/icons-material'
+import { useTranslation } from 'react-i18next'
+import ActionButton from '../../../components/common/ActionButton'
+import IconActionButton from '../../../components/common/IconActionButton'
+import NekroDialog from '../../../components/common/NekroDialog'
+import { useNotification } from '../../../hooks/useNotification'
+import { CARD_VARIANTS, SCROLLBAR_VARIANTS } from '../../../theme/variants'
+import { ApiError } from '../../../services/api/axios'
+import {
+  deploymentApi,
+  type DeploymentAgentVersion,
+  type DeploymentBackupSummary,
+  type DeploymentCapabilities,
+  type DeploymentInstance,
+  type DeploymentJobType,
+  type DeploymentJobStatus,
+  type DeploymentUpdateRequest,
+} from '../../../services/api/deployment'
+import { useDeploymentJob } from './useDeploymentJob'
+
+type UpdateChannel = DeploymentUpdateRequest['channel']
+
+interface PendingAction {
+  type: DeploymentJobType
+  channel?: UpdateChannel
+  backup?: boolean
+  restorePrePreview?: boolean
+  backupId?: string
+  backupName?: string
+  titleKey: string
+  messageKey: string
+  messageValues?: Record<string, string>
+  confirmTone?: 'primary' | 'danger'
+}
+
+const STATUS_COLOR: Record<
+  DeploymentJobStatus,
+  'default' | 'info' | 'success' | 'error' | 'warning'
+> = {
+  queued: 'info',
+  running: 'info',
+  succeeded: 'success',
+  failed: 'error',
+  cancel_requested: 'warning',
+  cancelled: 'default',
+}
+
+const createRequestId = (): string => crypto.randomUUID()
+
+const formatBackupSize = (sizeBytes: number): string => {
+  if (!Number.isFinite(sizeBytes) || sizeBytes < 0) return '-'
+  if (sizeBytes < 1024) return `${sizeBytes} B`
+  if (sizeBytes < 1024 * 1024) return `${(sizeBytes / 1024).toFixed(1)} KB`
+  if (sizeBytes < 1024 * 1024 * 1024) return `${(sizeBytes / 1024 / 1024).toFixed(1)} MB`
+  return `${(sizeBytes / 1024 / 1024 / 1024).toFixed(1)} GB`
+}
+
+const getBackupDisplayName = (backup: DeploymentBackupSummary, unnamedLabel: string): string => {
+  const name = backup.name?.trim()
+  if (name) return name
+
+  if (/^.+_backup_\d{8}_\d{6}\.tar\.gz$/.test(backup.filename)) {
+    return unnamedLabel
+  }
+
+  const namedMatch = backup.filename.match(/^.+_backup_(.+)_\d{8}_\d{6}\.tar\.gz$/)
+  if (namedMatch?.[1]) return namedMatch[1]
+
+  return backup.filename
+}
+
+const StatusField = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <Box sx={{ minWidth: 0 }}>
+    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+      {label}
+    </Typography>
+    <Box sx={{ minHeight: 28, display: 'flex', alignItems: 'center', minWidth: 0 }}>{value}</Box>
+  </Box>
+)
+
+export default function DeploymentPage() {
+  const { t } = useTranslation('deployment')
+  const theme = useTheme()
+  const notification = useNotification()
+  const [capabilities, setCapabilities] = useState<DeploymentCapabilities | null>(null)
+  const [instance, setInstance] = useState<DeploymentInstance | null>(null)
+  const [agentVersion, setAgentVersion] = useState<DeploymentAgentVersion | null>(null)
+  const [overviewLoading, setOverviewLoading] = useState(false)
+  const [overviewError, setOverviewError] = useState<string | null>(null)
+  const [backup, setBackup] = useState(true)
+  const [updateSandbox, setUpdateSandbox] = useState(true)
+  const [updateCcSandbox, setUpdateCcSandbox] = useState(false)
+  const [backupName, setBackupName] = useState('')
+  const [backups, setBackups] = useState<DeploymentBackupSummary[]>([])
+  const [backupsLoading, setBackupsLoading] = useState(false)
+  const [backupsError, setBackupsError] = useState<string | null>(null)
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [autoScroll, setAutoScroll] = useState(true)
+  const logContainerRef = useRef<HTMLDivElement | null>(null)
+  const refreshedJobRef = useRef<string | null>(null)
+
+  const {
+    activeTask,
+    job,
+    logs,
+    connectionState,
+    trackingError,
+    isCancelling,
+    startTracking,
+    cancelActiveJob,
+    dismissCompletedJob,
+  } = useDeploymentJob(true, capabilities?.supports.log_stream === true)
+
+  const resolveErrorMessage = useCallback(
+    (error: unknown) => {
+      if (error instanceof ApiError) {
+        return t(`errors.${error.type}`, { defaultValue: error.message })
+      }
+      return t('errors.unknown')
+    },
+    [t]
+  )
+
+  const loadOverview = useCallback(async () => {
+    setOverviewLoading(true)
+    setOverviewError(null)
+    try {
+      const nextCapabilities = await deploymentApi.getCapabilities()
+      setCapabilities(nextCapabilities)
+      const nextAgentVersion = await deploymentApi.getAgentVersion()
+      setAgentVersion(nextAgentVersion)
+      if (nextCapabilities.enabled) {
+        const nextInstance = await deploymentApi.getInstance()
+        setInstance(nextInstance)
+      } else {
+        setInstance(null)
+      }
+    } catch (error) {
+      setOverviewError(resolveErrorMessage(error))
+    } finally {
+      setOverviewLoading(false)
+    }
+  }, [resolveErrorMessage])
+
+  const loadBackups = useCallback(async () => {
+    setBackupsLoading(true)
+    setBackupsError(null)
+    try {
+      const response = await deploymentApi.listBackups()
+      setBackups(response.backups)
+    } catch (error) {
+      setBackupsError(resolveErrorMessage(error))
+    } finally {
+      setBackupsLoading(false)
+    }
+  }, [resolveErrorMessage])
+
+  useEffect(() => {
+    void loadOverview()
+  }, [loadOverview])
+
+  useEffect(() => {
+    if (capabilities?.enabled === true && capabilities.supports.backup === true) {
+      void loadBackups()
+    }
+  }, [capabilities?.enabled, capabilities?.supports.backup, loadBackups])
+
+  useEffect(() => {
+    if (capabilities && capabilities.supports.backup === false) {
+      setBackup(false)
+    }
+  }, [capabilities])
+
+  useEffect(() => {
+    if (!autoScroll || !logContainerRef.current) return
+    logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight
+  }, [autoScroll, logs])
+
+  useEffect(() => {
+    if (!job || job.status !== 'succeeded' || refreshedJobRef.current === job.job_id) return
+    refreshedJobRef.current = job.job_id
+    void loadOverview()
+    if (job.type === 'backup' || job.type === 'restore') {
+      void loadBackups()
+    }
+  }, [job, loadBackups, loadOverview])
+
+  const isTaskActive = activeTask !== null
+  const canUpdate = capabilities?.enabled === true && capabilities.supports.update === true
+  const showStableUpdate = agentVersion?.update_available === true
+  const supportsPreview = capabilities?.enabled === true && capabilities.supports.preview === true
+  const showPreviewUpdate = capabilities?.enabled !== true || supportsPreview
+  const supportsRollback = capabilities?.enabled === true && capabilities.supports.rollback === true
+  const isPreviewChannel = instance?.channel === 'preview'
+  const isPreviewVersion = isPreviewChannel || agentVersion?.current_version === 'preview'
+  const supportsRestore = capabilities?.supports.restore_pre_preview === true
+  const supportsManualBackup = capabilities?.enabled === true && capabilities.supports.backup === true
+  const supportsManualRestore = capabilities?.enabled === true && capabilities.supports.restore === true
+  const supportsCancel = capabilities?.supports.cancel === true
+
+  const submitDeploymentAction = useCallback(
+    async (action: PendingAction) => {
+      if (submitting || isTaskActive) return
+      setSubmitting(true)
+      const clientRequestId = createRequestId()
+      try {
+        const response =
+          action.type === 'backup'
+            ? await deploymentApi.createBackup({
+                name: action.backupName || undefined,
+                client_request_id: clientRequestId,
+              })
+            : action.type === 'restore'
+              ? await deploymentApi.createRestore({
+                  backup_id: action.backupId ?? '',
+                  client_request_id: clientRequestId,
+                })
+              : await deploymentApi.createUpdate({
+                  channel: action.channel ?? 'stable',
+                  backup: action.backup ?? true,
+                  update_sandbox: updateSandbox,
+                  update_cc_sandbox: updateCcSandbox,
+                  restore_pre_preview: action.restorePrePreview ?? false,
+                  client_request_id: clientRequestId,
+                })
+        startTracking(response, clientRequestId)
+        notification.success(t(`notifications.${action.type}JobCreated`))
+      } catch (error) {
+        notification.error(resolveErrorMessage(error), { autoHideDuration: 7000 })
+      } finally {
+        setSubmitting(false)
+        setPendingAction(null)
+      }
+    },
+    [
+      isTaskActive,
+      notification,
+      resolveErrorMessage,
+      startTracking,
+      submitting,
+      t,
+      updateCcSandbox,
+      updateSandbox,
+    ]
+  )
+
+  const handleStableUpdate = () => {
+    const action: PendingAction = {
+      type: 'update',
+      channel: 'stable',
+      backup,
+      restorePrePreview: false,
+      titleKey: 'confirm.noBackupTitle',
+      messageKey: 'confirm.noBackupMessage',
+      confirmTone: 'danger',
+    }
+    if (backup) {
+      void submitDeploymentAction(action)
+    } else {
+      setPendingAction(action)
+    }
+  }
+
+  const handleCreateBackup = () => {
+    setPendingAction({
+      type: 'backup',
+      backupName: backupName.trim(),
+      titleKey: 'confirm.manualBackupTitle',
+      messageKey: 'confirm.manualBackupMessage',
+    })
+  }
+
+  const handleRestoreBackup = (selectedBackup: DeploymentBackupSummary) => {
+    setPendingAction({
+      type: 'restore',
+      backupId: selectedBackup.backup_id,
+      titleKey: 'confirm.manualRestoreTitle',
+      messageKey: 'confirm.manualRestoreMessage',
+      messageValues: { filename: selectedBackup.filename },
+      confirmTone: 'danger',
+    })
+  }
+
+  const handleCopyLogs = async () => {
+    if (logs.length === 0) return
+    const text = logs
+      .map(entry => `${entry.ts ?? ''} [${entry.level}] ${entry.line}`.trim())
+      .join('\n')
+    try {
+      await navigator.clipboard.writeText(text)
+      notification.success(t('notifications.logsCopied'))
+    } catch {
+      notification.error(t('errors.copyFailed'))
+    }
+  }
+
+  const handleCancel = async () => {
+    try {
+      await cancelActiveJob()
+      notification.info(t('notifications.cancelRequested'))
+    } catch (error) {
+      notification.error(resolveErrorMessage(error))
+    }
+  }
+
+  const progressValue = useMemo(() => {
+    if (!job?.progress || !job.progress.total || job.progress.current === null) return undefined
+    return Math.min(100, Math.max(0, (job.progress.current / job.progress.total) * 100))
+  }, [job?.progress])
+
+  const connectionLabel = t(`connection.${connectionState}`)
+  const connectionColor =
+    connectionState === 'live' ? 'success' : connectionState === 'idle' ? 'default' : 'warning'
+
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        overflow: 'auto',
+        p: { xs: 1.5, md: 2 },
+        ...SCROLLBAR_VARIANTS.thin.styles,
+      }}
+    >
+      <Stack spacing={2} sx={{ maxWidth: 1280, mx: 'auto' }}>
+        <Paper sx={{ ...CARD_VARIANTS.elevated.styles, p: { xs: 2, md: 2.5 } }}>
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            alignItems={{ xs: 'stretch', sm: 'center' }}
+            justifyContent="space-between"
+            gap={1.5}
+            mb={2}
+          >
+            <Box>
+              <Typography variant="h6">{t('status.title')}</Typography>
+              <Typography variant="body2" color="text.secondary">
+                {t('status.subtitle')}
+              </Typography>
+            </Box>
+            <ActionButton
+              tone="secondary"
+              size="small"
+              startIcon={overviewLoading ? <CircularProgress size={16} /> : <RefreshIcon />}
+              onClick={() => void loadOverview()}
+              disabled={overviewLoading}
+              sx={{ flexShrink: 0 }}
+            >
+              {t('actions.refresh')}
+            </ActionButton>
+          </Stack>
+
+          {overviewError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {overviewError}
+            </Alert>
+          )}
+          {capabilities?.unavailable_reason && (
+            <Alert severity="warning" icon={<WarningIcon />} sx={{ mb: 2 }}>
+              <Typography variant="body2" fontWeight={600}>
+                {t(`errors.${capabilities.unavailable_reason.code}`, {
+                  defaultValue: capabilities.unavailable_reason.message,
+                })}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {t('status.unavailableHint')}
+              </Typography>
+            </Alert>
+          )}
+
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr 1fr', md: 'repeat(4, minmax(0, 1fr))' },
+              gap: { xs: 2, md: 2.5 },
+            }}
+          >
+            <StatusField
+              label={t('status.daemon')}
+              value={
+                <Chip
+                  size="small"
+                  icon={capabilities?.enabled ? <ConnectedIcon /> : <DisconnectedIcon />}
+                  color={capabilities?.enabled ? 'success' : 'default'}
+                  label={capabilities?.enabled ? t('common.available') : t('common.unavailable')}
+                />
+              }
+            />
+            <StatusField
+              label={t('status.provider')}
+              value={
+                <Typography noWrap>{capabilities?.provider ?? t('common.unknown')}</Typography>
+              }
+            />
+            <StatusField
+              label={t('status.platform')}
+              value={
+                <Typography noWrap>{capabilities?.platform ?? t('common.unknown')}</Typography>
+              }
+            />
+            <StatusField
+              label={t('status.protocol')}
+              value={
+                <Typography noWrap>
+                  {capabilities?.protocol_version ?? t('common.unknown')}
+                </Typography>
+              }
+            />
+            <StatusField
+              label={t('status.channel')}
+              value={<Chip size="small" label={instance?.channel ?? t('common.unknown')} />}
+            />
+            <StatusField
+              label={t('status.image')}
+              value={
+                <Typography noWrap title={instance?.image ?? undefined}>
+                  {instance?.image ?? t('common.unknown')}
+                </Typography>
+              }
+            />
+            <StatusField
+              label={t('status.container')}
+              value={<Typography>{instance?.container_status ?? t('common.unknown')}</Typography>}
+            />
+            <StatusField
+              label={t('status.health')}
+              value={<Typography>{instance?.app_health ?? t('common.unknown')}</Typography>}
+            />
+            <StatusField
+              label={t('status.docker')}
+              value={
+                <Chip
+                  size="small"
+                  color={instance?.docker_ok ? 'success' : 'default'}
+                  label={instance?.docker_ok ? t('common.ready') : t('common.unavailable')}
+                />
+              }
+            />
+            <StatusField
+              label={t('status.compose')}
+              value={
+                <Chip
+                  size="small"
+                  color={instance?.compose_ok ? 'success' : 'default'}
+                  label={instance?.compose_ok ? t('common.ready') : t('common.unavailable')}
+                />
+              }
+            />
+            <StatusField
+              label={t('status.agentVersion')}
+              value={
+                <Typography noWrap>
+                  {agentVersion?.current_version ?? t('common.unknown')}
+                </Typography>
+              }
+            />
+            <StatusField
+              label={t('status.latestVersion')}
+              value={
+                agentVersion?.checked ? (
+                  <Chip
+                    size="small"
+                    color={agentVersion.update_available ? 'warning' : 'success'}
+                    label={
+                      agentVersion.update_available
+                        ? t('status.updateAvailable', { version: agentVersion.latest_version })
+                        : t('status.alreadyLatest')
+                    }
+                  />
+                ) : (
+                  <Tooltip title={agentVersion?.error_message ?? ''}>
+                    <Chip
+                      size="small"
+                      color={agentVersion?.error_code ? 'warning' : 'default'}
+                      label={agentVersion?.error_code ? t('status.versionCheckFailed') : t('common.unknown')}
+                    />
+                  </Tooltip>
+                )
+              }
+            />
+          </Box>
+        </Paper>
+
+        <Paper sx={{ ...CARD_VARIANTS.elevated.styles, p: { xs: 2, md: 2.5 } }}>
+          <Typography variant="h6">{t('operations.title')}</Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {t('operations.subtitle')}
+          </Typography>
+
+          <Stack direction={{ xs: 'column', md: 'row' }} gap={{ xs: 0, md: 2 }} mb={2}>
+            <FormControlLabel
+              control={
+                <Checkbox checked={backup} onChange={event => setBackup(event.target.checked)} />
+              }
+              label={t('options.backup')}
+              disabled={capabilities?.supports.backup === false || isTaskActive || submitting}
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={updateSandbox}
+                  onChange={event => setUpdateSandbox(event.target.checked)}
+                />
+              }
+              label={t('options.updateSandbox')}
+              disabled={isTaskActive || submitting}
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={updateCcSandbox}
+                  onChange={event => setUpdateCcSandbox(event.target.checked)}
+                />
+              }
+              label={t('options.updateCcSandbox')}
+              disabled={isTaskActive || submitting}
+            />
+          </Stack>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} gap={1} flexWrap="wrap" useFlexGap>
+            {showStableUpdate && (
+              <ActionButton
+                tone="primary"
+                startIcon={
+                  submitting ? <CircularProgress size={16} color="inherit" /> : <UpdateIcon />
+                }
+                onClick={handleStableUpdate}
+                disabled={!canUpdate || isTaskActive || submitting}
+              >
+                {t('actions.updateStable')}
+              </ActionButton>
+            )}
+            {showPreviewUpdate && (
+              <ActionButton
+                tone="secondary"
+                startIcon={<PreviewIcon />}
+                onClick={() =>
+                  setPendingAction({
+                    type: 'update',
+                    channel: 'preview',
+                    backup: true,
+                    restorePrePreview: false,
+                    titleKey: isPreviewVersion ? 'confirm.updatePreviewTitle' : 'confirm.previewTitle',
+                    messageKey: isPreviewVersion
+                      ? 'confirm.updatePreviewMessage'
+                      : 'confirm.previewMessage',
+                  })
+                }
+                disabled={!supportsPreview || isTaskActive || submitting}
+              >
+                {t(isPreviewVersion ? 'actions.updatePreview' : 'actions.switchPreview')}
+              </ActionButton>
+            )}
+            {supportsRollback && isPreviewChannel && (
+              <ActionButton
+                tone="secondary"
+                startIcon={<RollbackIcon />}
+                onClick={() =>
+                  setPendingAction({
+                    type: 'update',
+                    channel: 'rollback',
+                    backup: false,
+                    restorePrePreview: false,
+                    titleKey: 'confirm.rollbackTitle',
+                    messageKey: 'confirm.rollbackMessage',
+                  })
+                }
+                disabled={isTaskActive || submitting}
+              >
+                {t('actions.rollbackStable')}
+              </ActionButton>
+            )}
+            {supportsRollback && supportsRestore && isPreviewChannel && (
+              <ActionButton
+                tone="danger"
+                startIcon={<RollbackIcon />}
+                onClick={() =>
+                  setPendingAction({
+                    type: 'update',
+                    channel: 'rollback',
+                    backup: false,
+                    restorePrePreview: true,
+                    titleKey: 'confirm.restoreTitle',
+                    messageKey: 'confirm.restoreMessage',
+                    confirmTone: 'danger',
+                  })
+                }
+                disabled={isTaskActive || submitting}
+              >
+                {t('actions.rollbackAndRestore')}
+              </ActionButton>
+            )}
+          </Stack>
+
+          <Divider sx={{ my: 2.5 }} />
+
+          <Stack spacing={1.5}>
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              justifyContent="space-between"
+              alignItems={{ xs: 'stretch', sm: 'center' }}
+              gap={1}
+            >
+              <Box>
+                <Typography variant="subtitle1" fontWeight={600}>
+                  {t('backup.title')}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {t('backup.subtitle')}
+                </Typography>
+              </Box>
+              <ActionButton
+                tone="ghost"
+                size="small"
+                startIcon={backupsLoading ? <CircularProgress size={16} /> : <RefreshIcon />}
+                onClick={() => void loadBackups()}
+                disabled={!supportsManualBackup || backupsLoading}
+              >
+                {t('actions.refreshBackups')}
+              </ActionButton>
+            </Stack>
+
+            {backupsError && <Alert severity="warning">{backupsError}</Alert>}
+
+            <Stack direction={{ xs: 'column', sm: 'row' }} gap={1} alignItems={{ sm: 'center' }}>
+              <TextField
+                size="small"
+                value={backupName}
+                onChange={event => setBackupName(event.target.value)}
+                label={t('backup.nameLabel')}
+                placeholder={t('backup.namePlaceholder')}
+                disabled={!supportsManualBackup || isTaskActive || submitting}
+                sx={{ minWidth: { sm: 260 }, flex: 1 }}
+              />
+              <ActionButton
+                tone="secondary"
+                startIcon={submitting ? <CircularProgress size={16} color="inherit" /> : <BackupIcon />}
+                onClick={handleCreateBackup}
+                disabled={!supportsManualBackup || isTaskActive || submitting}
+              >
+                {t('actions.createBackup')}
+              </ActionButton>
+            </Stack>
+
+            <Stack spacing={1}>
+              {backups.length === 0 ? (
+                <Box
+                  sx={{
+                    minHeight: 72,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    borderRadius: 1,
+                    bgcolor: theme.palette.action.hover,
+                  }}
+                >
+                  <Typography variant="body2" color="text.secondary">
+                    {backupsLoading ? t('backup.loading') : t('backup.empty')}
+                  </Typography>
+                </Box>
+              ) : (
+                backups.map(item => (
+                  <Box
+                    key={item.backup_id}
+                    sx={{
+                      display: 'grid',
+                      gridTemplateColumns: { xs: '1fr', md: 'minmax(0, 1fr) auto' },
+                      gap: 1,
+                      alignItems: 'center',
+                      borderRadius: 1,
+                      bgcolor: theme.palette.action.hover,
+                      px: 1.5,
+                      py: 1,
+                    }}
+                  >
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography noWrap title={item.filename} fontWeight={600}>
+                        {t('backup.displayTitle', {
+                          name: getBackupDisplayName(item, t('backup.unnamed')),
+                          time: new Date(item.created_at).toLocaleString(),
+                        })}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                        {t('backup.meta', {
+                          name: item.name || t('backup.unnamed'),
+                          time: new Date(item.created_at).toLocaleString(),
+                          size: formatBackupSize(item.size_bytes),
+                        })}
+                      </Typography>
+                    </Box>
+                    <ActionButton
+                      tone="danger"
+                      size="small"
+                      startIcon={<RestoreIcon />}
+                      onClick={() => handleRestoreBackup(item)}
+                      disabled={!supportsManualRestore || isTaskActive || submitting}
+                    >
+                      {t('actions.restoreBackup')}
+                    </ActionButton>
+                  </Box>
+                ))
+              )}
+            </Stack>
+          </Stack>
+
+          <Divider sx={{ my: 2.5 }} />
+
+          <Box sx={{ minHeight: 172 }}>
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
+              gap={1}
+              mb={1.5}
+            >
+              <Box>
+                <Typography variant="subtitle1" fontWeight={600}>
+                  {t('job.title')}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {job ? job.job_id : t('job.empty')}
+                </Typography>
+              </Box>
+              <Stack direction="row" gap={1} alignItems="center">
+                <Chip size="small" color={connectionColor} label={connectionLabel} />
+                {job && (
+                  <Chip
+                    size="small"
+                    color={STATUS_COLOR[job.status]}
+                    label={t(`job.status.${job.status}`)}
+                  />
+                )}
+              </Stack>
+            </Stack>
+
+            {connectionState === 'job_missing' && (
+              <Alert severity="warning" sx={{ mb: 1.5 }}>
+                {t('recovery.jobMissing')}
+              </Alert>
+            )}
+            {connectionState === 'waiting_for_backend' && (
+              <Alert severity="info" icon={<DisconnectedIcon />} sx={{ mb: 1.5 }}>
+                {t('recovery.waiting')}
+              </Alert>
+            )}
+            {trackingError && connectionState !== 'job_missing' && connectionState !== 'idle' && (
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                {t(`errors.${trackingError.code}`, { defaultValue: trackingError.message })}
+              </Typography>
+            )}
+
+            {job ? (
+              <Stack spacing={1.5}>
+                <Box>
+                  <Stack direction="row" justifyContent="space-between" mb={0.75}>
+                    <Typography variant="body2">{t(`job.phase.${job.phase}`)}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {progressValue === undefined
+                        ? t('job.progressPending')
+                        : `${Math.round(progressValue)}%`}
+                    </Typography>
+                  </Stack>
+                  <LinearProgress
+                    variant={progressValue === undefined ? 'indeterminate' : 'determinate'}
+                    value={progressValue}
+                  />
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: 'block', mt: 0.75, minHeight: 20 }}
+                  >
+                    {job.progress?.label || t(`job.phaseDescription.${job.phase}`)}
+                  </Typography>
+                </Box>
+                {job.error && (
+                  <Alert severity="error" icon={<ErrorIcon />}>
+                    <Typography variant="body2" fontWeight={600}>
+                      {job.error.code}
+                    </Typography>
+                    <Typography variant="body2">{job.error.message}</Typography>
+                  </Alert>
+                )}
+                {job.status === 'succeeded' && (
+                  <Alert severity="success" icon={<SuccessIcon />}>
+                    {t('job.succeededHint')}
+                  </Alert>
+                )}
+                <Stack direction="row" justifyContent="flex-end" gap={1}>
+                  {supportsCancel && isTaskActive && (
+                    <ActionButton
+                      tone="danger"
+                      size="small"
+                      startIcon={<CancelIcon />}
+                      onClick={() => void handleCancel()}
+                      disabled={isCancelling}
+                    >
+                      {t('actions.cancelJob')}
+                    </ActionButton>
+                  )}
+                  {!isTaskActive && (
+                    <ActionButton tone="ghost" size="small" onClick={dismissCompletedJob}>
+                      {t('actions.clearResult')}
+                    </ActionButton>
+                  )}
+                </Stack>
+              </Stack>
+            ) : (
+              <Box
+                sx={{
+                  minHeight: 92,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Typography color="text.secondary">{t('job.noActiveTask')}</Typography>
+              </Box>
+            )}
+          </Box>
+        </Paper>
+
+        <Paper sx={{ ...CARD_VARIANTS.elevated.styles, overflow: 'hidden' }}>
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            justifyContent="space-between"
+            alignItems={{ xs: 'stretch', sm: 'center' }}
+            gap={1}
+            sx={{ px: { xs: 2, md: 2.5 }, py: 1.5 }}
+          >
+            <Box>
+              <Typography variant="subtitle1" fontWeight={600}>
+                {t('logs.title')}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {t('logs.lineCount', { count: logs.length })}
+              </Typography>
+            </Box>
+            <Stack direction="row" alignItems="center" gap={0.5} justifyContent="flex-end">
+              <FormControlLabel
+                control={
+                  <Switch
+                    size="small"
+                    checked={autoScroll}
+                    onChange={event => setAutoScroll(event.target.checked)}
+                  />
+                }
+                label={t('logs.autoScroll')}
+                sx={{ mr: 0.5 }}
+              />
+              <Tooltip title={autoScroll ? t('logs.pause') : t('logs.resume')}>
+                <span>
+                  <IconActionButton
+                    size="small"
+                    onClick={() => setAutoScroll(value => !value)}
+                    disabled={logs.length === 0}
+                  >
+                    {autoScroll ? <PauseIcon fontSize="small" /> : <PlayIcon fontSize="small" />}
+                  </IconActionButton>
+                </span>
+              </Tooltip>
+              <Tooltip title={t('logs.copy')}>
+                <span>
+                  <IconActionButton
+                    size="small"
+                    onClick={() => void handleCopyLogs()}
+                    disabled={logs.length === 0}
+                  >
+                    <CopyIcon fontSize="small" />
+                  </IconActionButton>
+                </span>
+              </Tooltip>
+            </Stack>
+          </Stack>
+          <Divider />
+          <Box
+            ref={logContainerRef}
+            sx={{
+              height: { xs: 300, md: 360 },
+              overflow: 'auto',
+              p: 1.5,
+              bgcolor: alpha(
+                theme.palette.common.black,
+                theme.palette.mode === 'dark' ? 0.24 : 0.04
+              ),
+              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+              fontSize: '0.78rem',
+              lineHeight: 1.65,
+              ...SCROLLBAR_VARIANTS.thin.styles,
+            }}
+          >
+            {logs.length === 0 ? (
+              <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'inherit' }}>
+                {t('logs.empty')}
+              </Typography>
+            ) : (
+              logs.map(entry => (
+                <Box key={entry.seq} sx={{ display: 'flex', gap: 1, minWidth: 0 }}>
+                  <Box component="span" sx={{ color: 'text.secondary', flexShrink: 0 }}>
+                    {entry.ts ? new Date(entry.ts).toLocaleTimeString() : `#${entry.seq}`}
+                  </Box>
+                  <Box
+                    component="span"
+                    sx={{
+                      color:
+                        entry.level === 'error'
+                          ? 'error.main'
+                          : entry.level === 'warning'
+                            ? 'warning.main'
+                            : 'text.primary',
+                      whiteSpace: 'pre-wrap',
+                      overflowWrap: 'anywhere',
+                    }}
+                  >
+                    {entry.line}
+                  </Box>
+                </Box>
+              ))
+            )}
+          </Box>
+        </Paper>
+      </Stack>
+
+      <NekroDialog
+        open={pendingAction !== null}
+        onClose={() => !submitting && setPendingAction(null)}
+        title={pendingAction ? t(pendingAction.titleKey) : ''}
+        titleStartIcon={<WarningIcon color="warning" />}
+        maxWidth="sm"
+        actions={
+          <>
+            <ActionButton tone="ghost" onClick={() => setPendingAction(null)} disabled={submitting}>
+              {t('actions.close')}
+            </ActionButton>
+            <ActionButton
+              tone={pendingAction?.confirmTone ?? 'primary'}
+              onClick={() => pendingAction && void submitDeploymentAction(pendingAction)}
+              disabled={submitting}
+              startIcon={submitting ? <CircularProgress size={16} color="inherit" /> : undefined}
+            >
+              {t('actions.confirm')}
+            </ActionButton>
+          </>
+        }
+      >
+        <Stack spacing={1.5}>
+          <Typography>
+            {pendingAction ? t(pendingAction.messageKey, pendingAction.messageValues) : ''}
+          </Typography>
+          <Alert severity="warning">{t('confirm.restartWarning')}</Alert>
+        </Stack>
+      </NekroDialog>
+    </Box>
+  )
+}

--- a/frontend/src/pages/settings/deployment/useDeploymentJob.ts
+++ b/frontend/src/pages/settings/deployment/useDeploymentJob.ts
@@ -1,0 +1,426 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ApiError } from '../../../services/api/axios'
+import {
+  deploymentApi,
+  type DeploymentJob,
+  type DeploymentJobStatus,
+  type DeploymentLogEntry,
+  type DeploymentSseEvent,
+  type DeploymentUpdateResponse,
+} from '../../../services/api/deployment'
+import { healthApi } from '../../../services/api/health'
+
+const ACTIVE_JOB_STORAGE_KEY = 'nekro-deployment-active-job-v1'
+const LOG_RENDER_LIMIT = 750
+const RECOVERY_DELAY_MS = 3000
+const MAX_STREAM_FAILURES = 2
+
+const TERMINAL_STATUSES = new Set<DeploymentJobStatus>(['succeeded', 'failed', 'cancelled'])
+
+export type DeploymentConnectionState =
+  | 'idle'
+  | 'connecting'
+  | 'live'
+  | 'waiting_for_backend'
+  | 'polling'
+  | 'job_missing'
+
+interface StoredDeploymentTask {
+  job_id: string
+  client_request_id: string
+  after_seq: number
+  created_at: string
+}
+
+interface TrackingError {
+  code: string
+  message: string
+}
+
+const isStoredTask = (value: unknown): value is StoredDeploymentTask => {
+  if (typeof value !== 'object' || value === null) return false
+  const task = value as Partial<StoredDeploymentTask>
+  return (
+    typeof task.job_id === 'string' &&
+    typeof task.client_request_id === 'string' &&
+    typeof task.after_seq === 'number' &&
+    Number.isFinite(task.after_seq) &&
+    typeof task.created_at === 'string'
+  )
+}
+
+const readStoredTask = (): StoredDeploymentTask | null => {
+  try {
+    const raw = localStorage.getItem(ACTIVE_JOB_STORAGE_KEY)
+    if (!raw) return null
+    const value: unknown = JSON.parse(raw)
+    if (isStoredTask(value)) return value
+    localStorage.removeItem(ACTIVE_JOB_STORAGE_KEY)
+  } catch {
+    localStorage.removeItem(ACTIVE_JOB_STORAGE_KEY)
+  }
+  return null
+}
+
+const persistTask = (task: StoredDeploymentTask | null) => {
+  try {
+    if (task) {
+      localStorage.setItem(ACTIVE_JOB_STORAGE_KEY, JSON.stringify(task))
+    } else {
+      localStorage.removeItem(ACTIVE_JOB_STORAGE_KEY)
+    }
+  } catch {
+    // Storage may be unavailable in private browsing or hardened environments.
+  }
+}
+
+const toTrackingError = (error: unknown): TrackingError => {
+  if (error instanceof ApiError) {
+    return { code: error.type, message: error.message }
+  }
+  if (error instanceof Error) {
+    return { code: error.name || 'UnknownError', message: error.message }
+  }
+  return { code: 'UnknownError', message: 'Unknown deployment tracking error' }
+}
+
+const isJobNotFound = (error: unknown): boolean =>
+  error instanceof ApiError && error.type === 'job_not_found'
+
+export const useDeploymentJob = (enabled: boolean, streamEnabled: boolean) => {
+  const [activeTask, setActiveTask] = useState<StoredDeploymentTask | null>(() =>
+    enabled ? readStoredTask() : null
+  )
+  const [job, setJob] = useState<DeploymentJob | null>(null)
+  const [logs, setLogs] = useState<DeploymentLogEntry[]>([])
+  const [connectionState, setConnectionState] = useState<DeploymentConnectionState>('idle')
+  const [trackingError, setTrackingError] = useState<TrackingError | null>(null)
+  const [isCancelling, setIsCancelling] = useState(false)
+  const activeTaskRef = useRef<StoredDeploymentTask | null>(activeTask)
+  const activeJobId = activeTask?.job_id
+
+  const updateActiveTask = useCallback((task: StoredDeploymentTask | null) => {
+    activeTaskRef.current = task
+    setActiveTask(task)
+    persistTask(task)
+  }, [])
+
+  const updateAfterSeq = useCallback((seq: number | null | undefined) => {
+    if (seq === null || seq === undefined || !Number.isFinite(seq)) return
+    const current = activeTaskRef.current
+    if (!current || seq <= current.after_seq) return
+    const next = { ...current, after_seq: seq }
+    activeTaskRef.current = next
+    setActiveTask(next)
+    persistTask(next)
+  }, [])
+
+  const mergeLogs = useCallback(
+    (entries: DeploymentLogEntry[]) => {
+      if (entries.length === 0) return
+      setLogs(current => {
+        const bySeq = new Map(current.map(entry => [entry.seq, entry]))
+        for (const entry of entries) {
+          if (Number.isFinite(entry.seq)) bySeq.set(entry.seq, entry)
+        }
+        const merged = [...bySeq.values()].sort((left, right) => left.seq - right.seq)
+        return merged.slice(-LOG_RENDER_LIMIT)
+      })
+      updateAfterSeq(Math.max(...entries.map(entry => entry.seq)))
+    },
+    [updateAfterSeq]
+  )
+
+  const startTracking = useCallback(
+    (response: DeploymentUpdateResponse, clientRequestId: string) => {
+      const task: StoredDeploymentTask = {
+        job_id: response.job_id,
+        client_request_id: clientRequestId,
+        after_seq: 0,
+        created_at: new Date().toISOString(),
+      }
+      setLogs([])
+      setTrackingError(null)
+      setJob({
+        job_id: response.job_id,
+        type: response.type,
+        status: response.status,
+        phase: response.phase ?? 'validate_instance',
+        progress: null,
+        error: null,
+        result: null,
+      })
+      setConnectionState('connecting')
+      updateActiveTask(task)
+    },
+    [updateActiveTask]
+  )
+
+  const dismissCompletedJob = useCallback(() => {
+    if (activeTaskRef.current) return
+    setJob(null)
+    setLogs([])
+    setTrackingError(null)
+    setConnectionState('idle')
+  }, [])
+
+  const cancelActiveJob = useCallback(async () => {
+    const task = activeTaskRef.current
+    if (!task || isCancelling) return
+    setIsCancelling(true)
+    try {
+      const response = await deploymentApi.cancelJob(task.job_id)
+      setJob(current =>
+        current
+          ? { ...current, status: response.status, phase: response.phase ?? current.phase }
+          : current
+      )
+    } finally {
+      setIsCancelling(false)
+    }
+  }, [isCancelling])
+
+  useEffect(() => {
+    if (enabled) {
+      if (!activeTaskRef.current) {
+        const storedTask = readStoredTask()
+        if (storedTask) {
+          activeTaskRef.current = storedTask
+          setActiveTask(storedTask)
+        }
+      }
+    } else {
+      activeTaskRef.current = null
+      setActiveTask(null)
+      setConnectionState('idle')
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    if (!enabled || !activeJobId) return
+
+    let disposed = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let streamCleanup: (() => void) | null = null
+    let streamFailures = 0
+
+    const clearTimer = () => {
+      if (timer !== null) {
+        clearTimeout(timer)
+        timer = null
+      }
+    }
+
+    const stopStream = () => {
+      streamCleanup?.()
+      streamCleanup = null
+    }
+
+    const completeTracking = () => {
+      clearTimer()
+      stopStream()
+      updateActiveTask(null)
+      setConnectionState('idle')
+    }
+
+    const markJobMissing = (error: unknown) => {
+      clearTimer()
+      stopStream()
+      updateActiveTask(null)
+      setTrackingError(toTrackingError(error))
+      setConnectionState('job_missing')
+    }
+
+    const mergeJobEvent = (event: DeploymentSseEvent) => {
+      if (event.event === 'log') {
+        mergeLogs([event.data])
+        return
+      }
+
+      if ('seq' in event.data) updateAfterSeq(event.data.seq)
+
+      if (event.event === 'job') {
+        setJob(current =>
+          current ? { ...current, status: event.data.status, phase: event.data.phase } : current
+        )
+        return
+      }
+
+      if (event.event === 'progress') {
+        setJob(current => (current ? { ...current, progress: event.data } : current))
+        return
+      }
+
+      if (event.event === 'result') {
+        setJob(current =>
+          current
+            ? {
+                ...current,
+                status: event.data.status,
+                phase: event.data.status === 'succeeded' ? 'finished' : current.phase,
+                result: event.data.result ?? current.result,
+                error: event.data.error ?? current.error,
+              }
+            : current
+        )
+        if (TERMINAL_STATUSES.has(event.data.status)) completeTracking()
+      }
+    }
+
+    const refreshJobAndLogs = async (): Promise<boolean> => {
+      const task = activeTaskRef.current
+      if (!task) return false
+      const nextJob = await deploymentApi.getJob(task.job_id)
+      if (disposed) return false
+      setJob(nextJob)
+
+      const logResponse = await deploymentApi.getJobLogs(
+        task.job_id,
+        activeTaskRef.current?.after_seq
+      )
+      if (disposed) return false
+      mergeLogs(logResponse.logs)
+      updateAfterSeq(logResponse.next_after_seq)
+
+      if (TERMINAL_STATUSES.has(nextJob.status)) {
+        completeTracking()
+        return false
+      }
+      return true
+    }
+
+    const scheduleRecovery = () => {
+      if (disposed || timer !== null) return
+      setConnectionState('waiting_for_backend')
+      timer = setTimeout(() => {
+        timer = null
+        void recoverBackend()
+      }, RECOVERY_DELAY_MS)
+    }
+
+    const schedulePolling = () => {
+      if (disposed || timer !== null) return
+      setConnectionState('polling')
+      timer = setTimeout(() => {
+        timer = null
+        void pollJob()
+      }, RECOVERY_DELAY_MS)
+    }
+
+    const handleStreamFailure = (error: unknown) => {
+      if (disposed) return
+      stopStream()
+      streamFailures += 1
+      const nextError = toTrackingError(error)
+      setTrackingError(
+        nextError.code === 'Error' || nextError.code === 'TypeError'
+          ? { code: 'stream_disconnected', message: '' }
+          : nextError
+      )
+      scheduleRecovery()
+    }
+
+    const startStream = () => {
+      const task = activeTaskRef.current
+      if (!task || disposed) return
+      stopStream()
+      setConnectionState('connecting')
+      streamCleanup = deploymentApi.subscribeJobEvents(task.job_id, {
+        afterSeq: task.after_seq,
+        onEvent: event => {
+          if (disposed) return
+          setConnectionState('live')
+          setTrackingError(null)
+          if (event.event === 'error') {
+            handleStreamFailure(
+              new ApiError(event.data.code, event.data.message, null, event.data.details)
+            )
+            return
+          }
+          mergeJobEvent(event)
+        },
+        onError: handleStreamFailure,
+      })
+    }
+
+    const recoverBackend = async () => {
+      if (disposed) return
+      try {
+        await healthApi.check()
+        const stillActive = await refreshJobAndLogs()
+        if (!stillActive || disposed) return
+        setTrackingError(null)
+        if (streamEnabled && streamFailures < MAX_STREAM_FAILURES) {
+          startStream()
+        } else {
+          schedulePolling()
+        }
+      } catch (error) {
+        if (isJobNotFound(error)) {
+          markJobMissing(error)
+          return
+        }
+        setTrackingError(toTrackingError(error))
+        scheduleRecovery()
+      }
+    }
+
+    const pollJob = async () => {
+      if (disposed) return
+      try {
+        const stillActive = await refreshJobAndLogs()
+        if (!stillActive || disposed) return
+        setTrackingError(null)
+        schedulePolling()
+      } catch (error) {
+        if (isJobNotFound(error)) {
+          markJobMissing(error)
+          return
+        }
+        setTrackingError(toTrackingError(error))
+        scheduleRecovery()
+      }
+    }
+
+    const initialize = async () => {
+      setConnectionState('connecting')
+      try {
+        const stillActive = await refreshJobAndLogs()
+        if (!stillActive || disposed) return
+        setTrackingError(null)
+        if (streamEnabled) {
+          startStream()
+        } else {
+          schedulePolling()
+        }
+      } catch (error) {
+        if (isJobNotFound(error)) {
+          markJobMissing(error)
+          return
+        }
+        setTrackingError(toTrackingError(error))
+        scheduleRecovery()
+      }
+    }
+
+    void initialize()
+
+    return () => {
+      disposed = true
+      clearTimer()
+      stopStream()
+    }
+  }, [activeJobId, enabled, mergeLogs, streamEnabled, updateActiveTask, updateAfterSeq])
+
+  return {
+    activeTask,
+    job,
+    logs,
+    connectionState,
+    trackingError,
+    isCancelling,
+    startTracking,
+    cancelActiveJob,
+    dismissCompletedJob,
+  }
+}

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -175,6 +175,10 @@ const router = createHashRouter([
             element: lazyLoad(() => import('../pages/settings/space-cleanup')),
           },
           {
+            path: 'deployment',
+            element: lazyLoad(() => import('../pages/settings/deployment')),
+          },
+          {
             path: 'commands',
             element: lazyLoad(() => import('../pages/settings/commands')),
           },

--- a/frontend/src/services/api/axios.ts
+++ b/frontend/src/services/api/axios.ts
@@ -2,7 +2,12 @@ import axios, { AxiosError } from 'axios'
 import i18n from '../../config/i18n'
 import { useAuthStore } from '../../stores/auth'
 import { config } from '../../config/env'
-import type { ApiErrorResponse } from './types'
+import {
+  isApiErrorResponse,
+  isProtocolApiErrorResponse,
+  type ApiErrorResponse,
+  type ProtocolApiErrorResponse,
+} from './types'
 import { getCurrentAppPath, loginPath, sanitizeRedirectTarget } from '../../router/routes'
 
 /**
@@ -18,12 +23,7 @@ export class ApiError extends Error {
   /** 附加数据（可选） */
   public readonly data?: unknown
 
-  constructor(
-    type: string,
-    message: string,
-    detail?: string | null,
-    data?: unknown
-  ) {
+  constructor(type: string, message: string, detail?: string | null, data?: unknown) {
     super(message)
     this.name = 'ApiError'
     this.type = type
@@ -74,11 +74,14 @@ axiosInstance.interceptors.response.use(
   response => response,
 
   // 错误响应：统一处理
-  async (error: AxiosError<ApiErrorResponse>) => {
+  async (error: AxiosError<ApiErrorResponse | ProtocolApiErrorResponse>) => {
     // 网络错误
     if (!error.response) {
       if (error.message === 'Network Error') {
-        throw new ApiError('NetworkError', i18n.t('networkError', { ns: 'errors', defaultValue: '网络连接失败，请检查网络设置' }))
+        throw new ApiError(
+          'NetworkError',
+          i18n.t('networkError', { ns: 'errors', defaultValue: '网络连接失败，请检查网络设置' })
+        )
       }
       throw new ApiError('UnknownError', error.message)
     }
@@ -87,10 +90,12 @@ axiosInstance.interceptors.response.use(
 
     // 401 未授权
     if (status === 401) {
+      const authError = isApiErrorResponse(data) ? data : null
       // 非登录接口的 401，执行登出
       if (!error.config?.url?.includes('/user/login')) {
         const sessionMessage =
-          data?.message || i18n.t('sessionExpired', { ns: 'errors', defaultValue: '登录已过期，请重新登录' })
+          authError?.message ||
+          i18n.t('sessionExpired', { ns: 'errors', defaultValue: '登录已过期，请重新登录' })
         try {
           sessionStorage.setItem('auth_error', sessionMessage)
         } catch {
@@ -102,15 +107,19 @@ axiosInstance.interceptors.response.use(
       }
       // 使用后端返回的本地化消息，或使用前端翻译
       throw new ApiError(
-        data?.error || 'UnauthorizedError',
-        data?.message || i18n.t('unauthorized', { ns: 'errors', defaultValue: '未授权访问' }),
-        data?.detail
+        authError?.error || 'UnauthorizedError',
+        authError?.message || i18n.t('unauthorized', { ns: 'errors', defaultValue: '未授权访问' }),
+        authError?.detail
       )
     }
 
     // 后端返回了标准错误格式
-    if (data?.error && data?.message) {
+    if (isApiErrorResponse(data)) {
       throw new ApiError(data.error, data.message, data.detail, data.data)
+    }
+
+    if (isProtocolApiErrorResponse(data)) {
+      throw new ApiError(data.error.code, data.error.message, null, data.error.details)
     }
 
     // 兜底处理

--- a/frontend/src/services/api/deployment.ts
+++ b/frontend/src/services/api/deployment.ts
@@ -1,0 +1,267 @@
+import axios from './axios'
+import { createEventStream } from './utils/stream'
+
+export type DeploymentJobStatus =
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'cancel_requested'
+  | 'cancelled'
+
+export type DeploymentJobType = 'update' | 'backup' | 'restore'
+
+export type DeploymentPhase =
+  | 'validate_instance'
+  | 'backup'
+  | 'switch_channel'
+  | 'pull_images'
+  | 'restart_services'
+  | 'pull_sandbox'
+  | 'verify'
+  | 'finished'
+
+export interface DeploymentUnavailableReason {
+  code: string
+  message: string
+}
+
+export interface DeploymentSupports {
+  update?: boolean
+  preview?: boolean
+  rollback?: boolean
+  backup?: boolean
+  restore?: boolean
+  restore_pre_preview?: boolean
+  cancel?: boolean
+  log_stream?: boolean
+  daemon_update?: boolean
+  [key: string]: boolean | undefined
+}
+
+export interface DeploymentCapabilities {
+  enabled: boolean
+  provider: string | null
+  platform: string
+  protocol_version: string | null
+  instance_id: string | null
+  supports: DeploymentSupports
+  limits: Record<string, unknown>
+  unavailable_reason: DeploymentUnavailableReason | null
+}
+
+export interface DeploymentInstance {
+  channel: string | null
+  image: string | null
+  container_status: string | null
+  app_health: string | null
+  docker_ok: boolean
+  compose_ok: boolean
+}
+
+export interface DeploymentAgentVersion {
+  current_version: string
+  latest_version: string | null
+  update_available: boolean
+  checked: boolean
+  error_code: string | null
+  error_message: string | null
+}
+
+export interface DeploymentUpdateRequest {
+  channel: 'stable' | 'preview' | 'rollback'
+  backup: boolean
+  update_sandbox: boolean
+  update_cc_sandbox: boolean
+  restore_pre_preview: boolean
+  client_request_id: string
+}
+
+export interface DeploymentCreateBackupRequest {
+  name?: string
+  client_request_id: string
+}
+
+export interface DeploymentRestoreRequest {
+  backup_id: string
+  client_request_id: string
+}
+
+export interface DeploymentUpdateResponse {
+  job_id: string
+  type?: DeploymentJobType
+  status: DeploymentJobStatus
+  phase?: DeploymentPhase
+  message?: string
+}
+
+export interface DeploymentBackupSummary {
+  backup_id: string
+  filename: string
+  name: string | null
+  created_at: string
+  size_bytes: number
+}
+
+export interface DeploymentBackupsResponse {
+  backups: DeploymentBackupSummary[]
+}
+
+export interface DeploymentJobProgress {
+  current: number | null
+  total: number | null
+  label: string
+}
+
+export interface DeploymentJobError {
+  code: string
+  message: string
+  details?: Record<string, unknown>
+}
+
+export interface DeploymentJobResult {
+  channel?: string
+  image?: string
+  app_health?: string
+  [key: string]: unknown
+}
+
+export interface DeploymentJob {
+  job_id: string
+  type?: DeploymentJobType
+  status: DeploymentJobStatus
+  phase: DeploymentPhase
+  progress: DeploymentJobProgress | null
+  created_at?: string | null
+  started_at?: string | null
+  finished_at?: string | null
+  exit_code?: number | null
+  error: DeploymentJobError | null
+  result: DeploymentJobResult | null
+}
+
+export interface DeploymentLogEntry {
+  seq: number
+  ts?: string
+  level: string
+  stream: string
+  line: string
+}
+
+export interface DeploymentJobLogsResponse {
+  job_id: string
+  logs: DeploymentLogEntry[]
+  next_after_seq: number | null
+}
+
+export type DeploymentSseEventName = 'job' | 'progress' | 'log' | 'result' | 'error'
+
+export type DeploymentSseEvent =
+  | { event: 'job'; data: { seq?: number; status: DeploymentJobStatus; phase: DeploymentPhase } }
+  | { event: 'progress'; data: { seq?: number } & DeploymentJobProgress }
+  | { event: 'log'; data: DeploymentLogEntry }
+  | {
+      event: 'result'
+      data: {
+        seq?: number
+        status: 'succeeded' | 'failed' | 'cancelled'
+        result?: DeploymentJobResult
+        error?: DeploymentJobError
+      }
+    }
+  | { event: 'error'; data: DeploymentJobError }
+
+const parseSseEvent = (eventName: string, rawData: string): DeploymentSseEvent | null => {
+  if (!['job', 'progress', 'log', 'result', 'error'].includes(eventName)) {
+    return null
+  }
+
+  try {
+    const data: unknown = JSON.parse(rawData)
+    if (typeof data !== 'object' || data === null) {
+      return null
+    }
+    return { event: eventName, data } as DeploymentSseEvent
+  } catch {
+    return null
+  }
+}
+
+export const deploymentApi = {
+  getCapabilities: async () => {
+    const response = await axios.get<DeploymentCapabilities>('/deployment/capabilities')
+    return response.data
+  },
+
+  getInstance: async () => {
+    const response = await axios.get<DeploymentInstance>('/deployment/instance')
+    return response.data
+  },
+
+  getAgentVersion: async () => {
+    const response = await axios.get<DeploymentAgentVersion>('/deployment/agent-version')
+    return response.data
+  },
+
+  createUpdate: async (request: DeploymentUpdateRequest) => {
+    const response = await axios.post<DeploymentUpdateResponse>('/deployment/update', request)
+    return response.data
+  },
+
+  listBackups: async (limit = 50) => {
+    const response = await axios.get<DeploymentBackupsResponse>('/deployment/backups', {
+      params: { limit },
+    })
+    return response.data
+  },
+
+  createBackup: async (request: DeploymentCreateBackupRequest) => {
+    const response = await axios.post<DeploymentUpdateResponse>('/deployment/backup', request)
+    return response.data
+  },
+
+  createRestore: async (request: DeploymentRestoreRequest) => {
+    const response = await axios.post<DeploymentUpdateResponse>('/deployment/restore', request)
+    return response.data
+  },
+
+  getJob: async (jobId: string) => {
+    const response = await axios.get<DeploymentJob>(`/deployment/jobs/${encodeURIComponent(jobId)}`)
+    return response.data
+  },
+
+  getJobLogs: async (jobId: string, afterSeq?: number, limit = 1000) => {
+    const response = await axios.get<DeploymentJobLogsResponse>(
+      `/deployment/jobs/${encodeURIComponent(jobId)}/logs`,
+      { params: { after_seq: afterSeq, limit } }
+    )
+    return response.data
+  },
+
+  subscribeJobEvents: (
+    jobId: string,
+    options: {
+      afterSeq?: number
+      onEvent: (event: DeploymentSseEvent) => void
+      onError: (error: Error) => void
+    }
+  ) => {
+    const query = options.afterSeq === undefined ? '' : `?after_seq=${options.afterSeq}`
+    return createEventStream({
+      endpoint: `/deployment/jobs/${encodeURIComponent(jobId)}/events${query}`,
+      autoReconnect: false,
+      onEvent: (eventName, data) => {
+        const event = parseSseEvent(eventName, data)
+        if (event) options.onEvent(event)
+      },
+      onError: options.onError,
+    })
+  },
+
+  cancelJob: async (jobId: string) => {
+    const response = await axios.post<DeploymentUpdateResponse>(
+      `/deployment/jobs/${encodeURIComponent(jobId)}/cancel`
+    )
+    return response.data
+  },
+}

--- a/frontend/src/services/api/types.ts
+++ b/frontend/src/services/api/types.ts
@@ -26,6 +26,14 @@ export interface ApiErrorResponse {
   data?: unknown
 }
 
+export interface ProtocolApiErrorResponse {
+  error: {
+    code: string
+    message: string
+    details?: unknown
+  }
+}
+
 /**
  * 获取本地化文本
  *
@@ -64,3 +72,18 @@ export function isApiErrorResponse(data: unknown): data is ApiErrorResponse {
   )
 }
 
+export function isProtocolApiErrorResponse(data: unknown): data is ProtocolApiErrorResponse {
+  if (typeof data !== 'object' || data === null || !('error' in data)) {
+    return false
+  }
+
+  const error = (data as { error?: unknown }).error
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    'message' in error &&
+    typeof (error as { code?: unknown }).code === 'string' &&
+    typeof (error as { message?: unknown }).message === 'string'
+  )
+}

--- a/frontend/src/services/api/utils/stream.ts
+++ b/frontend/src/services/api/utils/stream.ts
@@ -3,7 +3,8 @@ import { useAuthStore } from '../../../stores/auth'
 import { config } from '../../../config/env'
 
 export interface StreamOptions {
-  onMessage: (data: string) => void
+  onMessage?: (data: string) => void
+  onEvent?: (eventName: string, data: string) => void
   onError?: (error: Error) => void
   /** SSE 连接断开后自动重连成功时触发（首次连接不触发） */
   onReconnect?: () => void
@@ -12,6 +13,7 @@ export interface StreamOptions {
   method?: 'GET' | 'POST'
   body?: Record<string, unknown>
   signal?: AbortSignal
+  autoReconnect?: boolean
 }
 
 export interface SharedStreamSubscriber {
@@ -27,6 +29,7 @@ export interface SharedStreamSubscriber {
 export const createEventStream = (options: StreamOptions) => {
   const {
     onMessage,
+    onEvent,
     onError,
     onReconnect,
     endpoint,
@@ -34,6 +37,7 @@ export const createEventStream = (options: StreamOptions) => {
     method = 'GET',
     body,
     signal,
+    autoReconnect = true,
   } = options
 
   if (!baseUrl) throw new Error('API 基础 URL 未配置')
@@ -46,6 +50,7 @@ export const createEventStream = (options: StreamOptions) => {
 
   let isFirstOpen = true
   let retryDelayMs = 1000
+  let errorReported = false
 
   try {
     // 创建 EventSource 连接
@@ -69,17 +74,25 @@ export const createEventStream = (options: StreamOptions) => {
         }
       },
       onmessage(ev: EventSourceMessage) {
-        onMessage(ev.data)
+        onEvent?.(ev.event || 'message', ev.data)
+        onMessage?.(ev.data)
       },
       onerror(err: Error) {
         if (signal?.aborted || controller.signal.aborted) return
+        errorReported = true
         if (onError) onError(err)
+        if (!autoReconnect) throw err
         const currentDelay = retryDelayMs
         retryDelayMs = Math.min(retryDelayMs * 2, 5000)
         return currentDelay
       },
+      onclose() {
+        if (signal?.aborted || controller.signal.aborted || autoReconnect) return
+        throw new Error('SSE connection closed')
+      },
     }).catch(err => {
-      if (onError && err instanceof Error) {
+      if (signal?.aborted || controller.signal.aborted) return
+      if (!errorReported && onError && err instanceof Error) {
         onError(err)
       }
     })

--- a/nekro_agent/routers/__init__.py
+++ b/nekro_agent/routers/__init__.py
@@ -32,6 +32,7 @@ from .commands import router as commands_router
 from .common import router as common_router
 from .config import router as config_router
 from .dashboard import router as dashboard_router
+from .deployment import router as deployment_router
 from .email import router as email_router
 from .events import router as events_router
 from .kb_library import router as kb_library_router
@@ -133,6 +134,7 @@ def mount_api_routes(app: FastAPI):
     api.include_router(plugin_editor_router)
     api.include_router(sandbox_router)
     api.include_router(dashboard_router)
+    api.include_router(deployment_router)
     api.include_router(chat_channel_router)
     api.include_router(webhook_router)
     api.include_router(presets_router)

--- a/nekro_agent/routers/deployment.py
+++ b/nekro_agent/routers/deployment.py
@@ -17,6 +17,9 @@ from nekro_agent.services.deployment.schemas import (
     DeploymentCapabilitiesResponse,
     DeploymentCreateBackupRequest,
     DeploymentInstanceResponse,
+    DeploymentJobLogsResponse,
+    DeploymentJobResponse,
+    DeploymentProxyErrorResponse,
     DeploymentRestoreRequest,
     DeploymentUpdateRequest,
 )
@@ -102,6 +105,15 @@ def _error_response(exc: DeploymentProxyError) -> JSONResponse:
     return JSONResponse(status_code=exc.status_code, content=exc.payload())
 
 
+DEPLOYMENT_ERROR_RESPONSES = {
+    400: {"model": DeploymentProxyErrorResponse},
+    404: {"model": DeploymentProxyErrorResponse},
+    409: {"model": DeploymentProxyErrorResponse},
+    502: {"model": DeploymentProxyErrorResponse},
+    503: {"model": DeploymentProxyErrorResponse},
+}
+
+
 @router.get("/capabilities", summary="获取部署更新能力", response_model=DeploymentCapabilitiesResponse)
 async def get_deployment_capabilities(
     _current_user: DBUser = Depends(get_current_active_user),
@@ -110,7 +122,12 @@ async def get_deployment_capabilities(
     return await client.get_capabilities()
 
 
-@router.get("/instance", summary="获取当前部署实例", response_model=DeploymentInstanceResponse)
+@router.get(
+    "/instance",
+    summary="获取当前部署实例",
+    response_model=DeploymentInstanceResponse,
+    responses=DEPLOYMENT_ERROR_RESPONSES,
+)
 async def get_deployment_instance(
     _current_user: DBUser = Depends(get_current_active_user),
     client: DeploymentDaemonClient = Depends(get_deployment_client),
@@ -129,7 +146,12 @@ async def get_deployment_agent_version(
     return await build_agent_version_response(fetch_latest_version)
 
 
-@router.post("/update", summary="创建部署更新任务", response_model=None)
+@router.post(
+    "/update",
+    summary="创建部署更新任务",
+    response_model=DeploymentJobResponse,
+    responses=DEPLOYMENT_ERROR_RESPONSES,
+)
 async def create_deployment_update(
     body: DeploymentUpdateRequest,
     current_user: DBUser = Depends(get_current_active_user),
@@ -141,7 +163,12 @@ async def create_deployment_update(
         return _error_response(exc)
 
 
-@router.get("/backups", summary="查询部署备份列表", response_model=DeploymentBackupsResponse)
+@router.get(
+    "/backups",
+    summary="查询部署备份列表",
+    response_model=DeploymentBackupsResponse,
+    responses=DEPLOYMENT_ERROR_RESPONSES,
+)
 async def list_deployment_backups(
     name: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=100),
@@ -154,7 +181,12 @@ async def list_deployment_backups(
         return _error_response(exc)
 
 
-@router.post("/backup", summary="创建部署备份任务", response_model=None)
+@router.post(
+    "/backup",
+    summary="创建部署备份任务",
+    response_model=DeploymentJobResponse,
+    responses=DEPLOYMENT_ERROR_RESPONSES,
+)
 async def create_deployment_backup(
     body: DeploymentCreateBackupRequest,
     current_user: DBUser = Depends(get_current_active_user),
@@ -166,7 +198,12 @@ async def create_deployment_backup(
         return _error_response(exc)
 
 
-@router.post("/restore", summary="创建部署还原任务", response_model=None)
+@router.post(
+    "/restore",
+    summary="创建部署还原任务",
+    response_model=DeploymentJobResponse,
+    responses=DEPLOYMENT_ERROR_RESPONSES,
+)
 async def create_deployment_restore(
     body: DeploymentRestoreRequest,
     current_user: DBUser = Depends(get_current_active_user),
@@ -178,7 +215,12 @@ async def create_deployment_restore(
         return _error_response(exc)
 
 
-@router.get("/jobs/{job_id}", summary="查询部署更新任务", response_model=None)
+@router.get(
+    "/jobs/{job_id}",
+    summary="查询部署更新任务",
+    response_model=DeploymentJobResponse,
+    responses=DEPLOYMENT_ERROR_RESPONSES,
+)
 async def get_deployment_job(
     job_id: str,
     _current_user: DBUser = Depends(get_current_active_user),
@@ -190,7 +232,12 @@ async def get_deployment_job(
         return _error_response(exc)
 
 
-@router.get("/jobs/{job_id}/logs", summary="查询部署更新日志", response_model=None)
+@router.get(
+    "/jobs/{job_id}/logs",
+    summary="查询部署更新日志",
+    response_model=DeploymentJobLogsResponse,
+    responses=DEPLOYMENT_ERROR_RESPONSES,
+)
 async def get_deployment_job_logs(
     job_id: str,
     after_seq: int | None = Query(default=None, ge=0),
@@ -227,7 +274,12 @@ async def stream_deployment_job_events(
     return EventSourceResponse(event_generator())
 
 
-@router.post("/jobs/{job_id}/cancel", summary="取消部署更新任务", response_model=None)
+@router.post(
+    "/jobs/{job_id}/cancel",
+    summary="取消部署更新任务",
+    response_model=DeploymentJobResponse,
+    responses=DEPLOYMENT_ERROR_RESPONSES,
+)
 async def cancel_deployment_job(
     job_id: str,
     _current_user: DBUser = Depends(get_current_active_user),

--- a/nekro_agent/routers/deployment.py
+++ b/nekro_agent/routers/deployment.py
@@ -1,0 +1,239 @@
+"""Deployment update proxy routes."""
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import JSONResponse
+from sse_starlette.sse import EventSourceResponse
+
+from nekro_agent.models.db_user import DBUser
+from nekro_agent.services.deployment.client import DeploymentDaemonClient, DeploymentProxyError
+from nekro_agent.services.deployment.schemas import (
+    DeploymentAgentVersionResponse,
+    DeploymentBackupsResponse,
+    DeploymentCapabilitiesResponse,
+    DeploymentCreateBackupRequest,
+    DeploymentInstanceResponse,
+    DeploymentRestoreRequest,
+    DeploymentUpdateRequest,
+)
+from nekro_agent.services.user.deps import get_current_active_user
+from nekro_agent.tools.common_util import compare_semver, get_app_version
+
+router = APIRouter(prefix="/deployment", tags=["Deployment"])
+LATEST_AGENT_VERSION_URL = "https://cloud.nekro.ai/api/na/latest-version"
+LatestAgentVersionFetcher = Callable[[], Awaitable[str | None]]
+
+
+def get_deployment_client() -> DeploymentDaemonClient:
+    return DeploymentDaemonClient()
+
+
+async def fetch_latest_agent_version() -> str | None:
+    async with httpx.AsyncClient(timeout=8.0, follow_redirects=True) as client:
+        response = await client.get(LATEST_AGENT_VERSION_URL)
+        response.raise_for_status()
+    return _extract_latest_agent_version(response.json())
+
+
+def _extract_latest_agent_version(payload: Any) -> str | None:
+    if not isinstance(payload, dict) or payload.get("success") is not True:
+        return None
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return None
+    latest_version = data.get("latestVersion")
+    return str(latest_version).strip() if latest_version else None
+
+
+def get_latest_agent_version_fetcher() -> LatestAgentVersionFetcher:
+    return fetch_latest_agent_version
+
+
+def _normalize_version(value: str | None) -> str:
+    return (value or "").strip().lstrip("vV")
+
+
+async def build_agent_version_response(
+    fetch_latest_version: LatestAgentVersionFetcher,
+) -> DeploymentAgentVersionResponse:
+    current_version = get_app_version()
+    normalized_current = _normalize_version(current_version)
+    if not normalized_current or normalized_current == "unknown":
+        return DeploymentAgentVersionResponse(
+            current_version=current_version,
+            checked=False,
+            error_code="local_version_unknown",
+            error_message="无法读取当前 Nekro Agent 版本",
+        )
+
+    try:
+        latest_version = await fetch_latest_version()
+    except (httpx.HTTPError, ValueError) as exc:
+        return DeploymentAgentVersionResponse(
+            current_version=current_version,
+            checked=False,
+            error_code="latest_version_unavailable",
+            error_message=f"无法获取 Nekro Agent 最新版本: {exc}",
+        )
+
+    normalized_latest = _normalize_version(latest_version)
+    if not normalized_latest:
+        return DeploymentAgentVersionResponse(
+            current_version=current_version,
+            latest_version=latest_version,
+            checked=False,
+            error_code="latest_version_missing",
+            error_message="云端版本接口未返回有效的 Nekro Agent 最新版本",
+        )
+
+    return DeploymentAgentVersionResponse(
+        current_version=current_version,
+        latest_version=latest_version,
+        update_available=compare_semver(normalized_current, normalized_latest) < 0,
+        checked=True,
+    )
+
+
+def _error_response(exc: DeploymentProxyError) -> JSONResponse:
+    return JSONResponse(status_code=exc.status_code, content=exc.payload())
+
+
+@router.get("/capabilities", summary="获取部署更新能力", response_model=DeploymentCapabilitiesResponse)
+async def get_deployment_capabilities(
+    _current_user: DBUser = Depends(get_current_active_user),
+    client: DeploymentDaemonClient = Depends(get_deployment_client),
+) -> DeploymentCapabilitiesResponse:
+    return await client.get_capabilities()
+
+
+@router.get("/instance", summary="获取当前部署实例", response_model=DeploymentInstanceResponse)
+async def get_deployment_instance(
+    _current_user: DBUser = Depends(get_current_active_user),
+    client: DeploymentDaemonClient = Depends(get_deployment_client),
+) -> DeploymentInstanceResponse | JSONResponse:
+    try:
+        return await client.get_instance()
+    except DeploymentProxyError as exc:
+        return _error_response(exc)
+
+
+@router.get("/agent-version", summary="检查 Nekro Agent 应用版本", response_model=DeploymentAgentVersionResponse)
+async def get_deployment_agent_version(
+    _current_user: DBUser = Depends(get_current_active_user),
+    fetch_latest_version: LatestAgentVersionFetcher = Depends(get_latest_agent_version_fetcher),
+) -> DeploymentAgentVersionResponse:
+    return await build_agent_version_response(fetch_latest_version)
+
+
+@router.post("/update", summary="创建部署更新任务", response_model=None)
+async def create_deployment_update(
+    body: DeploymentUpdateRequest,
+    current_user: DBUser = Depends(get_current_active_user),
+    client: DeploymentDaemonClient = Depends(get_deployment_client),
+) -> dict[str, Any] | JSONResponse:
+    try:
+        return await client.create_update(body, username=current_user.username)
+    except DeploymentProxyError as exc:
+        return _error_response(exc)
+
+
+@router.get("/backups", summary="查询部署备份列表", response_model=DeploymentBackupsResponse)
+async def list_deployment_backups(
+    name: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=100),
+    _current_user: DBUser = Depends(get_current_active_user),
+    client: DeploymentDaemonClient = Depends(get_deployment_client),
+) -> DeploymentBackupsResponse | JSONResponse:
+    try:
+        return await client.list_backups(name=name, limit=limit)
+    except DeploymentProxyError as exc:
+        return _error_response(exc)
+
+
+@router.post("/backup", summary="创建部署备份任务", response_model=None)
+async def create_deployment_backup(
+    body: DeploymentCreateBackupRequest,
+    current_user: DBUser = Depends(get_current_active_user),
+    client: DeploymentDaemonClient = Depends(get_deployment_client),
+) -> dict[str, Any] | JSONResponse:
+    try:
+        return await client.create_backup(body, username=current_user.username)
+    except DeploymentProxyError as exc:
+        return _error_response(exc)
+
+
+@router.post("/restore", summary="创建部署还原任务", response_model=None)
+async def create_deployment_restore(
+    body: DeploymentRestoreRequest,
+    current_user: DBUser = Depends(get_current_active_user),
+    client: DeploymentDaemonClient = Depends(get_deployment_client),
+) -> dict[str, Any] | JSONResponse:
+    try:
+        return await client.create_restore(body, username=current_user.username)
+    except DeploymentProxyError as exc:
+        return _error_response(exc)
+
+
+@router.get("/jobs/{job_id}", summary="查询部署更新任务", response_model=None)
+async def get_deployment_job(
+    job_id: str,
+    _current_user: DBUser = Depends(get_current_active_user),
+    client: DeploymentDaemonClient = Depends(get_deployment_client),
+) -> dict[str, Any] | JSONResponse:
+    try:
+        return await client.get_job(job_id)
+    except DeploymentProxyError as exc:
+        return _error_response(exc)
+
+
+@router.get("/jobs/{job_id}/logs", summary="查询部署更新日志", response_model=None)
+async def get_deployment_job_logs(
+    job_id: str,
+    after_seq: int | None = Query(default=None, ge=0),
+    limit: int = Query(default=200, ge=1, le=1000),
+    _current_user: DBUser = Depends(get_current_active_user),
+    client: DeploymentDaemonClient = Depends(get_deployment_client),
+) -> dict[str, Any] | JSONResponse:
+    try:
+        return await client.get_job_logs(job_id, after_seq=after_seq, limit=limit)
+    except DeploymentProxyError as exc:
+        return _error_response(exc)
+
+
+@router.get("/jobs/{job_id}/events", summary="代理部署更新事件流")
+async def stream_deployment_job_events(
+    request: Request,
+    job_id: str,
+    after_seq: int | None = Query(default=None, ge=0),
+    _current_user: DBUser = Depends(get_current_active_user),
+    client: DeploymentDaemonClient = Depends(get_deployment_client),
+) -> EventSourceResponse:
+    async def event_generator():
+        try:
+            async for event in client.stream_events(job_id, after_seq=after_seq):
+                if await request.is_disconnected():
+                    return
+                yield event
+        except DeploymentProxyError as exc:
+            yield {
+                "event": "error",
+                "data": json.dumps(exc.payload()["error"], ensure_ascii=False),
+            }
+
+    return EventSourceResponse(event_generator())
+
+
+@router.post("/jobs/{job_id}/cancel", summary="取消部署更新任务", response_model=None)
+async def cancel_deployment_job(
+    job_id: str,
+    _current_user: DBUser = Depends(get_current_active_user),
+    client: DeploymentDaemonClient = Depends(get_deployment_client),
+) -> dict[str, Any] | JSONResponse:
+    try:
+        return await client.cancel_job(job_id)
+    except DeploymentProxyError as exc:
+        return _error_response(exc)

--- a/nekro_agent/services/deployment/__init__.py
+++ b/nekro_agent/services/deployment/__init__.py
@@ -1,0 +1,2 @@
+"""Deployment update proxy service."""
+

--- a/nekro_agent/services/deployment/client.py
+++ b/nekro_agent/services/deployment/client.py
@@ -206,7 +206,9 @@ class DeploymentDaemonClient:
         params: dict[str, int] = {"limit": limit}
         if after_seq is not None:
             params["after_seq"] = after_seq
-        return await self._request_json("GET", f"/jobs/{job_id}/logs", config=self._load_available_config(), params=params)
+        return await self._request_json(
+            "GET", f"/jobs/{job_id}/logs", config=self._load_available_config(), params=params
+        )
 
     async def cancel_job(self, job_id: str) -> dict[str, Any]:
         capabilities = await self.get_capabilities()
@@ -250,7 +252,14 @@ class DeploymentDaemonClient:
                 code="daemon_token_missing",
                 message="未找到 NA-Tools daemon token，请重新运行 na-tools bind 或检查 daemon 配置",
             )
-        if not token_path.read_bytes().strip():
+        try:
+            token = token_path.read_bytes().strip()
+        except OSError:
+            return UnavailableReason(
+                code="daemon_unavailable",
+                message="无法读取 NA-Tools daemon token，请检查文件权限或重新运行 na-tools bind",
+            )
+        if not token:
             return UnavailableReason(
                 code="daemon_token_missing",
                 message="NA-Tools daemon token 为空，请重新运行 na-tools bind",
@@ -312,8 +321,12 @@ class DeploymentDaemonClient:
     ) -> AsyncIterator[dict[str, str]]:
         request = self._build_request("GET", path, config=config, params=params)
         try:
-            async with self._create_client(config, timeout=httpx.Timeout(connect=8.0, read=None, write=8.0, pool=8.0)) as client:
-                async with client.stream("GET", request.url, headers={**request.headers, "Accept": "text/event-stream"}) as response:
+            async with self._create_client(
+                config, timeout=httpx.Timeout(connect=8.0, read=None, write=8.0, pool=8.0)
+            ) as client:
+                async with client.stream(
+                    "GET", request.url, headers={**request.headers, "Accept": "text/event-stream"}
+                ) as response:
                     if response.status_code >= 400:
                         payload = await _json_payload_from_streaming_response(response)
                         raise _daemon_error(response.status_code, payload)
@@ -338,7 +351,14 @@ class DeploymentDaemonClient:
         body = _json_bytes(json_body)
         url = httpx.URL(f"{config.api_base}{path}", params={k: v for k, v in (params or {}).items() if v is not None})
         path_with_query = url.raw_path.decode("ascii")
-        token = Path(config.token_file or "").read_bytes().strip()
+        try:
+            token = Path(config.token_file or "").read_bytes().strip()
+        except OSError as exc:
+            raise DeploymentProxyError(
+                503,
+                "daemon_unavailable",
+                "无法读取 NA-Tools daemon token，请检查文件权限或重新运行 na-tools bind",
+            ) from exc
         headers = build_signature_headers(
             token=token,
             instance_id=config.instance_id or "",
@@ -464,9 +484,7 @@ def _message_for_reason(code: str) -> str:
         "env_missing": "未找到实例环境配置，请重新运行 na-tools bind",
         "docker_unavailable": "Docker 或 Docker Compose 当前不可用",
         "docker_not_running": "宿主 Docker 未运行或无法连接",
-        "docker_permission_denied": (
-            "NA-Tools daemon 无权访问宿主 Docker，请用具备 Docker 权限的用户重启 daemon"
-        ),
+        "docker_permission_denied": ("NA-Tools daemon 无权访问宿主 Docker，请用具备 Docker 权限的用户重启 daemon"),
         "docker_socket_missing": "未找到宿主 Docker socket，请确认 Docker 已启动",
     }.get(code, "NA-Tools daemon 当前不可用")
 

--- a/nekro_agent/services/deployment/client.py
+++ b/nekro_agent/services/deployment/client.py
@@ -1,0 +1,515 @@
+"""Client for proxying WebUI deployment requests to the NA-Tools daemon."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import AsyncIterator, Callable, Mapping
+from contextlib import aclosing
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+from socksio.exceptions import ProtocolError as SocksProtocolError
+
+from nekro_agent.services.deployment.schemas import (
+    DeploymentBackupsResponse,
+    DeploymentCapabilitiesResponse,
+    DeploymentCreateBackupRequest,
+    DeploymentInstanceResponse,
+    DeploymentRestoreRequest,
+    DeploymentUpdateRequest,
+    UnavailableReason,
+)
+from nekro_agent.services.deployment.signer import build_signature_headers
+
+DEFAULT_DAEMON_API_BASE = "http://na-tools.local/v1"
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_HIDDEN_KEY_PARTS = ("token", "secret", "password", "api_key", "authorization", "signature")
+_DROPPED_KEYS = {
+    "data_dir",
+    "compose_file",
+    "env_file",
+    "token_file",
+    "token_file_path",
+    "daemon_token",
+    "health_url",
+    "expose_port",
+    "api_base",
+    "socks_proxy",
+    "backup_file",
+}
+_INTERNAL_ENDPOINT_RE = re.compile(
+    r"(?i)\b(?:https?|socks5h?)://(?:127\.0\.0\.1|localhost|host\.docker\.internal|na-tools\.local)(?::\d+)?[^\s'\",)]*"
+)
+_UNIX_ABSOLUTE_PATH_RE = re.compile(r"(?<!:)/(?:home|root|srv|var|opt|etc|tmp|usr|mnt|data)/[^\s'\",)]*")
+_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"\b[A-Za-z]:\\[^\s'\",)]+")
+
+
+@dataclass(frozen=True)
+class DeploymentDaemonConfig:
+    enabled: bool
+    api_base: str = DEFAULT_DAEMON_API_BASE
+    socks_proxy: str | None = None
+    instance_id: str | None = None
+    token_file: str | None = None
+
+    @classmethod
+    def from_env(cls) -> "DeploymentDaemonConfig":
+        enabled = os.getenv("NA_TOOLS_DAEMON_ENABLED", "").strip().lower() in _TRUE_VALUES
+        api_base = (os.getenv("NA_TOOLS_DAEMON_API_BASE") or DEFAULT_DAEMON_API_BASE).strip()
+        return cls(
+            enabled=enabled,
+            api_base=api_base.rstrip("/") or DEFAULT_DAEMON_API_BASE,
+            socks_proxy=(os.getenv("NA_TOOLS_DAEMON_SOCKS") or "").strip() or None,
+            instance_id=(os.getenv("NA_TOOLS_DAEMON_INSTANCE_ID") or "").strip() or None,
+            token_file=(os.getenv("NA_TOOLS_DAEMON_TOKEN_FILE") or "").strip() or None,
+        )
+
+
+class DeploymentProxyError(Exception):
+    """Structured deployment proxy error returned to the WebUI."""
+
+    def __init__(
+        self,
+        status_code: int,
+        code: str,
+        message: str,
+        *,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.details = sanitize_public_payload(dict(details or {}))
+
+    def payload(self) -> dict[str, dict[str, Any]]:
+        return {
+            "error": {
+                "code": self.code,
+                "message": sanitize_text(self.message),
+                "details": self.details,
+            }
+        }
+
+
+class DeploymentDaemonClient:
+    """Lazy daemon client used by deployment routes."""
+
+    def __init__(
+        self,
+        *,
+        config_loader: Callable[[], DeploymentDaemonConfig] = DeploymentDaemonConfig.from_env,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._config_loader = config_loader
+        self._transport = transport
+
+    async def get_capabilities(self) -> DeploymentCapabilitiesResponse:
+        config = self._config_loader()
+        unavailable = self._preflight_unavailable(config)
+        if unavailable is not None:
+            return self._unavailable_capabilities(unavailable)
+
+        try:
+            payload = await self._request_json("GET", "/capabilities", config=config)
+        except DeploymentProxyError as exc:
+            return self._unavailable_capabilities(UnavailableReason(code=exc.code, message=exc.message))
+
+        unavailable_reason = _normalize_unavailable_reason(payload.get("unavailable_reason"))
+        return DeploymentCapabilitiesResponse(
+            enabled=bool(payload.get("enabled")) and unavailable_reason is None,
+            provider=_safe_optional_str(payload.get("provider")),
+            platform=_safe_optional_str(payload.get("platform")) or "unknown",
+            protocol_version=_safe_optional_str(payload.get("protocol_version")),
+            instance_id=_safe_optional_str(payload.get("instance_id")),
+            supports=_bool_dict(payload.get("supports")),
+            limits=sanitize_public_payload(payload.get("limits") if isinstance(payload.get("limits"), dict) else {}),
+            unavailable_reason=unavailable_reason,
+        )
+
+    async def get_instance(self) -> DeploymentInstanceResponse:
+        config = self._load_available_config()
+        payload = await self._request_json("GET", "/instances/current", config=config)
+        container = payload.get("container") if isinstance(payload.get("container"), dict) else {}
+        docker = payload.get("docker") if isinstance(payload.get("docker"), dict) else {}
+        available = payload.get("available")
+        app_health = _safe_optional_str(payload.get("app_health"))
+        if app_health is None and isinstance(available, bool):
+            app_health = "ok" if available else "unavailable"
+        return DeploymentInstanceResponse(
+            channel=_safe_optional_str(payload.get("channel")),
+            image=_safe_optional_str(container.get("image")),
+            container_status=_safe_optional_str(container.get("status")),
+            app_health=app_health,
+            docker_ok=bool(docker.get("docker_installed")),
+            compose_ok=bool(docker.get("compose_installed")),
+        )
+
+    async def create_update(self, request: DeploymentUpdateRequest, *, username: str) -> dict[str, Any]:
+        config = self._load_available_config()
+        payload = request.model_dump(exclude_none=True)
+        payload["instance_id"] = config.instance_id
+        payload["requested_by"] = {
+            "source": "nekro-agent-webui",
+            "username": username,
+        }
+        return await self._request_json("POST", "/jobs/update", config=config, json_body=payload, timeout=30.0)
+
+    async def list_backups(
+        self,
+        *,
+        name: str | None = None,
+        limit: int = 50,
+    ) -> DeploymentBackupsResponse:
+        config = self._load_available_config()
+        params: dict[str, Any] = {"limit": limit}
+        if name:
+            params["name"] = name
+        payload = await self._request_json("GET", "/backups", config=config, params=params)
+        return DeploymentBackupsResponse.model_validate(payload)
+
+    async def create_backup(self, request: DeploymentCreateBackupRequest, *, username: str) -> dict[str, Any]:
+        config = self._load_available_config()
+        payload = request.model_dump(exclude_none=True)
+        payload["instance_id"] = config.instance_id
+        payload["requested_by"] = {
+            "source": "nekro-agent-webui",
+            "username": username,
+        }
+        return await self._request_json("POST", "/jobs/backup", config=config, json_body=payload, timeout=30.0)
+
+    async def create_restore(self, request: DeploymentRestoreRequest, *, username: str) -> dict[str, Any]:
+        config = self._load_available_config()
+        payload = request.model_dump(exclude_none=True)
+        payload["instance_id"] = config.instance_id
+        payload["requested_by"] = {
+            "source": "nekro-agent-webui",
+            "username": username,
+        }
+        return await self._request_json("POST", "/jobs/restore", config=config, json_body=payload, timeout=30.0)
+
+    async def get_job(self, job_id: str) -> dict[str, Any]:
+        return await self._request_json("GET", f"/jobs/{job_id}", config=self._load_available_config())
+
+    async def get_job_logs(
+        self,
+        job_id: str,
+        *,
+        after_seq: int | None = None,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        params: dict[str, int] = {"limit": limit}
+        if after_seq is not None:
+            params["after_seq"] = after_seq
+        return await self._request_json("GET", f"/jobs/{job_id}/logs", config=self._load_available_config(), params=params)
+
+    async def cancel_job(self, job_id: str) -> dict[str, Any]:
+        capabilities = await self.get_capabilities()
+        if not capabilities.supports.get("cancel"):
+            raise DeploymentProxyError(404, "unsupported_operation", "当前 daemon 不支持取消任务")
+        return await self._request_json("POST", f"/jobs/{job_id}/cancel", config=self._load_available_config())
+
+    async def stream_events(self, job_id: str, *, after_seq: int | None = None) -> AsyncIterator[dict[str, str]]:
+        config = self._load_available_config()
+        params = {"after_seq": after_seq} if after_seq is not None else None
+        async with aclosing(self._request_sse(f"/jobs/{job_id}/events", config=config, params=params)) as events:
+            async for event in events:
+                yield event
+
+    def _load_available_config(self) -> DeploymentDaemonConfig:
+        config = self._config_loader()
+        unavailable = self._preflight_unavailable(config)
+        if unavailable is not None:
+            raise DeploymentProxyError(503, unavailable.code, unavailable.message)
+        return config
+
+    def _preflight_unavailable(self, config: DeploymentDaemonConfig) -> UnavailableReason | None:
+        if not config.enabled:
+            return UnavailableReason(
+                code="daemon_disabled",
+                message="未启用在线更新，请启用 NA-Tools daemon 后再重试",
+            )
+        if not config.instance_id:
+            return UnavailableReason(
+                code="daemon_instance_missing",
+                message="未找到 NA-Tools daemon 实例绑定信息，请重新运行 na-tools bind",
+            )
+        if not config.token_file:
+            return UnavailableReason(
+                code="daemon_token_missing",
+                message="未找到 NA-Tools daemon token，请重新运行 na-tools bind 或检查 daemon 配置",
+            )
+        token_path = Path(config.token_file)
+        if not token_path.is_file():
+            return UnavailableReason(
+                code="daemon_token_missing",
+                message="未找到 NA-Tools daemon token，请重新运行 na-tools bind 或检查 daemon 配置",
+            )
+        if not token_path.read_bytes().strip():
+            return UnavailableReason(
+                code="daemon_token_missing",
+                message="NA-Tools daemon token 为空，请重新运行 na-tools bind",
+            )
+        return None
+
+    @staticmethod
+    def _unavailable_capabilities(reason: UnavailableReason) -> DeploymentCapabilitiesResponse:
+        return DeploymentCapabilitiesResponse(
+            enabled=False,
+            provider=None,
+            platform="unknown",
+            protocol_version=None,
+            instance_id=None,
+            supports={},
+            limits={},
+            unavailable_reason=UnavailableReason(code=reason.code, message=sanitize_text(reason.message)),
+        )
+
+    async def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        config: DeploymentDaemonConfig,
+        json_body: Mapping[str, Any] | None = None,
+        params: Mapping[str, Any] | None = None,
+        timeout: float = 8.0,
+    ) -> dict[str, Any]:
+        request = self._build_request(method, path, config=config, json_body=json_body, params=params)
+        try:
+            async with self._create_client(config, timeout=timeout) as client:
+                response = await client.request(
+                    method.upper(),
+                    request.url,
+                    content=request.body,
+                    headers=request.headers,
+                )
+        except httpx.TimeoutException as exc:
+            raise DeploymentProxyError(503, "daemon_unavailable", "NA-Tools daemon 请求超时") from exc
+        except httpx.RequestError as exc:
+            raise DeploymentProxyError(503, "daemon_unavailable", "无法连接 NA-Tools daemon") from exc
+        except SocksProtocolError as exc:
+            raise DeploymentProxyError(503, "daemon_unavailable", "NA-Tools daemon SOCKS 代理响应无效") from exc
+
+        payload = _json_payload(response)
+        if response.status_code >= 400:
+            raise _daemon_error(response.status_code, payload)
+        if not isinstance(payload, dict):
+            raise DeploymentProxyError(502, "daemon_protocol_error", "NA-Tools daemon 返回了无效响应")
+        return sanitize_public_payload(payload)
+
+    async def _request_sse(
+        self,
+        path: str,
+        *,
+        config: DeploymentDaemonConfig,
+        params: Mapping[str, Any] | None = None,
+    ) -> AsyncIterator[dict[str, str]]:
+        request = self._build_request("GET", path, config=config, params=params)
+        try:
+            async with self._create_client(config, timeout=httpx.Timeout(connect=8.0, read=None, write=8.0, pool=8.0)) as client:
+                async with client.stream("GET", request.url, headers={**request.headers, "Accept": "text/event-stream"}) as response:
+                    if response.status_code >= 400:
+                        payload = await _json_payload_from_streaming_response(response)
+                        raise _daemon_error(response.status_code, payload)
+                    async for event in _iter_sse_events(response):
+                        yield event
+        except httpx.TimeoutException as exc:
+            raise DeploymentProxyError(503, "daemon_unavailable", "NA-Tools daemon 事件流超时") from exc
+        except httpx.RequestError as exc:
+            raise DeploymentProxyError(503, "daemon_unavailable", "无法连接 NA-Tools daemon 事件流") from exc
+        except SocksProtocolError as exc:
+            raise DeploymentProxyError(503, "daemon_unavailable", "NA-Tools daemon SOCKS 代理响应无效") from exc
+
+    def _build_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        config: DeploymentDaemonConfig,
+        json_body: Mapping[str, Any] | None = None,
+        params: Mapping[str, Any] | None = None,
+    ) -> "_SignedRequest":
+        body = _json_bytes(json_body)
+        url = httpx.URL(f"{config.api_base}{path}", params={k: v for k, v in (params or {}).items() if v is not None})
+        path_with_query = url.raw_path.decode("ascii")
+        token = Path(config.token_file or "").read_bytes().strip()
+        headers = build_signature_headers(
+            token=token,
+            instance_id=config.instance_id or "",
+            method=method,
+            path_with_query=path_with_query,
+            body=body,
+        )
+        if body:
+            headers["Content-Type"] = "application/json"
+        return _SignedRequest(url=url, body=body, headers=headers)
+
+    def _create_client(
+        self,
+        config: DeploymentDaemonConfig,
+        *,
+        timeout: float | httpx.Timeout,
+    ) -> httpx.AsyncClient:
+        kwargs: dict[str, Any] = {
+            "timeout": timeout,
+            "trust_env": False,
+        }
+        if self._transport is not None:
+            kwargs["transport"] = self._transport
+        elif config.socks_proxy:
+            socks_proxy = _normalize_httpx_proxy_url(config.socks_proxy)
+            kwargs["proxies"] = {
+                "http://": socks_proxy,
+                "https://": socks_proxy,
+            }
+        return httpx.AsyncClient(**kwargs)
+
+
+@dataclass(frozen=True)
+class _SignedRequest:
+    url: httpx.URL
+    body: bytes
+    headers: dict[str, str]
+
+
+def _json_bytes(payload: Mapping[str, Any] | None) -> bytes:
+    if payload is None:
+        return b""
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+def _json_payload(response: httpx.Response) -> Any:
+    try:
+        return response.json()
+    except ValueError:
+        return {}
+
+
+async def _json_payload_from_streaming_response(response: httpx.Response) -> Any:
+    content = await response.aread()
+    if not content:
+        return {}
+    try:
+        return json.loads(content)
+    except ValueError:
+        return {}
+
+
+def _daemon_error(status_code: int, payload: Any) -> DeploymentProxyError:
+    error = payload.get("error") if isinstance(payload, dict) else None
+    if not isinstance(error, dict):
+        return DeploymentProxyError(status_code, "daemon_error", "NA-Tools daemon 请求失败")
+    return DeploymentProxyError(
+        status_code,
+        _safe_optional_str(error.get("code")) or "daemon_error",
+        _safe_optional_str(error.get("message")) or "NA-Tools daemon 请求失败",
+        details=error.get("details") if isinstance(error.get("details"), dict) else None,
+    )
+
+
+async def _iter_sse_events(response: httpx.Response) -> AsyncIterator[dict[str, str]]:
+    event_name = "message"
+    data_lines: list[str] = []
+    async for line in response.aiter_lines():
+        if line == "":
+            if data_lines:
+                yield {"event": event_name, "data": _sanitize_sse_data("\n".join(data_lines))}
+            event_name = "message"
+            data_lines = []
+            continue
+        if line.startswith(":"):
+            continue
+        if line.startswith("event:"):
+            event_name = line[6:].strip() or "message"
+            continue
+        if line.startswith("data:"):
+            data = line[5:]
+            if data.startswith(" "):
+                data = data[1:]
+            data_lines.append(data)
+    if data_lines:
+        yield {"event": event_name, "data": _sanitize_sse_data("\n".join(data_lines))}
+
+
+def _sanitize_sse_data(data: str) -> str:
+    try:
+        payload = json.loads(data)
+    except ValueError:
+        return sanitize_text(data)
+    return json.dumps(sanitize_public_payload(payload), ensure_ascii=False, separators=(",", ":"))
+
+
+def _normalize_unavailable_reason(value: Any) -> UnavailableReason | None:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        code = _safe_optional_str(value.get("code")) or "daemon_unavailable"
+        message = _safe_optional_str(value.get("message")) or "NA-Tools daemon 不可用"
+        return UnavailableReason(code=code, message=sanitize_text(message))
+    text = _safe_optional_str(value)
+    if not text:
+        return None
+    return UnavailableReason(code=text, message=_message_for_reason(text))
+
+
+def _message_for_reason(code: str) -> str:
+    return {
+        "compose_missing": "未找到 Docker Compose 配置，请重新运行 na-tools bind",
+        "env_missing": "未找到实例环境配置，请重新运行 na-tools bind",
+        "docker_unavailable": "Docker 或 Docker Compose 当前不可用",
+        "docker_not_running": "宿主 Docker 未运行或无法连接",
+        "docker_permission_denied": (
+            "NA-Tools daemon 无权访问宿主 Docker，请用具备 Docker 权限的用户重启 daemon"
+        ),
+        "docker_socket_missing": "未找到宿主 Docker socket，请确认 Docker 已启动",
+    }.get(code, "NA-Tools daemon 当前不可用")
+
+
+def _bool_dict(value: Any) -> dict[str, bool]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(key): bool(item) for key, item in value.items()}
+
+
+def _safe_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = sanitize_text(str(value)).strip()
+    return text or None
+
+
+def _normalize_httpx_proxy_url(proxy_url: str) -> str:
+    url = httpx.URL(proxy_url)
+    if url.scheme.lower() == "socks5h":
+        return str(url.copy_with(scheme="socks5"))
+    return proxy_url
+
+
+def sanitize_public_payload(value: Any) -> Any:
+    if isinstance(value, dict):
+        clean: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            lowered = key_text.lower()
+            if lowered in _DROPPED_KEYS or any(part in lowered for part in _HIDDEN_KEY_PARTS):
+                continue
+            clean[key_text] = sanitize_public_payload(item)
+        return clean
+    if isinstance(value, list):
+        return [sanitize_public_payload(item) for item in value]
+    if isinstance(value, str):
+        return sanitize_text(value)
+    return value
+
+
+def sanitize_text(value: str) -> str:
+    value = _INTERNAL_ENDPOINT_RE.sub("[redacted_endpoint]", value)
+    value = _UNIX_ABSOLUTE_PATH_RE.sub("[redacted_path]", value)
+    value = _WINDOWS_ABSOLUTE_PATH_RE.sub("[redacted_path]", value)
+    return value

--- a/nekro_agent/services/deployment/schemas.py
+++ b/nekro_agent/services/deployment/schemas.py
@@ -30,6 +30,16 @@ class DeploymentInstanceResponse(BaseModel):
     compose_ok: bool = False
 
 
+class DeploymentProxyErrorInfo(BaseModel):
+    code: str
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class DeploymentProxyErrorResponse(BaseModel):
+    error: DeploymentProxyErrorInfo
+
+
 class DeploymentAgentVersionResponse(BaseModel):
     current_version: str
     latest_version: str | None = None
@@ -74,3 +84,58 @@ class DeploymentRestoreRequest(BaseModel):
 
     backup_id: str
     client_request_id: str | None = None
+
+
+class DeploymentJobProgress(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    current: int | None = None
+    total: int | None = None
+    label: str | None = None
+
+
+class DeploymentJobError(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    code: str
+    message: str
+    details: dict[str, Any] | None = None
+
+
+class DeploymentJobResult(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class DeploymentJobResponse(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    job_id: str
+    type: str | None = None
+    status: str
+    phase: str | None = None
+    progress: DeploymentJobProgress | None = None
+    created_at: str | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    exit_code: int | None = None
+    message: str | None = None
+    error: DeploymentJobError | None = None
+    result: DeploymentJobResult | None = None
+
+
+class DeploymentLogEntry(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    seq: int
+    ts: str | None = None
+    level: str
+    stream: str
+    line: str
+
+
+class DeploymentJobLogsResponse(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    job_id: str
+    logs: list[DeploymentLogEntry] = Field(default_factory=list)
+    next_after_seq: int | None = None

--- a/nekro_agent/services/deployment/schemas.py
+++ b/nekro_agent/services/deployment/schemas.py
@@ -1,0 +1,76 @@
+"""Pydantic schemas for the WebUI deployment API."""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class UnavailableReason(BaseModel):
+    code: str
+    message: str
+
+
+class DeploymentCapabilitiesResponse(BaseModel):
+    enabled: bool
+    provider: str | None = None
+    platform: str = "unknown"
+    protocol_version: str | None = None
+    instance_id: str | None = None
+    supports: dict[str, bool] = Field(default_factory=dict)
+    limits: dict[str, Any] = Field(default_factory=dict)
+    unavailable_reason: UnavailableReason | None = None
+
+
+class DeploymentInstanceResponse(BaseModel):
+    channel: str | None = None
+    image: str | None = None
+    container_status: str | None = None
+    app_health: str | None = None
+    docker_ok: bool = False
+    compose_ok: bool = False
+
+
+class DeploymentAgentVersionResponse(BaseModel):
+    current_version: str
+    latest_version: str | None = None
+    update_available: bool = False
+    checked: bool = False
+    error_code: str | None = None
+    error_message: str | None = None
+
+
+class DeploymentUpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    channel: Literal["stable", "preview", "rollback"]
+    backup: bool = True
+    update_sandbox: bool = True
+    update_cc_sandbox: bool = False
+    restore_pre_preview: bool = False
+    client_request_id: str | None = None
+
+
+class DeploymentBackupSummary(BaseModel):
+    backup_id: str
+    filename: str
+    name: str | None = None
+    created_at: str
+    size_bytes: int
+
+
+class DeploymentBackupsResponse(BaseModel):
+    backups: list[DeploymentBackupSummary] = Field(default_factory=list)
+
+
+class DeploymentCreateBackupRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    client_request_id: str | None = None
+
+
+class DeploymentRestoreRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    backup_id: str
+    client_request_id: str | None = None

--- a/nekro_agent/services/deployment/signer.py
+++ b/nekro_agent/services/deployment/signer.py
@@ -1,0 +1,44 @@
+"""HMAC signer for the NA-Tools daemon protocol."""
+
+import hashlib
+import hmac
+import secrets
+import time
+
+
+def now_unix_ms() -> str:
+    """Return the current unix timestamp in milliseconds."""
+
+    return str(int(time.time() * 1000))
+
+
+def new_nonce() -> str:
+    """Return a random 128-bit nonce as lowercase hex."""
+
+    return secrets.token_hex(16)
+
+
+def build_signature_headers(
+    *,
+    token: bytes,
+    instance_id: str,
+    method: str,
+    path_with_query: str,
+    body: bytes = b"",
+    timestamp: str | None = None,
+    nonce: str | None = None,
+) -> dict[str, str]:
+    """Build daemon HMAC headers for one request."""
+
+    timestamp = timestamp or now_unix_ms()
+    nonce = nonce or new_nonce()
+    body_hash = hashlib.sha256(body).hexdigest()
+    plaintext = "\n".join([method.upper(), path_with_query, timestamp, nonce, body_hash])
+    digest = hmac.new(token, plaintext.encode("utf-8"), hashlib.sha256).hexdigest()
+    return {
+        "X-NA-Instance": instance_id,
+        "X-NA-Timestamp": timestamp,
+        "X-NA-Nonce": nonce,
+        "X-NA-Signature": f"v1={digest}",
+    }
+

--- a/tests/test_deployment_client.py
+++ b/tests/test_deployment_client.py
@@ -1,0 +1,360 @@
+import asyncio
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from socksio.exceptions import ProtocolError as SocksProtocolError
+
+from nekro_agent.services.deployment.client import (
+    DeploymentDaemonClient,
+    DeploymentDaemonConfig,
+    DeploymentProxyError,
+)
+from nekro_agent.services.deployment.schemas import (
+    DeploymentCreateBackupRequest,
+    DeploymentRestoreRequest,
+    DeploymentUpdateRequest,
+)
+
+
+def _config(tmp_path: Path, *, enabled: bool = True, token_exists: bool = True) -> DeploymentDaemonConfig:
+    token_file = tmp_path / "daemon.token"
+    if token_exists:
+        token_file.write_bytes(b"fixed-token")
+    return DeploymentDaemonConfig(
+        enabled=enabled,
+        api_base="http://na-tools.local/v1",
+        socks_proxy=None,
+        instance_id="sha256:test",
+        token_file=str(token_file),
+    )
+
+
+def _client(config: DeploymentDaemonConfig, handler: httpx.MockTransport) -> DeploymentDaemonClient:
+    return DeploymentDaemonClient(config_loader=lambda: config, transport=handler)
+
+
+@pytest.mark.asyncio
+async def test_capabilities_disabled_does_not_call_daemon(tmp_path: Path) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("daemon should not be called")
+
+    client = _client(_config(tmp_path, enabled=False), httpx.MockTransport(handler))
+
+    response = await client.get_capabilities()
+
+    assert response.enabled is False
+    assert response.supports == {}
+    assert response.unavailable_reason is not None
+    assert response.unavailable_reason.code == "daemon_disabled"
+
+
+@pytest.mark.asyncio
+async def test_capabilities_token_missing_returns_unavailable_reason(tmp_path: Path) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("daemon should not be called")
+
+    client = _client(_config(tmp_path, token_exists=False), httpx.MockTransport(handler))
+
+    response = await client.get_capabilities()
+
+    assert response.enabled is False
+    assert response.unavailable_reason is not None
+    assert response.unavailable_reason.code == "daemon_token_missing"
+    assert str(tmp_path) not in response.unavailable_reason.message
+
+
+@pytest.mark.asyncio
+async def test_capabilities_network_error_maps_to_daemon_unavailable(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    client = _client(_config(tmp_path), httpx.MockTransport(handler))
+
+    response = await client.get_capabilities()
+
+    assert response.enabled is False
+    assert response.unavailable_reason is not None
+    assert response.unavailable_reason.code == "daemon_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_capabilities_socks_protocol_error_maps_to_daemon_unavailable(tmp_path: Path) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise SocksProtocolError("Malformed reply")
+
+    client = _client(_config(tmp_path), httpx.MockTransport(handler))
+
+    response = await client.get_capabilities()
+
+    assert response.enabled is False
+    assert response.unavailable_reason is not None
+    assert response.unavailable_reason.code == "daemon_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_create_client_accepts_socks5h_proxy_scheme(tmp_path: Path) -> None:
+    config = DeploymentDaemonConfig(
+        enabled=True,
+        api_base="http://na-tools.local/v1",
+        socks_proxy="socks5h://host.docker.internal:18082",
+        instance_id="sha256:test",
+        token_file=str(tmp_path / "daemon.token"),
+    )
+    client = DeploymentDaemonClient(config_loader=lambda: config)
+
+    http_client = client._create_client(config, timeout=1.0)
+    await http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_update_adds_instance_and_requested_by(tmp_path: Path) -> None:
+    seen_payload: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_payload.update(json.loads(request.content.decode("utf-8")))
+        assert request.url.path == "/v1/jobs/update"
+        assert request.headers["X-NA-Instance"] == "sha256:test"
+        return httpx.Response(200, json={"job_id": "upd_1", "status": "queued"}, request=request)
+
+    client = _client(_config(tmp_path), httpx.MockTransport(handler))
+
+    response = await client.create_update(
+        DeploymentUpdateRequest(
+            channel="stable",
+            backup=True,
+            update_sandbox=True,
+            update_cc_sandbox=False,
+            restore_pre_preview=False,
+            client_request_id="request-1",
+        ),
+        username="admin",
+    )
+
+    assert response["job_id"] == "upd_1"
+    assert seen_payload["instance_id"] == "sha256:test"
+    assert seen_payload["client_request_id"] == "request-1"
+    assert seen_payload["requested_by"] == {
+        "source": "nekro-agent-webui",
+        "username": "admin",
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_backups_returns_safe_summaries(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/backups"
+        return httpx.Response(
+            200,
+            json={
+                "backups": [
+                    {
+                        "backup_id": "nekro_backup_webui_20260611_010203.tar.gz",
+                        "filename": "nekro_backup_webui_20260611_010203.tar.gz",
+                        "name": "webui",
+                        "created_at": "2026-06-11T01:02:03+00:00",
+                        "size_bytes": 1024,
+                        "backup_file": "/home/user/.config/na-tools/backup/private.tar.gz",
+                    }
+                ],
+                "data_dir": "/home/user/nekro_agent",
+            },
+            request=request,
+        )
+
+    client = _client(_config(tmp_path), httpx.MockTransport(handler))
+
+    response = await client.list_backups()
+    serialized = response.model_dump_json()
+
+    assert response.backups[0].name == "webui"
+    assert response.backups[0].size_bytes == 1024
+    assert "/home/user" not in serialized
+    assert "backup_file" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_create_backup_adds_instance_and_requested_by(tmp_path: Path) -> None:
+    seen_payload: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_payload.update(json.loads(request.content.decode("utf-8")))
+        assert request.url.path == "/v1/jobs/backup"
+        return httpx.Response(200, json={"job_id": "upd_1", "type": "backup", "status": "queued"}, request=request)
+
+    client = _client(_config(tmp_path), httpx.MockTransport(handler))
+
+    response = await client.create_backup(
+        DeploymentCreateBackupRequest(name="webui", client_request_id="backup-1"),
+        username="admin",
+    )
+
+    assert response["type"] == "backup"
+    assert seen_payload["instance_id"] == "sha256:test"
+    assert seen_payload["name"] == "webui"
+    assert seen_payload["client_request_id"] == "backup-1"
+    assert seen_payload["requested_by"] == {
+        "source": "nekro-agent-webui",
+        "username": "admin",
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_restore_adds_instance_and_requested_by(tmp_path: Path) -> None:
+    seen_payload: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_payload.update(json.loads(request.content.decode("utf-8")))
+        assert request.url.path == "/v1/jobs/restore"
+        return httpx.Response(200, json={"job_id": "upd_2", "type": "restore", "status": "queued"}, request=request)
+
+    client = _client(_config(tmp_path), httpx.MockTransport(handler))
+
+    response = await client.create_restore(
+        DeploymentRestoreRequest(
+            backup_id="nekro_backup_webui_20260611_010203.tar.gz",
+            client_request_id="restore-1",
+        ),
+        username="admin",
+    )
+
+    assert response["type"] == "restore"
+    assert seen_payload["instance_id"] == "sha256:test"
+    assert seen_payload["backup_id"] == "nekro_backup_webui_20260611_010203.tar.gz"
+    assert seen_payload["client_request_id"] == "restore-1"
+    assert seen_payload["requested_by"] == {
+        "source": "nekro-agent-webui",
+        "username": "admin",
+    }
+
+
+@pytest.mark.asyncio
+async def test_daemon_conflict_preserves_code_and_message(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            409,
+            json={
+                "error": {
+                    "code": "job_conflict",
+                    "message": "已有更新任务正在运行",
+                    "details": {"job_id": "upd_running"},
+                }
+            },
+            request=request,
+        )
+
+    client = _client(_config(tmp_path), httpx.MockTransport(handler))
+
+    with pytest.raises(DeploymentProxyError) as exc_info:
+        await client.create_update(
+            DeploymentUpdateRequest(channel="stable"),
+            username="admin",
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.payload()["error"]["code"] == "job_conflict"
+    assert exc_info.value.payload()["error"]["message"] == "已有更新任务正在运行"
+
+
+@pytest.mark.asyncio
+async def test_instance_response_hides_paths_ports_and_health_url(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "instance_id": "sha256:test",
+                "data_dir": "/home/user/srv/nekro_agent",
+                "compose_file": "/home/user/srv/nekro_agent/docker-compose.yml",
+                "env_file": "/home/user/srv/nekro_agent/.env",
+                "channel": "stable",
+                "available": True,
+                "app": {
+                    "expose_port": 8021,
+                    "health_url": "http://127.0.0.1:8021/api/health",
+                },
+                "container": {
+                    "status": "running",
+                    "image": "kromiose/nekro-agent:latest",
+                },
+                "docker": {
+                    "docker_installed": True,
+                    "compose_installed": True,
+                },
+            },
+            request=request,
+        )
+
+    client = _client(_config(tmp_path), httpx.MockTransport(handler))
+
+    response = await client.get_instance()
+    serialized = response.model_dump_json()
+
+    assert response.channel == "stable"
+    assert response.image == "kromiose/nekro-agent:latest"
+    assert response.container_status == "running"
+    assert response.app_health == "ok"
+    assert response.docker_ok is True
+    assert response.compose_ok is True
+    assert "/home/user" not in serialized
+    assert "8021" not in serialized
+    assert "health_url" not in serialized
+
+
+class _TrackingSSEStream(httpx.AsyncByteStream):
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def __aiter__(self) -> Iterator[bytes]:
+        yield b"event: log\n"
+        yield b'data: {"seq":1,"line":"ok"}\n\n'
+        await asyncio.sleep(60)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_stream_events_closes_daemon_stream_when_generator_closes(tmp_path: Path) -> None:
+    stream = _TrackingSSEStream()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/jobs/upd_1/events"
+        return httpx.Response(200, stream=stream, request=request)
+
+    client = _client(_config(tmp_path), httpx.MockTransport(handler))
+
+    events = client.stream_events("upd_1")
+    event = await anext(events)
+    await events.aclose()
+
+    assert event == {"event": "log", "data": '{"seq":1,"line":"ok"}'}
+    assert stream.closed is True
+
+
+class _SensitiveSSEStream(httpx.AsyncByteStream):
+    async def __aiter__(self) -> Iterator[bytes]:
+        yield b"event: result\n"
+        yield (
+            b'data: {"seq":1,"status":"succeeded","result":'
+            b'{"backup_file":"/home/user/.config/na-tools/backup/private.tar.gz",'
+            b'"line":"stored at /home/user/private"}}\n\n'
+        )
+
+
+@pytest.mark.asyncio
+async def test_stream_events_sanitizes_structured_payloads(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=_SensitiveSSEStream(), request=request)
+
+    client = _client(_config(tmp_path), httpx.MockTransport(handler))
+
+    events = client.stream_events("upd_1")
+    event = await anext(events)
+    await events.aclose()
+
+    assert event["event"] == "result"
+    assert "backup_file" not in event["data"]
+    assert "/home/user" not in event["data"]

--- a/tests/test_deployment_client.py
+++ b/tests/test_deployment_client.py
@@ -68,6 +68,33 @@ async def test_capabilities_token_missing_returns_unavailable_reason(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_capabilities_token_read_error_maps_to_daemon_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("daemon should not be called")
+
+    config = _config(tmp_path)
+    token_path = Path(config.token_file or "")
+    original_read_bytes = Path.read_bytes
+
+    def read_bytes(path: Path) -> bytes:
+        if path == token_path:
+            raise PermissionError("permission denied")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
+    client = _client(config, httpx.MockTransport(handler))
+
+    response = await client.get_capabilities()
+
+    assert response.enabled is False
+    assert response.unavailable_reason is not None
+    assert response.unavailable_reason.code == "daemon_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_capabilities_network_error_maps_to_daemon_unavailable(tmp_path: Path) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("connection refused", request=request)

--- a/tests/test_deployment_router.py
+++ b/tests/test_deployment_router.py
@@ -107,6 +107,25 @@ def test_all_deployment_routes_require_active_user_dependency() -> None:
         assert get_current_active_user in dependency_calls
 
 
+def test_deployment_proxy_routes_have_explicit_response_models() -> None:
+    proxy_paths = {
+        "/deployment/instance",
+        "/deployment/update",
+        "/deployment/backups",
+        "/deployment/backup",
+        "/deployment/restore",
+        "/deployment/jobs/{job_id}",
+        "/deployment/jobs/{job_id}/logs",
+        "/deployment/jobs/{job_id}/cancel",
+    }
+    routes = {route.path: route for route in router.routes if getattr(route, "path", None) in proxy_paths}
+
+    assert set(routes) == proxy_paths
+    for route in routes.values():
+        assert route.response_model is not None
+        assert 503 in route.responses
+
+
 def test_extract_latest_agent_version_from_cloud_payload() -> None:
     payload = {"success": True, "data": {"latestVersion": "2.3.3"}}
 

--- a/tests/test_deployment_router.py
+++ b/tests/test_deployment_router.py
@@ -1,0 +1,170 @@
+from types import SimpleNamespace
+
+import pytest
+
+from nekro_agent.routers import deployment as deployment_router
+from nekro_agent.routers.deployment import (
+    _extract_latest_agent_version,
+    build_agent_version_response,
+    create_deployment_backup,
+    create_deployment_restore,
+    create_deployment_update,
+    router,
+)
+from nekro_agent.services.deployment.schemas import (
+    DeploymentCreateBackupRequest,
+    DeploymentRestoreRequest,
+    DeploymentUpdateRequest,
+)
+from nekro_agent.services.user.deps import get_current_active_user
+
+
+class _FakeDeploymentClient:
+    def __init__(self) -> None:
+        self.called = False
+        self.request: DeploymentUpdateRequest | DeploymentCreateBackupRequest | DeploymentRestoreRequest | None = None
+        self.username: str | None = None
+
+    async def create_update(self, request: DeploymentUpdateRequest, *, username: str) -> dict[str, str]:
+        self.called = True
+        self.request = request
+        self.username = username
+        return {"job_id": "upd_1", "status": "queued"}
+
+    async def create_backup(self, request: DeploymentCreateBackupRequest, *, username: str) -> dict[str, str]:
+        self.called = True
+        self.request = request
+        self.username = username
+        return {"job_id": "upd_2", "type": "backup", "status": "queued"}
+
+    async def create_restore(self, request: DeploymentRestoreRequest, *, username: str) -> dict[str, str]:
+        self.called = True
+        self.request = request
+        self.username = username
+        return {"job_id": "upd_3", "type": "restore", "status": "queued"}
+
+
+@pytest.mark.asyncio
+async def test_update_handler_passes_current_user_to_client() -> None:
+    fake_client = _FakeDeploymentClient()
+    request = DeploymentUpdateRequest(channel="stable", client_request_id="request-1")
+
+    response = await create_deployment_update(
+        request,
+        current_user=SimpleNamespace(username="owner"),
+        client=fake_client,
+    )
+
+    assert response == {"job_id": "upd_1", "status": "queued"}
+    assert fake_client.called is True
+    assert fake_client.username == "owner"
+    assert fake_client.request is not None
+    assert fake_client.request.client_request_id == "request-1"
+
+
+@pytest.mark.asyncio
+async def test_backup_handler_passes_current_user_to_client() -> None:
+    fake_client = _FakeDeploymentClient()
+    request = DeploymentCreateBackupRequest(name="webui", client_request_id="backup-1")
+
+    response = await create_deployment_backup(
+        request,
+        current_user=SimpleNamespace(username="owner"),
+        client=fake_client,
+    )
+
+    assert response == {"job_id": "upd_2", "type": "backup", "status": "queued"}
+    assert fake_client.called is True
+    assert fake_client.username == "owner"
+    assert isinstance(fake_client.request, DeploymentCreateBackupRequest)
+    assert fake_client.request.name == "webui"
+
+
+@pytest.mark.asyncio
+async def test_restore_handler_passes_current_user_to_client() -> None:
+    fake_client = _FakeDeploymentClient()
+    request = DeploymentRestoreRequest(backup_id="backup.tar.gz", client_request_id="restore-1")
+
+    response = await create_deployment_restore(
+        request,
+        current_user=SimpleNamespace(username="owner"),
+        client=fake_client,
+    )
+
+    assert response == {"job_id": "upd_3", "type": "restore", "status": "queued"}
+    assert fake_client.called is True
+    assert fake_client.username == "owner"
+    assert isinstance(fake_client.request, DeploymentRestoreRequest)
+    assert fake_client.request.backup_id == "backup.tar.gz"
+
+
+def test_all_deployment_routes_require_active_user_dependency() -> None:
+    routes = [route for route in router.routes if getattr(route, "path", "").startswith("/deployment")]
+
+    assert routes
+    for route in routes:
+        dependency_calls = {dependency.call for dependency in route.dependant.dependencies}
+        assert get_current_active_user in dependency_calls
+
+
+def test_extract_latest_agent_version_from_cloud_payload() -> None:
+    payload = {"success": True, "data": {"latestVersion": "2.3.3"}}
+
+    assert _extract_latest_agent_version(payload) == "2.3.3"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"success": False, "data": {"latestVersion": "2.3.3"}},
+        {"success": True, "data": {}},
+        {"success": True, "data": {"latestVersion": ""}},
+        [{"name": "v2.3.3"}],
+    ],
+)
+def test_extract_latest_agent_version_rejects_invalid_cloud_payload(payload: object) -> None:
+    assert _extract_latest_agent_version(payload) is None
+
+
+@pytest.mark.asyncio
+async def test_agent_version_response_detects_update(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(deployment_router, "get_app_version", lambda: "2.3.0")
+
+    async def fetch_latest_version() -> str:
+        return "v2.4.0"
+
+    response = await build_agent_version_response(fetch_latest_version)
+
+    assert response.current_version == "2.3.0"
+    assert response.latest_version == "v2.4.0"
+    assert response.checked is True
+    assert response.update_available is True
+
+
+@pytest.mark.asyncio
+async def test_agent_version_response_hides_update_for_latest(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(deployment_router, "get_app_version", lambda: "2.4.0")
+
+    async def fetch_latest_version() -> str:
+        return "v2.4.0"
+
+    response = await build_agent_version_response(fetch_latest_version)
+
+    assert response.checked is True
+    assert response.update_available is False
+
+
+@pytest.mark.asyncio
+async def test_agent_version_response_hides_update_when_check_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(deployment_router, "get_app_version", lambda: "2.3.0")
+
+    async def fetch_latest_version() -> str:
+        raise ValueError("bad payload")
+
+    response = await build_agent_version_response(fetch_latest_version)
+
+    assert response.checked is False
+    assert response.update_available is False
+    assert response.error_code == "latest_version_unavailable"

--- a/tests/test_deployment_signer.py
+++ b/tests/test_deployment_signer.py
@@ -1,0 +1,93 @@
+import hashlib
+import hmac
+
+from nekro_agent.services.deployment.signer import build_signature_headers
+
+
+def test_build_signature_headers_is_predictable_with_fixed_inputs() -> None:
+    token = b"fixed-token"
+    body = b'{"channel":"stable"}'
+    timestamp = "1781020800000"
+    nonce = "40d2c11d7f6f4e43a87486f2044613f1"
+    plaintext = "\n".join(
+        [
+            "POST",
+            "/v1/jobs/update",
+            timestamp,
+            nonce,
+            hashlib.sha256(body).hexdigest(),
+        ]
+    )
+    expected = "v1=" + hmac.new(token, plaintext.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    headers = build_signature_headers(
+        token=token,
+        instance_id="sha256:test",
+        method="post",
+        path_with_query="/v1/jobs/update",
+        body=body,
+        timestamp=timestamp,
+        nonce=nonce,
+    )
+
+    assert headers == {
+        "X-NA-Instance": "sha256:test",
+        "X-NA-Timestamp": timestamp,
+        "X-NA-Nonce": nonce,
+        "X-NA-Signature": expected,
+    }
+
+
+def test_build_signature_headers_hashes_empty_body() -> None:
+    token = b"fixed-token"
+    timestamp = "1781020800000"
+    nonce = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    plaintext = "\n".join(
+        [
+            "GET",
+            "/v1/capabilities",
+            timestamp,
+            nonce,
+            hashlib.sha256(b"").hexdigest(),
+        ]
+    )
+    expected = "v1=" + hmac.new(token, plaintext.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    headers = build_signature_headers(
+        token=token,
+        instance_id="sha256:test",
+        method="GET",
+        path_with_query="/v1/capabilities",
+        timestamp=timestamp,
+        nonce=nonce,
+    )
+
+    assert headers["X-NA-Signature"] == expected
+
+
+def test_build_signature_headers_includes_query_in_path() -> None:
+    token = b"fixed-token"
+    timestamp = "1781020800000"
+    nonce = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    plaintext = "\n".join(
+        [
+            "GET",
+            "/v1/jobs/upd_1/logs?after_seq=10&limit=20",
+            timestamp,
+            nonce,
+            hashlib.sha256(b"").hexdigest(),
+        ]
+    )
+    expected = "v1=" + hmac.new(token, plaintext.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    headers = build_signature_headers(
+        token=token,
+        instance_id="sha256:test",
+        method="GET",
+        path_with_query="/v1/jobs/upd_1/logs?after_seq=10&limit=20",
+        timestamp=timestamp,
+        nonce=nonce,
+    )
+
+    assert headers["X-NA-Signature"] == expected
+


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [x] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：

## 🔍 变更类型 (勾选所有适用项)

- [ ] 🐛 Bug 修复 (修复一个问题)
- [x] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

- 新增 `/api/deployment` 后端代理，使用 HMAC 签名调用 NA-Tools daemon
- 新增部署更新页面，支持 stable 更新、preview、回退、备份和还原任务
- 支持 SSE 任务跟踪、日志续接恢复和协议错误处理
- 补充 deployment API 类型、国际化文案和后端单元测试

## 🛠️ 实现复杂度

- [x] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## Summary by Sourcery

添加一个部署管理后端 API 和 Web UI 页面，通过基于 SSE 的作业追踪以及 HMAC 签名的代理调用与 NA-Tools 守护进程进行交互。

New Features:
- 引入部署路由器和守护进程客户端，使用 HMAC 签名将部署、备份、恢复以及作业日志/事件操作代理到 NA-Tools。
- 在 Web UI 中添加设置中的部署页面，用于更新、备份、恢复和回滚部署，并支持实时日志流和作业状态跟踪。
- 暴露与部署相关的 REST 端点以及 TypeScript 客户端类型，涵盖能力、实例、代理版本、作业和备份。

Bug Fixes:
- 改进全局 Axios 错误处理，支持协议风格的错误封装，并增强对 401 的处理。
- 加固 SSE 流式工具，增加事件类型分发、可选重连以及更好的错误传播。

Enhancements:
- 完成新部署设置页面的导航和路由接线，并调整菜单创建逻辑以支持本地化条目。
- 在仅存在 token 的情况下，在主布局挂载时进行用户认证信息的初始化填充。
- 清理守护进程响应和 SSE 负载，在返回给 Web UI 之前去除密钥、文件路径和内部端点信息。
- 扩展测试范围，覆盖部署客户端 HMAC 签名、守护进程代理、路由行为以及 SSE 数据清洗逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a deployment management backend API and Web UI page with SSE-based job tracking and HMAC-signed proxy calls to the NA-Tools daemon.

New Features:
- Introduce a deployment router and daemon client to proxy deployment, backup, restore, and job log/event operations to NA-Tools using HMAC signatures.
- Add a settings deployment page in the Web UI for updating, backing up, restoring, and rolling back deployments with live log streaming and job status tracking.
- Expose deployment-related REST endpoints and TypeScript client types for capabilities, instances, agent version, jobs, and backups.

Bug Fixes:
- Improve global Axios error handling to support protocol-style error envelopes and more robust 401 handling.
- Harden SSE streaming utilities with event-type dispatch, optional reconnection, and better error propagation.

Enhancements:
- Ensure navigation and router wiring for the new deployment settings page and adjust menu creation for locale-aware items.
- Add auth user-info hydration on main layout mount when only a token is present.
- Sanitize daemon responses and SSE payloads to strip secrets, file paths, and internal endpoints before returning them to the Web UI.
- Extend tests to cover deployment client HMAC signing, daemon proxying, router behaviors, and SSE sanitization.

</details>