### PR TITLE
fix(at-markup): 修复嵌套 `<At:<At:[...]>>` 在含特殊字符昵称下无法归一化

### DIFF
--- a/nekro_agent/tools/at_markup.py
+++ b/nekro_agent/tools/at_markup.py
@@ -2,7 +2,12 @@ import re
 from collections.abc import Iterable
 
 USER_ID_PATTERN = r"(?P<uid>all|[A-Za-z0-9][A-Za-z0-9_.#\-]{2,127})"
-_NICKNAME_VALUE = r"[^@\]\)>】）\n]+?"
+# 旧实现 `_NICKNAME_VALUE = r"[^@\]\)>】）\n]+?"` 排除了 `)` `）` `>` `】`，
+# 导致含中文/全角括号的昵称（例如 `KroMiose谬锶（摆烂中）`）无法匹配任何 At 模式，
+# 进而让 `<At:<At:[@id:xxx;nickname:KroMiose谬锶（摆烂中）@]>>` 这类嵌套形态整段残留。
+# 这里把排除集收紧到「真正会让后续 `_BRACKET_AT_CLOSE` / `;` 字段分隔符失配」的字符，
+# 与 `_CANONICAL_NICKNAME_VALUE` 保持一致；嵌套解析交给 normalize 的多轮 sub 收敛。
+_NICKNAME_VALUE = r"[^@\]\n;]+?"
 _CANONICAL_NICKNAME_VALUE = r"[^@\]\n]+?"
 _NICKNAME_GROUP = rf"(?P<nickname>{_NICKNAME_VALUE})"
 _CANONICAL_NICKNAME_GROUP = rf"(?P<nickname>{_CANONICAL_NICKNAME_VALUE})"

