### PR TITLE
feat(emotion): 新增表情包多模态嵌入 provider 抽象（占位）

### DIFF
--- a/plugins/builtin/emotion.py
+++ b/plugins/builtin/emotion.py
@@ -201,6 +201,105 @@ class EmotionConfig(ConfigBase):
             ),
         ).model_dump(),
     )
+    EMBEDDING_PROVIDER: str = Field(
+        default="text",
+        title="嵌入服务提供方",
+        description=(
+            "表情包向量化所用的提供方：text = 复用现有 OpenAI 兼容文本嵌入模型组；"
+            "multimodal = 使用阿里云 DashScope 多模态嵌入（直接对图片生成向量，"
+            "不依赖文本描述）。切换为 multimodal 后，向量维度与现有集合不兼容，"
+            "请先执行 /emo_reindex 重建索引。"
+        ),
+        json_schema_extra=ExtraField(
+            i18n_title=i18n.i18n_text(
+                zh_CN="嵌入服务提供方",
+                en_US="Embedding Provider",
+            ),
+            i18n_description=i18n.i18n_text(
+                zh_CN="表情包向量化所用的提供方：text=OpenAI 兼容文本嵌入；multimodal=阿里云 DashScope 多模态嵌入（图片直接向量化）。",
+                en_US=(
+                    "Embedding provider for emotions: "
+                    "text = OpenAI-compatible text embedding (current behavior); "
+                    "multimodal = Aliyun DashScope multimodal embedding (image-direct)."
+                ),
+            ),
+        ).model_dump(),
+    )
+    MULTIMODAL_API_KEY: str = Field(
+        default="",
+        title="多模态嵌入 API Key",
+        description="阿里云 DashScope（或其他多模态嵌入服务）的 API Key。建议通过环境变量注入。",
+        json_schema_extra=ExtraField(
+            i18n_title=i18n.i18n_text(
+                zh_CN="多模态嵌入 API Key",
+                en_US="Multimodal Embedding API Key",
+            ),
+            i18n_description=i18n.i18n_text(
+                zh_CN="阿里云 DashScope API Key，留空将使用对应环境变量。",
+                en_US="Aliyun DashScope API key. Falls back to env var when empty.",
+            ),
+        ).model_dump(),
+    )
+    MULTIMODAL_BASE_URL: str = Field(
+        default="https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding",
+        title="多模态嵌入 Endpoint",
+        description="多模态嵌入服务的完整 URL。默认值为阿里云 DashScope multimodal-embedding 端点。",
+        json_schema_extra=ExtraField(
+            i18n_title=i18n.i18n_text(
+                zh_CN="多模态嵌入 Endpoint",
+                en_US="Multimodal Embedding Endpoint",
+            ),
+            i18n_description=i18n.i18n_text(
+                zh_CN="多模态嵌入服务的完整 URL（默认阿里云 DashScope）。",
+                en_US="Full URL for the multimodal embedding service (default: Aliyun DashScope).",
+            ),
+        ).model_dump(),
+    )
+    MULTIMODAL_MODEL: str = Field(
+        default="multimodal-embedding-v1",
+        title="多模态嵌入模型名",
+        description="提交给多模态嵌入服务的模型标识（默认 multimodal-embedding-v1）。",
+        json_schema_extra=ExtraField(
+            i18n_title=i18n.i18n_text(
+                zh_CN="多模态嵌入模型名",
+                en_US="Multimodal Embedding Model",
+            ),
+            i18n_description=i18n.i18n_text(
+                zh_CN="提交给多模态嵌入服务的模型标识。",
+                en_US="Model identifier sent to the multimodal embedding service.",
+            ),
+        ).model_dump(),
+    )
+    MULTIMODAL_DIMENSION: int = Field(
+        default=1024,
+        title="多模态嵌入维度",
+        description="多模态嵌入返回的向量维度，需与 Qdrant 集合的 size 一致；切换 provider 后请 /emo_reindex 重建索引。",
+        json_schema_extra=ExtraField(
+            i18n_title=i18n.i18n_text(
+                zh_CN="多模态嵌入维度",
+                en_US="Multimodal Embedding Dimension",
+            ),
+            i18n_description=i18n.i18n_text(
+                zh_CN="多模态嵌入返回的向量维度。",
+                en_US="Vector dimension returned by the multimodal embedding service.",
+            ),
+        ).model_dump(),
+    )
+    MULTIMODAL_REQUEST_TIMEOUT: int = Field(
+        default=30,
+        title="多模态嵌入请求超时时间",
+        description="调用多模态嵌入服务时的 HTTP 请求超时时间（秒）。图片 base64 较大时建议适当调大。",
+        json_schema_extra=ExtraField(
+            i18n_title=i18n.i18n_text(
+                zh_CN="多模态嵌入请求超时时间",
+                en_US="Multimodal Embedding Request Timeout",
+            ),
+            i18n_description=i18n.i18n_text(
+                zh_CN="调用多模态嵌入服务时的 HTTP 请求超时时间（秒）。",
+                en_US="HTTP timeout in seconds for multimodal embedding requests.",
+            ),
+        ).model_dump(),
+    )
 
 
 # 获取配置和插件存储
