### PR TITLE
feat(emotion): 标签加权 + 精准过滤的检索优化

### DIFF
--- a/plugins/builtin/emotion.py
+++ b/plugins/builtin/emotion.py
@@ -249,6 +249,18 @@ async def init_vector_db():
         )
         logger.success(f"表情包向量数据库集合 {collection_name} 创建成功")
 
+    # 为 tags 字段创建 KEYWORD 载荷索引，以便支持按标签精确过滤
+    # （Qdrant 对数组字段使用 MatchValue 过滤前需要对应类型的索引）
+    try:
+        await client.create_payload_index(
+            collection_name=collection_name,
+            field_name="tags",
+            field_schema=qdrant_models.PayloadSchemaType.KEYWORD,
+        )
+    except Exception as e:
+        # 索引已存在时 Qdrant 也会抛错，视为幂等成功
+        logger.debug(f"创建 tags 载荷索引跳过（可能已存在）: {e}")
+
 
 # region: 表情包系统数据模型
 class EmotionMetadata(BaseModel):
@@ -427,6 +439,57 @@ async def migrate_emotion_paths():
             logger.info("没有需要迁移的表情包路径")
 
     return migrated_count
+
+
+def _build_emotion_embedding_text(description: str, tags: List[str]) -> str:
+    """构造用于嵌入的表情包文本。
+
+    使用 ``标签:`` 前缀将标签与描述在语义空间上做轻量分组，
+    让 embedding 模型在写入时把标签视为同类语义信息，
+    避免 ``"描述" + "tag1 tag2"`` 的简单空格拼接造成的语义稀释。
+    兼容 ``tags=None`` / ``tags=[]`` 与空描述。
+    """
+    safe_description = (description or "").strip()
+    normalized_tags = [t.strip() for t in (tags or []) if t and t.strip()]
+    if not normalized_tags:
+        return safe_description
+    return f"{safe_description} 标签: {' '.join(normalized_tags)}"
+
+
+def _normalize_tag(tag: str) -> str:
+    """规范化标签字符串用于精确匹配。"""
+    return tag.strip().lower()
+
+
+def _build_tags_filter(tags: Optional[List[str]]) -> Optional[qdrant_models.Filter]:
+    """根据标签列表构造 Qdrant ``Filter``（AND 语义：所有标签都必须命中）。
+
+    返回 ``None`` 时表示不附加过滤条件，由 Qdrant 退回到纯向量检索。
+    标签会做去重 + 大小写归一化，避免空字符串 / 重复值污染过滤器。
+    """
+    if not tags:
+        return None
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        if not tag:
+            continue
+        norm = _normalize_tag(tag)
+        if not norm or norm in seen:
+            continue
+        seen.add(norm)
+        normalized.append(norm)
+    if not normalized:
+        return None
+    return qdrant_models.Filter(
+        must=[
+            qdrant_models.FieldCondition(
+                key="tags",
+                match=qdrant_models.MatchValue(value=tag),
+            )
+            for tag in normalized
+        ],
+    )
 
 
 async def generate_embedding(text: str, max_retries: int = 3) -> List[float]:
@@ -925,6 +988,16 @@ async def emo_reindex_cmd(
         )
         logger.info(f"已创建新集合: {collection_name}")
 
+        # 重建后立即补上 tags 载荷索引，保证搜索时仍可按标签精确过滤
+        try:
+            await client.create_payload_index(
+                collection_name=collection_name,
+                field_name="tags",
+                field_schema=qdrant_models.PayloadSchemaType.KEYWORD,
+            )
+        except Exception as e:
+            logger.warning(f"重建集合后创建 tags 载荷索引失败: {e}")
+
     except Exception as e:
         logger.error(f"重置向量集合失败: {e}")
         yield CmdCtl.failed(f"重置向量集合失败: {e!s}")
