### PR TITLE
feat: fix OneBot v11 connection (1006) and sync with main

### DIFF
--- a/nekro_agent/adapters/onebot_v11/adapter.py
+++ b/nekro_agent/adapters/onebot_v11/adapter.py
@@ -1,9 +1,11 @@
+import asyncio
 import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type
 
 from fastapi import APIRouter
 from nonebot.adapters.onebot.v11 import Bot, Message, MessageSegment
+from nonebot.adapters.onebot.v11.exception import NetworkError as OneBotNetworkError
 from pydantic import Field
 
 from nekro_agent.adapters.interface.schemas.platform import (
@@ -385,7 +387,7 @@ class OnebotV11Adapter(BaseAdapter[OnebotV11Config]):
                 logger.warning(f"Unsupported segment type in normal mode: {segment.type}")
 
         if message:
-            return await self._send_to_chat(request.chat_key, message)
+            return await self._send_to_chat_with_retry(request.chat_key, message)
         return None
 
     def _append_text_message_segment(self, message: Message, text: str) -> None:
@@ -464,6 +466,40 @@ class OnebotV11Adapter(BaseAdapter[OnebotV11Config]):
 
         logger.debug(f"发送消息成功: {ret}")
         return str(ret.get("message_id", "")) or ""
+
+    async def _send_to_chat_with_retry(self, chat_key: str, message: Message) -> str:
+        """带指数退避重试的发送包装器，用于应对 NapCat WebSocket 1006 异常关闭。
+
+        触发场景：NTQQ 进程掉线 / NapCat ↔ NTQQ 短暂断连 / 网络抖动
+        重试策略：3 / 6 / 12 秒，最多 3 次（总耗时 ≤ 21 秒）
+        异常吞咽：仅吞咽 OneBotNetworkError（WebSocket 关闭、连接超时等）
+        其余异常（ActionFailed / ValueError 等业务错误）立即抛出，避免掩盖真实问题。
+        """
+        _MAX_RETRIES = 3
+        _BASE_BACKOFF_SECONDS = 3
+
+        last_error: Optional[Exception] = None
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                return await self._send_to_chat(chat_key, message)
+            except OneBotNetworkError as e:
+                last_error = e
+                if attempt >= _MAX_RETRIES:
+                    logger.error(
+                        f"[OneBot] 发送消息失败，已重试 {_MAX_RETRIES} 次仍失败: {e!s}"
+                    )
+                    raise
+                wait_seconds = _BASE_BACKOFF_SECONDS * (2 ** attempt)
+                logger.warning(
+                    f"[OneBot] 网络异常（attempt {attempt + 1}/{_MAX_RETRIES}），"
+                    f"等待 {wait_seconds}s 后重试: {e!s}"
+                )
+                await asyncio.sleep(wait_seconds)
+
+        # 理论上不会执行到这里（循环要么 return 要么 raise），加防御性兜底
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("_send_to_chat_with_retry: unexpected retry loop exit")
 
     async def get_self_info(self) -> PlatformUser:
         """获取自身信息"""


### PR DESCRIPTION
## 背景

生产环境 OneBot v11 适配器近期频繁遭遇 1006 异常关闭（NTQQ 进程掉线 / NapCat ↔ NTQQ 链路抖动），典型表现：

- 2026-06-24 08:35：定时任务（上班提醒）大面积通讯失败 `result: 1006514`
- 2026-06-24 16:27：GitHub Star 庆祝消息发送失败（接收 webhook 正常，发送异常）
- 2026-06-25 16:08：900 Star 庆祝消息、PR 合并汇总均发送失败

`1006514 = 1006 (WebSocket RFC abnormal closure) + 514 (NapCat 后缀)`，**不是限流**，是底层 Socket 彻底断开。

## 本 PR 内容

### 1. 同步 upstream/main（3 个 commit）

通过 rebase 把本分支对齐到 upstream 最新 HEAD（`77cff4c`）：

- `77f4c7d` feat: add QQBot OpenClaw adapter (#317)
- `f7316e7` 增加 nonebot v11 适配器对语音消息处理自动转文字的支持 (#315)
- `77cff4c` 添加部署更新控制面板 (#316)

### 2. OneBot v11 适配器：1006 网络异常重试

为 `OnebotV11Adapter._send_to_chat` 添加 `_send_to_chat_with_retry` 包装器：

- **仅捕获** `OneBotNetworkError`（WebSocket 关闭、连接超时）
- **指数退避**：3s / 6s / 12s，最多 3 次重试
- **业务异常透传**：`ActionFailed` / `ValueError` 等不吞咽，立即抛出避免掩盖真实问题
- **API 兼容性**：仅修改内部调用点，公开方法签名不变

```python
# 仅截取关键片段，详见 commit diff
async def _send_to_chat_with_retry(self, chat_key: str, message: Message) -> str:
    _MAX_RETRIES = 3
    _BASE_BACKOFF_SECONDS = 3
    for attempt in range(_MAX_RETRIES + 1):
        try:
            return await self._send_to_chat(chat_key, message)
        except OneBotNetworkError as e:
            if attempt >= _MAX_RETRIES:
                logger.error(f"[OneBot] 发送消息失败，已重试 {_MAX_RETRIES} 次仍失败: {e!s}")
                raise
            wait_seconds = _BASE_BACKOFF_SECONDS * (2 ** attempt)
            logger.warning(f"[OneBot] 网络异常（attempt {attempt + 1}/{_MAX_RETRIES}），等待 {wait_seconds}s 后重试: {e!s}")
            await asyncio.sleep(wait_seconds)
```

## 修改清单

| 文件 | 改动 | 原因 |
|------|------|------|
| `nekro_agent/adapters/onebot_v11/adapter.py` | +37 / -1 | 新增重试包装器 + 调整 1 个调用点 |

## 验证

- ✅ 静态语法检查（`python3 -c "ast.parse(...)"`）
- ❌ `poe lint` / `poe typecheck` / `poe test`：沙箱无 poe 工具
- ❌ 运行时验证：沙箱无法连接 NTQQ / NapCat

**强烈建议在 staging 环境验证后再合并**。重点观察：

1. 触发 1006 后是否自动恢复（3s 后开始重试）
2. 重试日志是否清晰可追踪
3. 业务异常（retcode 1200、ActionFailed）未被吞咽

## 风险与未覆盖

- **本修复是治标**：根因仍是 NapCat ↔ NTQQ 链路稳定性，建议长期迁移到 OpenClaw（#317），不再依赖 NTQQ 进程
- **最大重试时长 21s**：可能拉长 NA 任务执行时间窗口，但不阻塞其他任务
- **未触碰**：`@on_bot_disconnect` 处理器、heartInterval 硬编码

## 关联

- 调查产出：`shared/diagnostic_2026-06-24_1006514.md` / `shared/diagnostic_update.md` / `shared/diagnostic_report_latest.md`
- 上游 PR：#317（OpenClaw 适配器，本分支已同步）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

为 OneBot v11 适配器引入更具弹性的消息发送机制，以减少由临时 WebSocket 断开导致的发送失败。

新功能：
- 在 OneBot v11 聊天发送上添加带指数退避的重试封装，以自动从 NapCat WebSocket 1006 网络关闭中恢复。

错误修复：
- 将 OneBot v11 消息发送统一通过新的重试封装进行处理，使临时网络错误不再立即导致消息投递失败。

改进：
- 在 OneBot v11 网络重试过程中记录更详细的警告和错误日志，以提升对 NTQQ/NapCat 连接问题的可观测性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce resilient message sending for the OneBot v11 adapter to reduce failures caused by transient WebSocket disconnects.

New Features:
- Add an exponential-backoff retry wrapper around OneBot v11 chat sending to automatically recover from NapCat WebSocket 1006 network closures.

Bug Fixes:
- Route OneBot v11 message sending through the new retry wrapper so transient network errors no longer cause immediate message delivery failures.

Enhancements:
- Log detailed warnings and errors around OneBot v11 network retries to improve observability of NTQQ/NapCat connectivity issues.

</details>