### PR TITLE
feat: 添加 You.com 官方 MCP 服务器到内置注册表

### DIFF
--- a/nekro_agent/services/mcp/registry.py
+++ b/nekro_agent/services/mcp/registry.py
@@ -84,6 +84,22 @@ BUILTIN_REGISTRY: list[McpRegistryItem] = [
     ),
     # ── 空白传输类型模板（从零开始） ──
     McpRegistryItem(
+        id="youcom",
+        name="You.com",
+        description="You.com 官方托管 MCP 服务器，支持网页搜索、深度研究和内容提取",
+        icon="search",
+        type=McpServerType.sse,
+        url="https://api.you.com/mcp",
+        env_keys=[
+            McpEnvKeyDef(
+                key="YOUCOM_API_KEY",
+                description="You.com API 密钥（可选；无 key 时使用公开访问额度）",
+                required=False,
+            ),
+        ],
+        tags=["preset", "sse", "search", "research"],
+    ),
+    McpRegistryItem(
         id="blank-stdio",
         name="自定义 stdio 服务",
         description="基于命令行进程通信的 MCP 服务（最常见类型）",


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [x] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 若有类型忽略标记，请简述原因 -->

## 🔍 变更类型 (勾选所有适用项)

- [ ] 🐛 Bug 修复 (修复一个问题)
- [x] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

<!-- 请详细描述你的PR解决了什么问题，为什么这个变更是必要的 -->
在 nekro_agent/services/mcp/registry.py 的 BUILTIN_REGISTRY 中新增 You.com 官方托管 MCP 服务器条目。You.com MCP 为 SSE 类型远程服务（https://api.you.com/mcp），提供 you-search（网页搜索）、you-research（深度研究）、you-content （内容提取）等工具，可供 Agent 在沙盒中直接调用，无需额外部署 MCP 服务端。

## 🔗 相关 Issue

<!-- 如果有相关Issue，请在此处引用 (例如: Closes #123, Fixes #456) -->
Closes https://github.com/KroMiose/nekro-agent/issues/329

## 📸 修改效果截图

<!-- 如果你的PR包含UI变更或功能改进，请提供修改前后的对比截图 -->
不涉及 UI 变更

## 🛠️ 实现复杂度

<!-- 请选择一项 -->

- [x] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

<!-- 如果实现方式比较复杂或特殊，可以在这里详细说明技术实现 -->
新增 16 行代码，在 BUILTIN_REGISTRY 列表末尾、blank-* 模板之前插入一个 McpRegistryItem 条目：
- id="youcom"，name="You.com"
- type=McpServerType.sse，url="https://api.you.com/mcp"
- YOUCOM_API_KEY 定义为可选环境变量（You.com MCP 支持免 Key 公开访问）
- 标签：["preset", "sse", "search", "research"]
无路由、Schema、文档或测试文件变更，纯注册表数据条目添加。

## 🧪 测试步骤 (可选)

<!-- 说明如何测试这个PR的功能，例如:
1. 进入...页面
2. 点击...按钮
3. 观察...结果
-->
1. 启动 NekroAgent，进入 MCP 管理页面
2. 在预设 MCP 服务器列表中确认看到 "You.com" 条目
3. 启用并填写 YOUCOM_API_KEY（可选）
4. 点击验证，确认 MCP 握手成功并显示可用工具列表

## Summary by Sourcery

新功能：
- 在内置 MCP 注册表中注册官方的 You.com SSE MCP 服务器，使搜索、研究和内容提取工具在无需自定义服务器部署的情况下即可使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Register the official You.com SSE MCP server in the built-in MCP registry, enabling search, research, and content extraction tools without custom server deployment.

</details>