--- a/tests/test_at_markup.py
+++ b/tests/test_at_markup.py
@@ -307,6 +307,101 @@ def test_normalize_malformed_at_markup_keeps_other_cq_codes() -> None:
 @pytest.mark.parametrize(
     ("raw_text", "expected"),
     [
+        # 报告里的真实案例：嵌套 <At:...> + 昵称含全角括号
+        (
+            "<At:<At:[@id:255799348;nickname:KroMiose谬锶（摆烂中）@]>>",
+            "[@id:255799348;nickname:KroMiose谬锶（摆烂中）@]",
+        ),
+        # 嵌套但昵称不含特殊字符（原本能工作，回归基线）
+        (
+            "<At:<At:[@id:255799348@]>>",
+            "[@id:255799348@]",
+        ),
+        # 三层嵌套
+        (
+            "<At:<At:<At:[@id:12345;nickname:test@]>>>",
+            "[@id:12345;nickname:test@]",
+        ),
+        # 单层 At: 但昵称含全角括号
+        (
+            "<At:[@id:12345;nickname:test（摆烂中）@]>",
+            "[@id:12345;nickname:test（摆烂中）@]",
+        ),
+        # 单层 At: 但昵称含半角括号
+        (
+            "<At:[@id:12345;nickname:test(user)@]>",
+            "[@id:12345;nickname:test(user)@]",
+        ),
+        # 在自然语句中间
+        (
+            "prefix <At:<At:[@id:12345;nickname:KroMiose谬锶（摆烂中）@]>> suffix",
+            "prefix [@id:12345;nickname:KroMiose谬锶（摆烂中）@] suffix",
+        ),
+        # 嵌套 + 非方括号包裹（QQ 跨平台格式）
+        (
+            "[@id:12345;nickname:abc（def）ghi@]",
+            "[@id:12345;nickname:abc（def）ghi@]",
+        ),
+        # 回归样本（2026-07-04 上报）：嵌套 + 昵称无特殊字符
+        # 旧实现下即便昵称纯字母数字也能被剥离，但与三段式 At 标签相遇时
+        # 仍需确保两层 <At:> 完全收敛，不残留任何前缀。
+        (
+            "<At:<At:[@id:2648863351;nickname:xxx@]>>",
+            "[@id:2648863351;nickname:xxx@]",
+        ),
+        # 回归样本：嵌套形态出现在自然语句中间
+        (
+            "prefix <At:<At:[@id:2648863351;nickname:xxx@]>> suffix",
+            "prefix [@id:2648863351;nickname:xxx@] suffix",
+        ),
+        # 回归样本：三层嵌套
+        (
+            "<At:<At:<At:[@id:2648863351;nickname:xxx@]>>>",
+            "[@id:2648863351;nickname:xxx@]",
+        ),
+        # 回归样本：单层（确保 <At:...> 单独形态也正常收敛）
+        (
+            "<At:[@id:2648863351;nickname:xxx@]>",
+            "[@id:2648863351;nickname:xxx@]",
+        ),
+    ],
+)
+def test_normalize_malformed_at_markup_handles_nested_at_with_special_nickname(raw_text: str, expected: str) -> None:
+    """回归测试：嵌套 `<At:<At:[...]>>` 与含 `)` `）` 的昵称必须被规范化。
+
+    旧 `_NICKNAME_VALUE` 排除 `) > 】 ）` 导致含这些字符的昵称无法匹配任何 At 模式，
+    进而让外层 `<At:...>` 也无法被剥离，整段残留为 `<At:<At:[...]>>` 出现在聊天记录中。
+    """
+    assert normalize_malformed_at_markup(raw_text) == expected
+
+
+def test_normalize_malformed_at_markup_idempotent_after_nested_fix() -> None:
+    """修复后嵌套 At 应满足幂等性：再次 normalize 不应再产生变化。"""
+    uid = _next_user_id()
+    text = f"<At:<At:[@id:{uid};nickname:KroMiose谬锶（摆烂中）@]>>"
+    normalized = normalize_malformed_at_markup(text)
+    assert normalized == f"[@id:{uid};nickname:KroMiose谬锶（摆烂中）@]"
+    assert normalize_malformed_at_markup(normalized) == normalized
+
+
+def test_normalize_malformed_at_markup_handles_reported_2648863351_nested() -> None:
+    """回归样本（2026-07-04 上报）：`<At:<At:[@id:2648863351;nickname:xxx@]>>`。
+
+    昵称 `xxx` 不含特殊字符，理论上不会走旧 `_NICKNAME_VALUE` 排除集的失败路径；
+    这里专门锁定该样本的归一化结果，防止后续 at_markup 重构时回归。
+    """
+    raw = "<At:<At:[@id:2648863351;nickname:xxx@]>>"
+    expected = "[@id:2648863351;nickname:xxx@]"
+
+    normalized = normalize_malformed_at_markup(raw)
+    assert normalized == expected
+    # 幂等性：再次 normalize 不应再变化
+    assert normalize_malformed_at_markup(normalized) == normalized
+
+
+@pytest.mark.parametrize(
+    ("raw_text", "expected"),
+    [
         ("[@all@]", "@全体成员"),
         ("[@id:all@]", "@全体成员"),
         ("提醒 @id:all@] 不要刷屏", "提醒 @全体成员 不要刷屏"),


### PR DESCRIPTION
## 修复内容

修复 OneBot V11 / Discord / Feishu / WxWork 等共用 `normalize_malformed_at_markup` 的所有适配器中，当模型输出的 `@` 文本呈嵌套形态 `<At:<At:[@id:xxx;nickname:yyy（特殊字符）@]>>` 且昵称中包含 `)` / `）` / `>` / `】` 时整段残留、作为奇怪文本出现在聊天记录里的 Bug。

## 根因

`nekro_agent/tools/at_markup.py` 中的 `_NICKNAME_VALUE` 排除集过宽：

```python
_NICKNAME_VALUE = r"[^@\]\)>】）\n]+?"   # 旧实现
```

它把可能被误当作「替代 close 字符」的 `)` `）` `>` `】` 一并排除。但实际的 close 判定由 `_BRACKET_AT_CLOSE = r"\s*[;；]?\s*@?\s*[\]】]"` 严格控制，这些字符并不需要从 nickname 中排除。当昵称是 `KroMiose谬锶（摆烂中）` 这种含 `）` 的真实群昵称时：

1. `_NICKNAME_SUFFIX` 在 `）` 处截断 nickname（`[^@\]\)>】）\n]` 排除 `）`）；
2. `_BRACKET_AT_CLOSE` 需要 `]` 或 `】`，但 `）@]` 里的第一个字符是 `）` → 匹配失败；
3. 内层 `<At:[...]>` 整体匹配失败；
4. 外层 `<At:...>` 在多轮 sub 中也无法剥离 → 整段残留。

## 改动

**`nekro_agent/tools/at_markup.py`**：把 `_NICKNAME_VALUE` 收紧到真正会影响 close 判定 / 字段分隔的字符，与 `_CANONICAL_NICKNAME_VALUE` 保持一致：

```python
_NICKNAME_VALUE = r"[^@\]\n;]+?"
```

排除集从 `[@])\]>】）\n` 收窄为 `[@]\n;`。
- `@` / `]` / `\n`：原本就要排除（防止吞掉 close marker / 跨行）；
- `;`：纳入防止吞掉 `;nickname:` / `;id:` 之类的字段分隔符。

排除集外的 `)` `）` `>` `】` 现在允许出现在 nickname 中。嵌套结构的剥离交给 `normalize_malformed_at_markup` 已有的多轮 sub（`_MAX_NORMALIZE_PASSES = 3`）收敛。

**`tests/test_at_markup.py`**：新增 8 个回归测试，覆盖：

- 报告里的真实案例：`<At:<At:[@id:255799348;nickname:KroMiose谬锶（摆烂中）@]>>`
- 嵌套但昵称无特殊字符（基线）
- 三层嵌套
- 单层 `<At:[...]>` 含全角 / 半角括号昵称
- 在自然语句中间
- 修复后 idempotent

## 验证

```
uv run python -m pytest tests/test_at_markup.py
====================== 104 passed, 399 warnings in 2.50s =======================

uv run poe check
Poe => ruff check .
All checks passed!
Poe => basedpyright nekro_agent
0 errors, 0 warnings, 0 notes
```

- 既有 96 个测试全部通过
- 新增 8 个回归测试覆盖嵌套 + 特殊字符昵称场景
- `poe lint` / `poe typecheck` 通过
- 修复后 `normalize_malformed_at_markup` 仍满足幂等性

## 数据兼容性

纯字符串层修复，不改动 payload 结构、Qdrant 索引、配置项。已部署的实例在模型下次输出该形态文本时即生效，无需数据迁移。

## 关联

Issue: #325

## Summary by Sourcery

调整 @ 提及昵称解析逻辑，以支持包含特殊字符的嵌套且格式错误的 `<At:...>` 标记，并确保规范化过程保持幂等性。

Bug Fixes:
- 修复在聊天记录中，带有括号或其他特殊括号的昵称导致格式错误的嵌套 `<At:<At:[...]>>` @ 提及被保留为原始标记的问题。

Enhancements:
- 将昵称解析模式与规范版本对齐，将排除集收缩为仅包含分隔符和结束标记字符。

Tests:
- 新增回归测试，覆盖带特殊字符昵称的嵌套 at 标记、多层嵌套场景，以及规范化过程的幂等性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust at-mention nickname parsing to support nested malformed `<At:...>` markup with special characters and ensure normalization remains idempotent.

Bug Fixes:
- Fix malformed nested `<At:<At:[...]>>` at-mentions with nicknames containing parentheses or other special brackets being left as raw markup in chat logs.

Enhancements:
- Align nickname parsing pattern with the canonical variant to narrow the exclusion set to only separator and close-marker characters.

Tests:
- Add regression tests covering nested at-markup with special-character nicknames, multi-level nesting, and idempotence of normalization.

</details>