@@ -429,7 +528,39 @@ async def migrate_emotion_paths():
     return migrated_count
 
 
-async def generate_embedding(text: str, max_retries: int = 3) -> List[float]:
+async def generate_embedding(
+    text: str,
+    image_path: Optional[Path] = None,
+    max_retries: int = 3,
+) -> List[float]:
+    """生成表情包向量（按配置自动选择 provider，带重试机制）
+
+    Args:
+        text: 文本（仅 text provider 实际使用；multimodal 视为降级 fallback 文本）
+        image_path: 表情包图片绝对路径（仅 multimodal provider 实际使用）
+        max_retries: 最大重试次数，默认3次
+
+    Returns:
+        List[float]: 嵌入向量
+
+    Raises:
+        ValueError: 向量维度不匹配或 provider 配置缺失
+        NotImplementedError: multimodal provider 当前为占位实现，API 形态需在 PR 后续确认
+        Exception: 重试次数耗尽后仍然失败
+    """
+    provider = (emotion_config.EMBEDDING_PROVIDER or "text").strip().lower()
+    if provider == "multimodal":
+        if image_path is None:
+            raise ValueError("multimodal provider 需要 image_path，不能为空")
+        return await _generate_multimodal_embedding(image_path, text, max_retries)
+    if provider != "text":
+        logger.warning(
+            f"未知的 EMBEDDING_PROVIDER={emotion_config.EMBEDDING_PROVIDER!r},回退到 text provider",
+        )
+    return await _generate_text_embedding(text, max_retries)
+
+
+async def _generate_text_embedding(text: str, max_retries: int = 3) -> List[float]:
     """生成文本嵌入向量（带重试机制）
 
     Args:
@@ -531,6 +662,78 @@ async def generate_embedding(text: str, max_retries: int = 3) -> List[float]:
     else:
         error_msg = f"生成嵌入向量失败，已重试 {max_retries} 次: {last_exception}"
     raise Exception(error_msg) from last_exception
+
+
+def _resolve_multimodal_api_key() -> str:
+    """解析多模态 API Key,优先读 config,再回退到环境变量。
+
+    环境变量命名约定:
+    - DASHSCOPE_API_KEY (Aliyun DashScope 默认)
+    - NEKRO_MULTIMODAL_API_KEY (项目级 override)
+    """
+    cfg_key = (emotion_config.MULTIMODAL_API_KEY or "").strip()
+    if cfg_key:
+        return cfg_key
+    import os
+
+    return os.environ.get("DASHSCOPE_API_KEY", "") or os.environ.get(
+        "NEKRO_MULTIMODAL_API_KEY",
+        "",
+    )
+
+
+async def _generate_multimodal_embedding(
+    image_path: Path,
+    fallback_text: str,
+    max_retries: int = 3,
+) -> List[float]:
+    """多模态嵌入占位实现
+
+    本函数是 ``EMBEDDING_PROVIDER=multimodal`` 时被 ``generate_embedding`` 调用的入口。
+    设计目标: 当主文本嵌入服务 401 时,允许降级到「直接对图片生成向量」的方案。
+
+    当前实现为**占位**: 在不掌握官方 API 完整请求/响应形态前,不臆造不可运行代码,
+    直接抛出 ``NotImplementedError``,并在日志中给出需要确认的官方参数清单。
+    维护者完成下列官方参数验证后,只需替换本函数体即可启用:
+
+    1. 官方 endpoint / path 是否为 ``/embeddings`` 还是自定义子路径
+       (默认 ``MULTIMODAL_BASE_URL`` 已假设为 DashScope multimodal-embedding 完整 URL)。
+    2. 鉴权 header 形态 (DashScope 常见为 ``Authorization: Bearer <key>``)。
+    3. 请求 payload 形态 (DashScope 通常为
+       ``{"model": "...", "input": {"contents": [{"image": "<data:image/...;base64,...>"}, {"text": "..."}]}}``)
+       或 OpenAI 兼容多模态 embeddings 风格。
+    4. 响应中向量字段路径 (常见为 ``output.embeddings[*].embedding`` 或
+       ``data[*].embedding``)。
+    5. 维度参数是否需要随请求一起传 (DashScope 默认按模型决定,需要在 prompt 注明)。
+
+    Args:
+        image_path: 表情包图片绝对路径
+        fallback_text: 文本描述 (供后续实现作为补充输入)
+        max_retries: 重试次数 (占位实现不消耗)
+
+    Raises:
+        NotImplementedError: 始终抛出,等待 PR 后续落实 API 形态
+    """
+    api_key = _resolve_multimodal_api_key()
+    if not api_key:
+        raise ValueError(
+            "EMBEDDING_PROVIDER=multimodal 需要配置 MULTIMODAL_API_KEY "
+            "或环境变量 DASHSCOPE_API_KEY / NEKRO_MULTIMODAL_API_KEY",
+        )
+
+    # 占位: 等待官方 API 形态确认后实现。当前显式 NotImplementedError,
+    # 便于在管理员选择 multimodal 但 provider 尚未落地的中间状态下立刻失败并暴露问题,
+    # 而不是悄悄回退到文本嵌入 (后者会让 401 报错看上去 "好了" 但实际语义错位)。
+    logger.error(
+        "EMBEDDING_PROVIDER=multimodal 当前为占位实现,API 形态待官方参数确认后实现。"
+        f"需要确认的参数: endpoint={emotion_config.MULTIMODAL_BASE_URL!r}, "
+        f"model={emotion_config.MULTIMODAL_MODEL!r}, "
+        f"dimension={emotion_config.MULTIMODAL_DIMENSION}, "
+        f"image={image_path!s}, fallback_text={fallback_text[:30]!r}",
+    )
+    raise NotImplementedError(
+        "multimodal embedding provider is a placeholder pending official API spec verification"
+    )
 
 
 async def download_image(url: str, save_path: Path) -> bool:
@@ -947,7 +1150,7 @@ async def emo_reindex_cmd(
                 continue
 
             embedding_text = f"{metadata.description} {' '.join(metadata.tags)}"
-            embedding = await generate_embedding(embedding_text)
+            embedding = await generate_embedding(embedding_text, image_path=file_path)
 
             current_batch.append(
                 qdrant_models.PointStruct(
@@ -1125,7 +1328,10 @@ async def collect_emotion(
             emotion_store.add_emotion(duplicate_id, metadata)
 
             # 生成嵌入向量
-            embedding = await generate_embedding(f"{description} {' '.join(tags)}")
+            embedding = await generate_embedding(
+                f"{description} {' '.join(tags)}",
+                image_path=absolute_file_path,
+            )
 
             # 获取Qdrant客户端
             client = await get_qdrant_client()
@@ -1181,7 +1387,10 @@ async def collect_emotion(
     # 添加到向量数据库
     try:
         # 生成嵌入向量
-        embedding = await generate_embedding(f"{description} {' '.join(tags)}")
+        embedding = await generate_embedding(
+            f"{description} {' '.join(tags)}",
+            image_path=absolute_file_path,
+        )
 
         # 获取Qdrant客户端
         client = await get_qdrant_client()
@@ -1268,7 +1477,8 @@ async def update_emotion(
     # 更新向量数据库
     # 生成嵌入向量
     embedding_text = f"{description} {' '.join(tags)}"
-    embedding = await generate_embedding(embedding_text)
+    update_file_path = resolve_emotion_file_path(metadata.file_path)
+    embedding = await generate_embedding(embedding_text, image_path=update_file_path)
 
     # 获取Qdrant客户端
     client = await get_qdrant_client()

--- a/tests/test_emotion_embedding_provider.py
+++ b/tests/test_emotion_embedding_provider.py
@@ -1,0 +1,169 @@
+"""表情包嵌入 provider 抽象测试
+
+覆盖逻辑：`plugins/builtin/emotion.py` 中
+`generate_embedding` 的 provider 分发，以及 multimodal provider
+的占位实现（NotImplementedError + 清晰错误信息）。
+
+说明：本测试不直接 import `plugins.builtin.emotion`，
+原因是该模块在 import 时会触发 ``nekro_agent`` 完整初始化（数据库、Qdrant 等）。
+本测试通过对源文件做静态分析 + stub 实现来校验逻辑。
+"""
+
+import re
+from pathlib import Path
+
+# ----------------------------------------------------------------------------
+# 源码静态分析：保证核心契约不会被无意破坏
+# ----------------------------------------------------------------------------
+
+
+EMOTION_PY = (
+    Path(__file__).parent.parent / "plugins" / "builtin" / "emotion.py"
+)
+
+
+def _read_emotion_src() -> str:
+    return EMOTION_PY.read_text(encoding="utf-8")
+
+
+def test_emotion_module_defines_provider_config():
+    """EmotionConfig 必须暴露 EMBEDDING_PROVIDER 字段。"""
+    src = _read_emotion_src()
+    assert "EMBEDDING_PROVIDER" in src
+    # 默认值必须是 "text"，保持向后兼容
+    assert re.search(
+        r'EMBEDDING_PROVIDER:\s*str\s*=\s*Field\(\s*default="text"',
+        src,
+    ), "EMBEDDING_PROVIDER 必须默认 'text' 以保持向后兼容"
+
+
+def test_emotion_module_defines_multimodal_configs():
+    """多模态相关配置字段必须存在。"""
+    src = _read_emotion_src()
+    required = [
+        "MULTIMODAL_API_KEY",
+        "MULTIMODAL_BASE_URL",
+        "MULTIMODAL_MODEL",
+        "MULTIMODAL_DIMENSION",
+        "MULTIMODAL_REQUEST_TIMEOUT",
+    ]
+    for name in required:
+        assert name in src, f"缺少多模态配置字段: {name}"
+
+
+def test_generate_embedding_dispatches_on_provider():
+    """generate_embedding 必须按 provider 分发到 text 或 multimodal 实现。"""
+    src = _read_emotion_src()
+    # 分发核心逻辑: provider == "multimodal" 时调用 multimodal 实现
+    assert 'EMBEDDING_PROVIDER or "text"' in src or 'EMBEDDING_PROVIDER' in src
+    assert "_generate_multimodal_embedding" in src
+    assert "_generate_text_embedding" in src
+    # 未知 provider 必须回退到 text,避免误配置炸服务
+    assert "回退到 text provider" in src or "回退到 text" in src
+
+
+def test_generate_embedding_image_path_parameter_added():
+    """generate_embedding 必须新增 image_path 参数以支持 multimodal 输入。"""
+    src = _read_emotion_src()
+    # 函数签名必须包含 image_path
+    assert re.search(
+        r"async def generate_embedding\(\s*[^)]*image_path",
+        src,
+        re.DOTALL,
+    ), "generate_embedding 签名必须包含 image_path 参数"
+
+
+def test_multimodal_provider_raises_not_implemented():
+    """multimodal 占位必须明确抛 NotImplementedError 而不是静默回退。"""
+    src = _read_emotion_src()
+    assert "raise NotImplementedError" in src
+    # 错误信息中应包含 "multimodal" 关键字便于排查
+    assert "multimodal" in src.lower()
+
+
+def test_multimodal_api_key_env_fallback():
+    """多模态 API Key 必须支持从环境变量回退,不得硬编码。"""
+    src = _read_emotion_src()
+    assert "_resolve_multimodal_api_key" in src
+    # 至少出现 DASHSCOPE_API_KEY 或 NEKRO_MULTIMODAL_API_KEY 之一作为环境变量 fallback
+    assert (
+        "DASHSCOPE_API_KEY" in src or "NEKRO_MULTIMODAL_API_KEY" in src
+    ), "多模态 API Key 必须支持环境变量回退"
+
+
+def test_multimodal_base_url_default_points_to_dashscope():
+    """多模态默认 endpoint 必须指向阿里云 DashScope,便于国内用户开箱即用。"""
+    src = _read_emotion_src()
+    m = re.search(
+        r'MULTIMODAL_BASE_URL:\s*str\s*=\s*Field\(\s*default="([^"]+)"',
+        src,
+    )
+    assert m, "MULTIMODAL_BASE_URL 必须显式给定默认值"
+    default_url = m.group(1)
+    assert "dashscope" in default_url.lower(), (
+        f"MULTIMODAL_BASE_URL 默认值应指向阿里云 DashScope,实际: {default_url}"
+    )
+
+
+def test_no_hardcoded_api_key_in_module():
+    """禁止在源码中硬编码 API Key,仅允许默认值=空 + 环境变量回退。"""
+    src = _read_emotion_src()
+    # 简易检查: MULTIMODAL_API_KEY 默认值必须为空字符串
+    m = re.search(
+        r'MULTIMODAL_API_KEY:\s*str\s*=\s*Field\(\s*default="([^"]*)"',
+        src,
+    )
+    assert m, "MULTIMODAL_API_KEY 字段定义未找到"
+    default_value = m.group(1)
+    assert default_value == "", (
+        f"MULTIMODAL_API_KEY 默认值必须为空字符串以避免泄露密钥,实际: {default_value!r}"
+    )
+
+
+def test_collect_update_reindex_pass_image_path():
+    """collect / update / reindex 路径必须把图片路径传给 generate_embedding。"""
+    src = _read_emotion_src()
+    # 至少出现 3 次 image_path= 调用,覆盖 collect / update / reindex 三条路径
+    matches = re.findall(r"image_path=", src)
+    assert len(matches) >= 3, (
+        f"generate_embedding 调用点应至少 3 处传入 image_path,实际: {len(matches)}"
+    )
+
+
+# ----------------------------------------------------------------------------
+# 行为测试: 通过 stub 验证 multimodal 占位逻辑
+# ----------------------------------------------------------------------------
+
+
+def _stub_multimodal_dispatch(provider_value: str) -> str:
+    """复刻 generate_embedding 中的 provider 分发判定。"""
+    provider = (provider_value or "text").strip().lower()
+    if provider == "multimodal":
+        return "multimodal"
+    if provider != "text":
+        return "fallback_text"
+    return "text"
+
+
+def test_dispatch_text_provider():
+    assert _stub_multimodal_dispatch("text") == "text"
+
+
+def test_dispatch_multimodal_provider():
+    assert _stub_multimodal_dispatch("multimodal") == "multimodal"
+
+
+def test_dispatch_empty_provider_falls_back_to_text():
+    """空字符串必须回退到 text 而非崩服务。"""
+    assert _stub_multimodal_dispatch("") == "text"
+
+
+def test_dispatch_unknown_provider_warns_and_falls_back():
+    """未知 provider 应回退到 text(便于管理员误配时优雅降级)。"""
+    assert _stub_multimodal_dispatch("foobar") == "fallback_text"
+
+
+def test_dispatch_case_insensitive():
+    """provider 比较应大小写不敏感。"""
+    assert _stub_multimodal_dispatch("MULTIMODAL") == "multimodal"
+    assert _stub_multimodal_dispatch("Text") == "text"


### PR DESCRIPTION
## 背景

群友反馈「表情包收集入库时嵌入服务返回 401」,并建议接入阿里云 DashScope 多模态嵌入作为降级方案。当前 ``plugins/builtin/emotion.py`` 仅支持基于文本的 OpenAI 兼容嵌入,无法直接对图片生成向量。

## 设计权衡

本 PR 严格遵循「不臆造不可运行代码」原则:

1. **不直接实现** ``_generate_multimodal_embedding`` 的真实 API 调用 —— 当前无法在沙箱中访问 DashScope 官方文档核验请求/响应形态。
2. **提供清晰抽象**: provider 字段 + 6 个 multimodal 配置 + 分发逻辑,占位函数 ``NotImplementedError`` + 列出 5 项需要官方确认的 API 参数。
3. **不破坏现有行为**: ``EMBEDDING_PROVIDER`` 默认 ``"text"``,所有现有用户行为不变。

## 变更摘要

| 文件 | 行数 | 说明 |
|------|------|------|
| ``plugins/builtin/emotion.py`` | +215 / -5 | 新增 6 个配置字段、重构 ``generate_embedding`` 为分发器、新增占位实现、更新 4 处 call site |
| ``tests/test_emotion_embedding_provider.py`` | +169 (新文件) | 14 个测试覆盖:配置存在性、源码契约、API Key 不硬编码、endpoint 默认值、分发逻辑 |

## 配置 Schema

```
EMBEDDING_PROVIDER:        "text" | "multimodal"  # 默认 "text"
MULTIMODAL_API_KEY:        str                    # 默认 "",回退环境变量 DASHSCOPE_API_KEY / NEKRO_MULTIMODAL_API_KEY
MULTIMODAL_BASE_URL:       str                    # 默认 https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding
MULTIMODAL_MODEL:          str                    # 默认 "multimodal-embedding-v1"
MULTIMODAL_DIMENSION:      int                    # 默认 1024
MULTIMODAL_REQUEST_TIMEOUT: int                   # 默认 30
```

## 待维护者落实的参数 (在占位函数注释中已列)

1. 官方 endpoint path 是否需要追加子路径
2. 鉴权 header 形态 (Bearer token vs APIKey header)
3. 请求 payload 形态 (DashScope 的 ``input.contents`` 风格 vs OpenAI 多模态风格)
4. 响应中向量字段路径
5. 维度参数是否随请求一起传

## 验证结果

```bash
$ uv run --no-cache ruff check plugins/builtin/emotion.py \
                                         tests/test_emotion_embedding_provider.py
All checks passed!

$ uv run --no-cache python -m pytest tests/test_emotion_embedding_provider.py -v
============================= 14 passed in 0.03s ==============================
```

## 兼容性

- 默认行为零变化:``EMBEDDING_PROVIDER="text"`` 时所有路径走原有 ``_generate_text_embedding``。
- 新参数 ``image_path`` 在 ``generate_embedding`` 中默认 ``None``,text provider 忽略此参数,完全向后兼容。
- 切换至 multimodal 后,向量维度会变化,**用户需执行** ``/emo_reindex -y`` **重建索引** —— 已在配置项 description 中提示。

## 不在范围内

- 文本-图像跨模态搜索(textual query → image embedding) —— 需要保持 image 与 text 在同一向量空间,等 API 形态确认后再实现。
- embedding 缓存层 —— 当前 401 是鉴权层问题,加缓存不解决根因。
- 多 provider 联邦降级(text → multimodal 自动回退) —— 留作未来可选增强。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

添加一个可配置的情绪向量嵌入提供者框架，包括多模态占位实现和更新后的调用端，同时保留现有的基于文本的行为，并为新的抽象添加测试覆盖。

New Features:
- 引入用于情绪向量的嵌入提供者抽象，可配置文本和多模态提供者。

Enhancements:
- 添加多模态嵌入的配置选项（API key、endpoint、model、dimension、timeout），并提供支持国际化的描述。
- 将情绪嵌入生成重构为一个提供者分发函数，该函数支持可选的图片路径，同时保持文本提供者为默认实现。

Tests:
- 添加专门的测试套件，用于验证新提供者和多模态配置字段的存在及其默认值、分发逻辑，以及各调用端是否将图片路径传递给嵌入生成。
- 添加测试以确保多模态提供者仍然是一个明确的占位实现，会抛出 NotImplementedError，并且不会硬编码 API key。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable embedding provider framework for emotion vectors, including multimodal placeholders and updated call sites, while preserving existing text-based behavior and covering the new abstraction with tests.

New Features:
- Introduce an embedding provider abstraction for emotion vectors with configurable text and multimodal providers.

Enhancements:
- Add multimodal embedding configuration options (API key, endpoint, model, dimension, timeout) with i18n-aware descriptions.
- Refactor emotion embedding generation into a provider-dispatching function that supports optional image paths while keeping text provider as the default.

Tests:
- Add a dedicated test suite validating the presence and defaults of the new provider and multimodal config fields, the dispatch logic, and that call sites pass image paths to embedding generation.
- Add tests to ensure the multimodal provider remains a clear placeholder raising NotImplementedError and that API keys are not hardcoded.

</details>