@@ -946,7 +1019,7 @@ async def emo_reindex_cmd(
                 missing_file_count += 1
                 continue
 
-            embedding_text = f"{metadata.description} {' '.join(metadata.tags)}"
+            embedding_text = _build_emotion_embedding_text(metadata.description, metadata.tags)
             embedding = await generate_embedding(embedding_text)
 
             current_batch.append(
@@ -1125,7 +1198,7 @@ async def collect_emotion(
             emotion_store.add_emotion(duplicate_id, metadata)
 
             # 生成嵌入向量
-            embedding = await generate_embedding(f"{description} {' '.join(tags)}")
+            embedding = await generate_embedding(_build_emotion_embedding_text(description, tags))
 
             # 获取Qdrant客户端
             client = await get_qdrant_client()
@@ -1181,7 +1254,7 @@ async def collect_emotion(
     # 添加到向量数据库
     try:
         # 生成嵌入向量
-        embedding = await generate_embedding(f"{description} {' '.join(tags)}")
+        embedding = await generate_embedding(_build_emotion_embedding_text(description, tags))
 
         # 获取Qdrant客户端
         client = await get_qdrant_client()
@@ -1267,7 +1340,7 @@ async def update_emotion(
 
     # 更新向量数据库
     # 生成嵌入向量
-    embedding_text = f"{description} {' '.join(tags)}"
+    embedding_text = _build_emotion_embedding_text(description, tags)
     embedding = await generate_embedding(embedding_text)
 
     # 获取Qdrant客户端
@@ -1450,6 +1523,7 @@ async def search_emotion(
     _ctx: schemas.AgentCtx,
     query: str,
     max_results: Optional[int] = None,
+    tags: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Search Emotion
 
@@ -1458,14 +1532,20 @@ async def search_emotion(
     Args:
         query (str): The search query
         max_results (int, optional): Maximum number of results to observe (recommended: 3-5)
+        tags (List[str], optional): Restrict results to emotions that contain ALL of these tags
+            (case-insensitive AND match). Use this when the caller wants a hard tag constraint
+            on top of semantic similarity.
 
     Returns:
         Dict: OpenAI chat message format containing the search results
 
     Example:
         ```python
-        # Search for happy cat emotions
+        # Semantic-only search
         search_results = search_emotion("开心猫")
+
+        # Combined: semantic similarity restricted to specific tags
+        search_results = search_emotion("开心", tags=["猫", "动漫"])
         ```
     """
     if not query:
@@ -1479,17 +1559,23 @@ async def search_emotion(
     # 生成查询向量
     query_embedding = await generate_embedding(query)
 
+    # 构造可选的标签精确过滤条件
+    tags_filter = _build_tags_filter(tags)
+
     # 获取Qdrant客户端
     client = await get_qdrant_client()
 
-    # 进行向量搜索
+    # 进行向量搜索（可叠加标签过滤）
     try:
-        search_results = await client.search(
-            collection_name=plugin.get_vector_collection_name(),
-            query_vector=query_embedding,
-            limit=search_limit,
-            with_payload=True,  # 确保返回payload以获取原始emotion_id
-        )
+        search_kwargs: dict = {
+            "collection_name": plugin.get_vector_collection_name(),
+            "query_vector": query_embedding,
+            "limit": search_limit,
+            "with_payload": True,  # 确保返回payload以获取原始emotion_id
+        }
+        if tags_filter is not None:
+            search_kwargs["query_filter"] = tags_filter
+        search_results = await client.search(**search_kwargs)
     except Exception as e:
         logger.error(f"向量搜索失败: {e}")
         msg = OpenAIChatMessage.from_text(

--- a/tests/test_emotion_search.py
+++ b/tests/test_emotion_search.py
@@ -1,0 +1,210 @@
+"""Unit tests for emotion plugin search / write helpers.
+
+These tests cover the pure-Python helpers introduced by the tag-aware
+search optimization. The full ``plugins.builtin.emotion`` module pulls in
+heavy dependencies (aiofiles / libmagic / qdrant client stack) that may
+not be available in every sandbox / CI runner, so we extract the helpers
+via AST instead of importing the module directly. This keeps the tests
+fast, deterministic, and aligned with the actual production code: any
+change to the helper bodies will fail these tests immediately.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List, Optional
+
+import pytest
+
+EMOTION_PLUGIN_PATH = Path(__file__).resolve().parent.parent / "plugins" / "builtin" / "emotion.py"
+
+
+# region: AST-based helper extraction
+
+
+def _extract_function(source: str, func_name: str) -> str:
+    """Return the source of the top-level function `func_name` from `source`."""
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            return textwrap.dedent(ast.get_source_segment(source, node) or "")
+    raise AssertionError(f"function {func_name!r} not found in source")
+
+
+def _load_helpers() -> dict:
+    """Compile the three pure helpers (`_build_emotion_embedding_text`,
+    `_normalize_tag`, `_build_tags_filter`) into an isolated namespace.
+
+    We avoid executing the rest of the plugin module — the helpers only
+    depend on `qdrant_client.models` for the Filter / FieldCondition /
+    MatchValue types, which we substitute with lightweight stand-ins that
+    share the same construction interface.
+    """
+    source = EMOTION_PLUGIN_PATH.read_text(encoding="utf-8")
+    func_sources = [
+        _extract_function(source, "_build_emotion_embedding_text"),
+        _extract_function(source, "_normalize_tag"),
+        _extract_function(source, "_build_tags_filter"),
+    ]
+
+    class _MatchValue:
+        def __init__(self, value: Any) -> None:
+            self.value = value
+
+    class _FieldCondition:
+        def __init__(self, *, key: str, match: Any) -> None:
+            self.key = key
+            self.match = match
+
+    class _Filter:
+        def __init__(self, must: Optional[List[Any]] = None) -> None:
+            self.must = list(must or [])
+
+    stub_models = SimpleNamespace(
+        Filter=_Filter,
+        FieldCondition=_FieldCondition,
+        MatchValue=_MatchValue,
+    )
+
+    namespace: dict = {
+        "qdrant_models": stub_models,
+        "List": List,
+        "Optional": Optional,
+    }
+    exec("\n\n".join(func_sources), namespace)
+    return {
+        "build_text": namespace["_build_emotion_embedding_text"],
+        "normalize": namespace["_normalize_tag"],
+        "filter": namespace["_build_tags_filter"],
+    }
+
+
+helpers = pytest.lazy_fixture if False else _load_helpers()
+build_text = helpers["build_text"]
+normalize_tag = helpers["normalize"]
+build_filter = helpers["filter"]
+
+
+# endregion
+
+
+# region: _build_emotion_embedding_text
+
+
+def test_build_emotion_embedding_text_uses_label_marker() -> None:
+    text = build_text("一只开心的猫", ["开心", "猫", "动漫"])
+    assert text == "一只开心的猫 标签: 开心 猫 动漫"
+
+
+def test_build_emotion_embedding_text_omits_marker_when_no_tags() -> None:
+    assert build_text("描述文本", []) == "描述文本"
+    assert build_text("描述文本", None) == "描述文本"
+
+
+def test_build_emotion_embedding_text_handles_empty_description() -> None:
+    assert build_text("", ["a"]) == " 标签: a"
+    assert build_text("   ", ["a", "b"]) == " 标签: a b"
+
+
+def test_build_emotion_embedding_text_strips_whitespace_in_tags() -> None:
+    text = build_text("desc", ["  hello ", "", "  ", "world"])
+    assert text == "desc 标签: hello world"
+
+
+# endregion
+
+
+# region: _normalize_tag / _build_tags_filter
+
+
+def test_normalize_tag_lowercases_and_strips() -> None:
+    assert normalize_tag("  Cat  ") == "cat"
+    assert normalize_tag("动漫") == "动漫"
+
+
+def test_build_tags_filter_returns_none_when_no_tags() -> None:
+    assert build_filter(None) is None
+    assert build_filter([]) is None
+
+
+def test_build_tags_filter_returns_none_for_only_empty_tags() -> None:
+    assert build_filter(["", "  "]) is None
+
+
+def test_build_tags_filter_dedupes_case_insensitive() -> None:
+    filt = build_filter(["Cat", "cat", "CAT", "Dog"])
+    assert filt is not None
+    assert len(filt.must) == 2
+    values = {cond.match.value for cond in filt.must}
+    assert values == {"cat", "dog"}
+
+
+def test_build_tags_filter_uses_and_semantics_on_tags_field() -> None:
+    filt = build_filter(["开心", "动漫"])
+    assert filt is not None
+    assert len(filt.must) == 2
+    for cond in filt.must:
+        assert cond.key == "tags"
+        assert cond.match.value in {"开心", "动漫"}
+
+
+def test_build_tags_filter_preserves_input_order_for_distinct_tags() -> None:
+    filt = build_filter(["z", "a", "m"])
+    assert filt is not None
+    values = [cond.match.value for cond in filt.must]
+    assert values == ["z", "a", "m"]
+
+
+# endregion
+
+
+# region: search_emotion signature compatibility (static check)
+
+
+def test_search_emotion_signature_accepts_optional_tags() -> None:
+    """Static guarantee that `search_emotion` exposes the new tags parameter
+    so the optimization is reachable from the LLM tool surface."""
+    source = EMOTION_PLUGIN_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "search_emotion":
+            arg_names = {a.arg for a in node.args.args}
+            assert "tags" in arg_names, "search_emotion must expose a `tags` parameter"
+            # Default must be None so old callers without tags keep working
+            for default, arg in zip(
+                reversed(node.args.defaults),
+                reversed(node.args.args),
+            ):
+                if arg.arg == "tags":
+                    assert isinstance(default, ast.Constant) and default.value is None
+                    return
+            pytest.fail("search_emotion.tags must default to None")
+    pytest.fail("search_emotion not found in plugin source")
+
+
+def test_init_vector_db_creates_tags_payload_index() -> None:
+    """The plugin must register a payload index on `tags` so that
+    Qdrant accepts Filter(MatchValue) on array-typed keyword fields."""
+    source = EMOTION_PLUGIN_PATH.read_text(encoding="utf-8")
+    assert "create_payload_index" in source, "init_vector_db must call create_payload_index"
+    assert "PayloadSchemaType.KEYWORD" in source, "tags index must be of KEYWORD type"
+
+
+def test_write_sites_use_helper_instead_of_inline_concat() -> None:
+    """All four write-side embedding-text constructions must go through
+    the helper, otherwise new write paths will drift from the search side."""
+    source = EMOTION_PLUGIN_PATH.read_text(encoding="utf-8")
+    forbidden_patterns = [
+        "f\"{description} {' '.join(tags)}\"",
+        "f\"{metadata.description} {' '.join(metadata.tags)}\"",
+    ]
+    for pattern in forbidden_patterns:
+        assert pattern not in source, (
+            f"inline embedding-text concat found, replace with _build_emotion_embedding_text: {pattern}"
+        )
+
+
+# endregion


### PR DESCRIPTION
## 背景

表情包插件当前检索流程是**纯向量余弦相似度**：写入侧把 `description + ' '.join(tags)` 拼成一段文本扔给 embedding；检索侧只用 `query` 向量化后 `client.search(limit=N, with_payload=True)`。这带来两个问题：

1. **写入侧**：标签与描述简单空格拼接，长串标签或 emoji 会"挤掉"描述的语义权重。
2. **检索侧**：没有办法在 LLM 想要"只在动漫/猫类标签里找"时叠加硬约束，结果完全由向量相似度决定。

## 改动

### 写入侧：结构化拼接

新增 `_build_emotion_embedding_text(description, tags)` helper：

```
"一只开心的猫 标签: 开心 猫 动漫"
```

通过 `标签:` 前缀做轻量语义分组，让 embedding 模型把标签视为同类信息而非噪声。兼容 `tags=None / []` 与空描述。

`collect_emotion`（新增 + 重复两条分支）、`update_emotion`、`emo_reindex_cmd` 四处拼接全部统一到该 helper。

### 检索侧：精准过滤 + 检索协同

`search_emotion` 新增 `tags: Optional[List[str]] = None` 参数：

- 为 `None / []` 时：完全保留旧行为，纯向量检索。
- 提供标签时：`_build_tags_filter(tags)` 构造 `qdrant_models.Filter(must=[FieldCondition(key="tags", match=MatchValue(...))])` 与向量查询叠加（AND 语义）。
- 标签自动做大小写归一化 + 去重 + 跳过空值。

LLM 现在可以这样调用：

```python
search_results = search_emotion("开心", tags=["猫", "动漫"])
```

### 配套基础设施

`init_vector_db` 与 `emo_reindex_cmd` 在创建/重建集合后立即为 `tags` 字段创建 `PayloadSchemaType.KEYWORD` 载荷索引。Qdrant 对数组字段使用 `MatchValue` 过滤必须先建对应类型索引，否则过滤会失败。索引创建失败视为幂等（已存在的情况）。

## 数据兼容性

- **不影响历史数据**：旧表情包仍在 Qdrant 中，向量与 payload（包含 `tags` 字段）保留。`search_emotion` 在不传 `tags` 时完全走旧路径，行为不变。
- **写入侧的字符串格式变化**：从 `f"{desc} {tag1} {tag2}"` 变为 `f"{desc} 标签: {tag1} {tag2}"`。**已存在的向量与新写入的向量不在同一语义空间**，但同一 emotion_id 的向量会按 `update_emotion` 流程被重建（删除旧点 + upsert 新点）。
- **建议**：用户首次升级后执行一次 `emo_reindex -y` 让所有向量空间统一。

## 验证

- `poe lint` 通过
- `poe typecheck` 0 errors / 0 warnings / 0 notes
- 新增 `tests/test_emotion_search.py`（13 个用例，全部通过）：
  - `_build_emotion_embedding_text`：标签标记、无标签、空描述、空白过滤
  - `_normalize_tag` / `_build_tags_filter`：去重、AND 语义、字段 key 正确、空输入返回 None
  - 静态签名检查：`search_emotion` 暴露 `tags` 参数且默认 `None`、`init_vector_db` 调用 `create_payload_index` 并使用 `KEYWORD` 类型、所有写入点都已切换到 helper

## 兼容性备注

- 没有改动 `emo_search_cmd`（命令版本），如后续需要也可以基于同样的 helper 暴露标签过滤参数，保持本次 PR 范围最小化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

优化情绪插件搜索，以支持基于标签感知的向量嵌入，并在向量相似度之上实现精确的标签过滤。

New Features:
- 在 `search_emotion` 中添加支持标签感知的搜索，通过可选的 `tags` 参数，在语义相似基础上启用强制标签约束。

Enhancements:
- 通过 `_build_emotion_embedding_text` 统一嵌入文本构造方式，使用标签前缀将描述与标签在语义上进行归组。
- 引入辅助函数，用于归一化标签并构建具备 AND 语义和去重能力的 Qdrant 过滤器。
- 确保 `init_vector_db` 和重新索引时在 `tags` 字段上创建 KEYWORD 负载索引，以实现高效的标签过滤。

Tests:
- 添加 `tests/test_emotion_search.py`，用于验证嵌入文本辅助函数的行为、标签归一化与过滤器构建，以及搜索与索引集成的静态保证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize emotion plugin search to support tag-aware embeddings and precise tag filtering on top of vector similarity.

New Features:
- Add tag-aware search in `search_emotion` with optional tags parameter enabling hard tag constraints combined with semantic similarity.

Enhancements:
- Unify embedding text construction via `_build_emotion_embedding_text` to group descriptions and tags semantically using a label prefix.
- Introduce helper functions to normalize tags and build Qdrant filters with AND semantics and deduplication.
- Ensure `init_vector_db` and reindexing create a KEYWORD payload index on the `tags` field for efficient tag filtering.

Tests:
- Add `tests/test_emotion_search.py` to validate embedding text helper behavior, tag normalization and filter construction, and static guarantees around search and indexing integration.

</details>