### PR TITLE
feat(plugin): 支持插件 WebUI 页面路径

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,4 +273,3 @@ NekroAgent 采用 [自定义的开源协议](./LICENSE)（基于 Apache License 
 ## ⭐ Star 历史
 
 ![Star History Chart](https://api.star-history.com/svg?repos=KroMiose/nekro-agent&type=Date)
-```

--- a/frontend/src/locales/en-US/plugins.json
+++ b/frontend/src/locales/en-US/plugins.json
@@ -3,6 +3,7 @@
   "tabs": {
     "info": "Info",
     "config": "Config",
+    "webui": "Page",
     "methods": "Methods",
     "webhook": "Webhook",
     "data": "Data Management"
@@ -85,6 +86,11 @@
     "copied": "Webhook URL copied!",
     "description": "Description",
     "noEndpoints": "No webhook endpoints defined for this plugin"
+  },
+  "webui": {
+    "title": "{{name}} Plugin Page",
+    "loading": "Loading plugin page...",
+    "openInNewPage": "Open in New Page"
   },
   "data": {
     "title": "Plugin Data",

--- a/frontend/src/locales/zh-CN/plugins.json
+++ b/frontend/src/locales/zh-CN/plugins.json
@@ -3,6 +3,7 @@
   "tabs": {
     "info": "基本信息",
     "config": "配置",
+    "webui": "页面",
     "methods": "方法",
     "webhook": "Webhook",
     "data": "数据管理"
@@ -73,6 +74,11 @@
     "copied": "已复制 Webhook 地址～",
     "description": "描述",
     "noEndpoints": "此插件没有定义 Webhook 接入点"
+  },
+  "webui": {
+    "title": "{{name}} 插件页面",
+    "loading": "插件页面加载中...",
+    "openInNewPage": "新页面打开"
   },
   "methodTypes": {
     "tool": "工具方法",

--- a/frontend/src/pages/plugins/management.tsx
+++ b/frontend/src/pages/plugins/management.tsx
@@ -61,6 +61,8 @@ import {
   Bookmark as BookmarkIcon,
   MoreVert as MoreVertIcon,
   Close as CloseIcon,
+  WebAsset as WebAssetIcon,
+  OpenInNew as OpenInNewIcon,
 } from '@mui/icons-material'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Method, Plugin, pluginsApi } from '../../services/api/plugins'
@@ -95,6 +97,8 @@ const getPluginDescription = (plugin: Plugin, language: string) => {
   return getLocalizedText(plugin.i18n_description, plugin.description, language)
 }
 
+type PluginTabKey = 'info' | 'config' | 'webui' | 'methods' | 'webhook' | 'data'
+
 interface PluginDetailProps {
   plugin: Plugin
   activationStrategyLoading: boolean
@@ -111,7 +115,8 @@ function PluginDetails({
   onToggleEnabled,
   onOpenPlugin,
 }: PluginDetailProps) {
-  const [activeTab, setActiveTab] = useState(0)
+  const [activeTab, setActiveTab] = useState<PluginTabKey>('info')
+  const [webuiLoaded, setWebuiLoaded] = useState(false)
   const [reloadConfirmOpen, setReloadConfirmOpen] = useState(false)
   const [resetDataConfirmOpen, setResetDataConfirmOpen] = useState(false)
   const [errorDetailOpen, setErrorDetailOpen] = useState(false)
@@ -130,12 +135,34 @@ function PluginDetails({
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'))
   const notification = useNotification()
   const { t, i18n } = useTranslation('plugins')
+  const pluginTabs = useMemo(
+    () =>
+      [
+        { key: 'info' as const, label: t('tabs.info'), icon: <InfoIcon />, isVisible: true },
+        {
+          key: 'config' as const,
+          label: t('tabs.config'),
+          icon: <SettingsIcon />,
+          isVisible: plugin.hasConfig,
+        },
+        {
+          key: 'webui' as const,
+          label: t('tabs.webui'),
+          icon: <WebAssetIcon />,
+          isVisible: Boolean(plugin.webuiPath && !plugin.loadFailed),
+        },
+        { key: 'methods' as const, label: t('tabs.methods'), icon: <CodeIcon />, isVisible: true },
+        { key: 'webhook' as const, label: t('tabs.webhook'), icon: <WebhookIcon />, isVisible: true },
+        { key: 'data' as const, label: t('tabs.data'), icon: <StorageIcon />, isVisible: true },
+      ].filter(tab => tab.isVisible),
+    [plugin.hasConfig, plugin.loadFailed, plugin.webuiPath, t]
+  )
 
   // 获取插件配置
   const { data: pluginConfig, isLoading: configLoading } = useQuery({
     queryKey: ['plugin-config', plugin?.id],
     queryFn: () => unifiedConfigApi.getPluginConfig(plugin?.id),
-    enabled: !!plugin && activeTab === 1 && plugin.hasConfig,
+    enabled: !!plugin && activeTab === 'config' && plugin.hasConfig,
   })
 
   // 获取插件文档
@@ -146,14 +173,14 @@ function PluginDetails({
   } = useQuery({
     queryKey: ['plugin-docs', plugin?.id],
     queryFn: () => pluginsApi.getPluginDocs(plugin.id),
-    enabled: !!plugin && activeTab === 0,
+    enabled: !!plugin && activeTab === 'info',
   })
 
   // 获取插件数据
   const { data: pluginData = [], isLoading: isDataLoading } = useQuery({
     queryKey: ['plugin-data', plugin?.id],
     queryFn: () => pluginsApi.getPluginData(plugin.id),
-    enabled: !!plugin && activeTab === 4,
+    enabled: !!plugin && activeTab === 'data',
   })
 
   // 重载插件
@@ -277,23 +304,23 @@ function PluginDetails({
     navigate('/plugins/editor')
   }
 
-  useEffect(() => {
-    // 如果当前tab不存在（例如从有配置的插件切换到没配置的），则重置
-    const tabCount = 1 + (plugin.hasConfig ? 1 : 0) + 1 + 1 + 1 // info + config? + methods + webhook + data
-    if (activeTab >= tabCount) {
-      setActiveTab(0)
+  const handleOpenWebuiInNewPage = () => {
+    if (!plugin.webuiPath) return
+    const openedWindow = window.open(plugin.webuiPath, '_blank', 'noopener,noreferrer')
+    if (openedWindow) {
+      openedWindow.opener = null
     }
-  }, [plugin, activeTab])
+  }
 
-  if (!plugin) return null
+  useEffect(() => {
+    if (!pluginTabs.some(tab => tab.key === activeTab)) {
+      setActiveTab('info')
+    }
+  }, [activeTab, pluginTabs])
 
-  const pluginTabs = [
-    { label: t('tabs.info'), icon: <InfoIcon />, isVisible: true },
-    { label: t('tabs.config'), icon: <SettingsIcon />, isVisible: plugin.hasConfig },
-    { label: t('tabs.methods'), icon: <CodeIcon />, isVisible: true },
-    { label: t('tabs.webhook'), icon: <WebhookIcon />, isVisible: true },
-    { label: t('tabs.data'), icon: <StorageIcon />, isVisible: true },
-  ].filter(tab => tab.isVisible)
+  useEffect(() => {
+    setWebuiLoaded(false)
+  }, [plugin.id, plugin.webuiPath])
 
   return (
     <Box
@@ -379,7 +406,7 @@ function PluginDetails({
         <Box sx={{ display: 'flex', alignItems: 'center', px: { xs: 1, sm: 1.5 } }}>
           <PageTabs
             value={activeTab}
-            onChange={(_, newValue) => setActiveTab(newValue)}
+            onChange={(_, newValue: PluginTabKey) => setActiveTab(newValue)}
             variant="scrollable"
             scrollButtons="auto"
             allowScrollButtonsMobile
@@ -399,7 +426,7 @@ function PluginDetails({
             }}
           >
             {pluginTabs.map(tab => (
-              <Tab key={tab.label} label={tab.label} icon={tab.icon} />
+              <Tab key={tab.key} value={tab.key} label={tab.label} icon={tab.icon} />
             ))}
           </PageTabs>
 
@@ -545,7 +572,7 @@ function PluginDetails({
 
       {/* 选项卡内容 */}
       <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
-        {activeTab === 0 && (
+        {activeTab === 'info' && (
           <Stack spacing={2}>
             {/* 插件信息 */}
             <Card sx={CARD_VARIANTS.default.styles}>
@@ -792,7 +819,7 @@ function PluginDetails({
         )}
 
         {/* 配置项 */}
-        {plugin.hasConfig && activeTab === 1 && (
+        {plugin.hasConfig && activeTab === 'config' && (
           <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
             {pluginConfig && pluginConfig.length > 0 ? (
               <ConfigTable
@@ -815,8 +842,86 @@ function PluginDetails({
           </Box>
         )}
 
+        {/* 插件页面 */}
+        {activeTab === 'webui' && plugin.webuiPath && (
+          <Card
+            sx={{
+              ...CARD_VARIANTS.default.styles,
+              height: '100%',
+              minHeight: { xs: 520, md: 640 },
+              overflow: 'hidden',
+            }}
+          >
+            <Box
+              sx={{
+                position: 'relative',
+                height: '100%',
+                minHeight: { xs: 520, md: 640 },
+                '& iframe': {
+                  width: '100%',
+                  height: '100%',
+                  border: 'none',
+                  opacity: webuiLoaded ? 1 : 0,
+                  transition: 'opacity 0.3s ease',
+                },
+              }}
+            >
+              {plugin.webuiType === 'route' && (
+                <ActionButton
+                  size="small"
+                  startIcon={<OpenInNewIcon fontSize="small" />}
+                  onClick={handleOpenWebuiInNewPage}
+                  sx={{
+                    position: 'absolute',
+                    top: 12,
+                    right: 12,
+                    zIndex: 2,
+                    bgcolor: 'background.paper',
+                    boxShadow: 1,
+                    opacity: 0.55,
+                    transition: 'opacity 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease',
+                    '&:hover': {
+                      opacity: 1,
+                      bgcolor: 'background.paper',
+                      boxShadow: 2,
+                    },
+                  }}
+                >
+                  {t('webui.openInNewPage')}
+                </ActionButton>
+              )}
+              <Box
+                component="iframe"
+                title={t('webui.title', { name: getPluginName(plugin, i18n.language) })}
+                src={plugin.webuiPath}
+                onLoad={() => setWebuiLoaded(true)}
+              />
+              <Box
+                sx={{
+                  position: 'absolute',
+                  inset: 0,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 2,
+                  bgcolor: 'background.paper',
+                  opacity: webuiLoaded ? 0 : 1,
+                  pointerEvents: webuiLoaded ? 'none' : 'auto',
+                  transition: 'opacity 0.3s ease',
+                }}
+              >
+                <CircularProgress size={32} />
+                <Typography variant="body2" color="text.secondary">
+                  {t('webui.loading')}
+                </Typography>
+              </Box>
+            </Box>
+          </Card>
+        )}
+
         {/* 方法列表 */}
-        {activeTab === (plugin.hasConfig ? 2 : 1) && (
+        {activeTab === 'methods' && (
           <Card sx={CARD_VARIANTS.default.styles}>
             <CardContent sx={{ p: isSmall ? 1.5 : 2 }}>
               {plugin.methods && plugin.methods.length > 0 ? (
@@ -905,7 +1010,7 @@ function PluginDetails({
         )}
 
         {/* Webhook 列表 */}
-        {activeTab === (plugin.hasConfig ? 3 : 2) && (
+        {activeTab === 'webhook' && (
           <Card sx={CARD_VARIANTS.default.styles}>
             <CardContent sx={{ p: isSmall ? 1.5 : 2 }}>
               {plugin.webhooks && plugin.webhooks.length > 0 ? (
@@ -1056,7 +1161,7 @@ function PluginDetails({
         )}
 
         {/* 数据管理 */}
-        {activeTab === 4 && (
+        {activeTab === 'data' && (
           <Card sx={CARD_VARIANTS.default.styles}>
             <CardContent>
               {isDataLoading ? (

--- a/frontend/src/services/api/plugins.ts
+++ b/frontend/src/services/api/plugins.ts
@@ -25,6 +25,8 @@ export interface Plugin {
   description: string
   author: string
   url: string
+  webuiPath?: string | null
+  webuiType?: 'route' | 'file' | null
   methods: Method[]
   webhooks: Webhook[]
   enabled: boolean

--- a/nekro_agent/services/plugin/base.py
+++ b/nekro_agent/services/plugin/base.py
@@ -1,6 +1,8 @@
 import asyncio
+import mimetypes
 import re
 from pathlib import Path
+from posixpath import normpath
 from types import ModuleType
 from typing import (
     Any,
@@ -17,7 +19,8 @@ from typing import (
 )
 
 import aiofiles
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
 
 from nekro_agent.core.core_utils import ConfigBase
 from nekro_agent.core.logger import get_sub_logger
@@ -59,6 +62,7 @@ class NekroPlugin:
         i18n_description: Optional[I18nDict] = None,
         allow_sleep: bool | None = None,
         sleep_brief: str = "",
+        webui_path: str | None = None,
     ):
         """
         Args:
@@ -71,6 +75,8 @@ class NekroPlugin:
             support_adapter: 支持的适配器
             i18n_name: 插件名称国际化
             i18n_description: 插件描述国际化
+            webui_path: 插件 WebUI 路径。以 / 开头时表示插件路由内页面路径；
+                相对路径时必须指向插件目录内的 HTML 文件。
 
         可用回调方法:
             init_method: 初始化方法
@@ -105,6 +111,7 @@ class NekroPlugin:
         self.i18n_description = i18n_description
         self.allow_sleep = allow_sleep
         self.sleep_brief = sleep_brief.strip()
+        self.webui_path = _normalize_webui_path(webui_path)
         self._is_enabled = True
         self._key = f"{self.author}.{self.module_name}"
 
@@ -310,26 +317,128 @@ class NekroPlugin:
             Optional[APIRouter]: 插件路由实例，如果插件没有注册路由则返回None
         """
 
-        if not self._router_func:
-            return None
-
         # 如果已有缓存的路由实例，直接返回
         if self._router is not None:
             return self._router
 
-        try:
-            # 调用路由生成函数
-            self._router = self._router_func()
+        if not self._router_func and not self._is_webui_html_file():
+            return None
 
-            if not isinstance(self._router, APIRouter):
-                self.logger.error(f"插件 {self.name} 的路由生成函数必须返回 APIRouter 实例，实际返回: {type(self._router)}")
+        try:
+            merged_router = APIRouter()
+            has_routes = False
+
+            if self._router_func:
+                # 调用路由生成函数
+                plugin_router = self._router_func()
+
+                if not isinstance(plugin_router, APIRouter):
+                    self.logger.error(f"插件 {self.name} 的路由生成函数必须返回 APIRouter 实例，实际返回: {type(plugin_router)}")
+                    return None
+                if plugin_router.routes:
+                    merged_router.include_router(plugin_router)
+                    has_routes = True
+
+            webui_router = self._create_webui_file_router()
+            if webui_router:
+                merged_router.include_router(webui_router)
+                has_routes = True
+
+            if not has_routes:
                 return None
+            self._router = merged_router
         except Exception:
             self.logger.exception(f"插件 {self.name} 生成路由时出错")
             return None
         else:
             self.logger.info(f"插件 {self.name} 路由生成成功，路由数量: {len(self._router.routes)}")
             return self._router
+
+    def get_webui_url_path(self) -> str | None:
+        """获取前端可直接加载的插件 WebUI URL 路径。"""
+        if not self.webui_path:
+            return None
+        if self.webui_path.startswith("/"):
+            if not self._router_func:
+                return None
+            return f"/plugins/{self.key}{self.webui_path}"
+        html_file = self._resolve_webui_html_file()
+        if not html_file:
+            return None
+        return f"/plugins/{self.key}/__webui__/{html_file.name}"
+
+    def get_webui_type(self) -> Literal["route", "file"] | None:
+        """获取插件 WebUI 类型，用于前端决定可用操作。"""
+        if not self.webui_path:
+            return None
+        if self.webui_path.startswith("/"):
+            return "route" if self._router_func else None
+        return "file" if self._resolve_webui_html_file() else None
+
+    def _is_webui_html_file(self) -> bool:
+        return bool(self.webui_path and not self.webui_path.startswith("/"))
+
+    def _get_source_dir(self) -> Path | None:
+        if not self._module or not self._module.__file__:
+            return None
+        return Path(self._module.__file__).resolve().parent
+
+    def _resolve_webui_html_file(self) -> Path | None:
+        if not self._is_webui_html_file() or not self.webui_path:
+            return None
+
+        source_dir = self._get_source_dir()
+        if not source_dir:
+            self.logger.error(f"插件 {self.name} 未绑定模块文件，无法解析 WebUI HTML: {self.webui_path}")
+            return None
+
+        html_path = (source_dir / Path(*self.webui_path.split("/"))).resolve()
+        source_root = source_dir.resolve()
+        if not html_path.is_relative_to(source_root):
+            self.logger.error(f"插件 {self.name} 的 WebUI HTML 越界: {self.webui_path}")
+            return None
+        if not html_path.is_file():
+            self.logger.error(f"插件 {self.name} 的 WebUI HTML 文件不存在: {html_path}")
+            return None
+        return html_path
+
+    def _create_webui_file_router(self) -> APIRouter | None:
+        html_file = self._resolve_webui_html_file()
+        if not html_file:
+            return None
+
+        router = APIRouter(include_in_schema=False)
+        static_root = html_file.parent.resolve()
+
+        async def serve_file(file_path: str) -> FileResponse:
+            normalized_path = normpath(file_path).lstrip("/")
+            if not normalized_path or normalized_path == ".":
+                target_file = html_file
+            else:
+                target_file = (static_root / Path(*normalized_path.split("/"))).resolve()
+                if not target_file.is_relative_to(static_root):
+                    raise HTTPException(status_code=404, detail="File not found")
+                if not target_file.is_file():
+                    raise HTTPException(status_code=404, detail="File not found")
+
+            media_type, _encoding = mimetypes.guess_type(target_file.name)
+            if target_file.suffix.lower() in {".html", ".htm"}:
+                media_type = "text/html"
+            return FileResponse(target_file, media_type=media_type)
+
+        @router.get("/__webui__")
+        async def plugin_webui_root() -> FileResponse:
+            return await serve_file("")
+
+        @router.get("/__webui__/")
+        async def plugin_webui_index() -> FileResponse:
+            return await serve_file("")
+
+        @router.get("/__webui__/{file_path:path}")
+        async def plugin_webui_static(file_path: str) -> FileResponse:
+            return await serve_file(file_path)
+
+        return router
 
     def mount_sandbox_method(
         self,
@@ -990,3 +1099,40 @@ def _validate_name(name: str, field_name: str) -> str:
     if re.match(r"^\d", name):
         raise ValueError(f"{field_name} must not start with a number")
     return name
+
+
+def _normalize_webui_path(webui_path: str | None) -> str | None:
+    """规范化插件 WebUI 路径，只允许插件路由路径或插件内 HTML 相对路径。"""
+    if webui_path is None:
+        return None
+
+    normalized = webui_path.strip()
+    if not normalized:
+        return None
+    if "\\" in normalized:
+        raise ValueError("webui_path 不支持反斜杠路径")
+    if "://" in normalized or normalized.startswith("//"):
+        raise ValueError("webui_path 不支持外部 URL")
+
+    if normalized.startswith("/"):
+        if "?" in normalized or "#" in normalized:
+            raise ValueError("webui_path 路由模式只支持路径，不支持查询参数或锚点")
+        if any(part in {".", ".."} for part in normalized.split("/")):
+            raise ValueError("webui_path 路由模式包含非法路径片段")
+
+        route_path = normpath(normalized)
+        if not route_path.startswith("/"):
+            raise ValueError("webui_path 路由模式必须是插件内绝对路径")
+        if normalized.endswith("/") and route_path != "/":
+            route_path = f"{route_path}/"
+        return route_path
+
+    normalized = normpath(normalized)
+    path = Path(normalized)
+    if normalized == ".." or normalized.startswith("../") or path.is_absolute():
+        raise ValueError("webui_path 不允许越过插件目录")
+    if path.suffix.lower() not in {".html", ".htm"}:
+        raise ValueError("webui_path 使用相对路径时必须指向 .html 或 .htm 文件")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("webui_path 包含非法路径片段")
+    return normalized

--- a/nekro_agent/services/plugin/manager.py
+++ b/nekro_agent/services/plugin/manager.py
@@ -76,6 +76,8 @@ async def get_all_ext_meta_data() -> List[dict]:
             "author": plugin.author,
             "enabled": plugin.is_enabled,
             "hasConfig": hasattr(plugin, "_Configs") and plugin._Configs != ConfigBase,  # noqa: SLF001
+            "webuiPath": plugin.get_webui_url_path(),
+            "webuiType": plugin.get_webui_type(),
             "url": plugin.url or "",
             "isBuiltin": plugin.is_builtin,
             "isPackage": plugin.is_package,
@@ -98,6 +100,8 @@ async def get_all_ext_meta_data() -> List[dict]:
                 "author": "N/A",
                 "enabled": False,
                 "hasConfig": False,
+                "webuiPath": None,
+                "webuiType": None,
                 "url": "N/A",
                 "isBuiltin": failed_plugin.is_builtin,
                 "isPackage": failed_plugin.is_package,
@@ -135,6 +139,8 @@ async def get_plugin_detail(plugin_id: str) -> Optional[dict]:
                 "url": "N/A",
                 "enabled": False,
                 "hasConfig": False,
+                "webuiPath": None,
+                "webuiType": None,
                 "methods": [],
                 "webhooks": [],
                 "router": None,
@@ -192,6 +198,8 @@ async def get_plugin_detail(plugin_id: str) -> Optional[dict]:
         "url": plugin.url or "",
         "enabled": plugin.is_enabled,
         "hasConfig": hasattr(plugin, "_Configs") and plugin._Configs != ConfigBase,  # noqa: SLF001
+        "webuiPath": plugin.get_webui_url_path(),
+        "webuiType": plugin.get_webui_type(),
         "methods": methods,
         "webhooks": webhooks,
         "router": router_info,  # 新增路由信息


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：Pylance (basic+) + ruff + Black Formatter
  - 前端：TypeScript 严格模式
- [x] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：

## 🔍 变更类型 (勾选所有适用项)

- [ ] 🐛 Bug 修复 (修复一个问题)
- [x] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

### 概述

为插件系统增加 `webui_path` 支持，让插件可以在 WebUI 插件详情页中挂载自定义页面。

### 主要改动

- `NekroPlugin` 新增 `webui_path` 参数
- 支持两种 WebUI 页面模式：
  - 路由模式：如 `/`、`/admin`，加载 `/plugins/{plugin.id}/...`
  - HTML 文件模式：如 `web/index.html`，自动挂载为静态页面
- HTML 文件模式会自动服务同目录下的 `style.css`、`script.js`、图片等资源
- 插件列表和详情接口新增 `webuiPath` / `webuiType`
- 插件详情页新增“页面”Tab，通过 iframe 加载插件页面
- 路由模式下提供“新页面打开”按钮，文件模式不显示
- 加强 route 模式 `webui_path` 校验，拒绝 `..`、query、hash 等非法路径


## 📸 修改效果截图

<img width="1281" height="832" alt="image" src="https://github.com/user-attachments/assets/f505e1e2-1adf-4348-ac47-0ea67bb0f0a1" />

## 🛠️ 实现复杂度

- [x] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## Summary by Sourcery

添加对插件自定义 WebUI 页面 的支持，并在后端元数据和前端插件管理界面中展示这些页面。

新功能：
- 允许插件声明 `webui_path`，用于内部路由或基于 HTML 文件的页面，这些页面从插件目录中提供服务。
- 通过插件列表和详情 API 暴露插件 WebUI 的 URL 和类型，供前端使用。
- 在插件管理页面中添加 WebUI 选项卡，通过 iframe 加载插件 WebUI，并可选支持在新浏览器标签页中打开基于路由的页面。

增强：
- 规范化并校验 `webui_path` 的值，以防止在插件 WebUI 配置中出现非法路径、外部 URL 和目录遍历。
- 通过额外的 FastAPI 路由自动挂载基于静态 HTML 的插件 WebUI 页面及其相邻静态资源。
- 重构插件详情页中的选项卡，改为使用稳定的字符串键而非位置索引，以实现更健壮的选项卡处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for plugin-defined WebUI pages and surface them in both backend metadata and the frontend plugin management UI.

New Features:
- Allow plugins to declare a webui_path for either internal routes or HTML file-based pages served from the plugin directory.
- Expose plugin WebUI URL and type via plugin list and detail APIs for frontend consumption.
- Add a WebUI tab in the plugin management page that loads the plugin WebUI via iframe and optionally allows opening route-based pages in a new browser tab.

Enhancements:
- Normalize and validate webui_path values to prevent invalid paths, external URLs, and directory traversal in plugin WebUI configuration.
- Auto-mount static HTML-based plugin WebUI pages and their adjacent assets through additional FastAPI routes.
- Refactor plugin detail tabs to use stable string keys instead of positional indices for more robust tab handling.

</details>