### PR TITLE
feat: add Atlas Cloud provider preset

### DIFF
--- a/frontend/src/config/model-presets.ts
+++ b/frontend/src/config/model-presets.ts
@@ -43,6 +43,11 @@ export const OPENAI_COMPAT_PROVIDERS: OpenAICompatProvider[] = [
     label: { 'zh-CN': 'NekroAI中转', 'en-US': 'NekroAI Relay' },
   },
   {
+    id: 'atlasCloud',
+    url: 'https://api.atlascloud.ai/v1',
+    label: { 'zh-CN': 'Atlas Cloud', 'en-US': 'Atlas Cloud' },
+  },
+  {
     id: 'googleGemini',
     url: 'https://generativelanguage.googleapis.com/v1beta/openai',
     label: { 'zh-CN': '谷歌Gemini', 'en-US': 'Google Gemini' },


### PR DESCRIPTION
# PR submission checklist

## License confirmation

- [x] I have read and agree to the NekroAgent license terms, including the contributor terms.
- [x] I confirm that this contribution does not infringe third-party intellectual property.

## Code quality

- [x] TypeScript strict type checking and ESLint completed successfully.
- [x] No type-ignore markers were added.

## Change type

- [x] New feature
- [x] Configuration change
- [x] AI model/provider related

## Description

Add Atlas Cloud to the shared OpenAI-compatible provider preset registry with its official `https://api.atlascloud.ai/v1` base URL.

The shared registry is consumed by both the initial setup flow and model group settings, so users can select Atlas Cloud without manually entering the endpoint in either location. The change follows the existing provider preset structure and does not add promotional README content.

## Related issue

N/A. The contribution guide and PR template do not require an issue for this scoped provider preset.

## Screenshot

N/A. This adds an option to the existing provider selectors without changing their layout or styling.

## Implementation complexity

- [x] Simple

## Testing

- `uv tool run --from poethepoet poe frontend-check-full`
  - TypeScript typecheck passed
  - ESLint passed with zero warnings
  - Vite production build passed
- Live Atlas Cloud compatibility probe:
  - `POST /v1/chat/completions`
  - model: `deepseek-ai/deepseek-v3.2`
  - HTTP 200, `finish_reason=stop`, non-empty content

## Summary by Sourcery

新功能：
- 引入 Atlas Cloud OpenAI 兼容的提供方预设，并使用其官方 API 基础 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce an Atlas Cloud OpenAI-compatible provider preset with its official API base URL.

</details>