### PR TITLE
插件添加调用优先级

### DIFF
--- a/frontend/src/locales/en-US/plugins.json
+++ b/frontend/src/locales/en-US/plugins.json
@@ -59,6 +59,16 @@
       "always_loaded": "Always fully visible"
     }
   },
+  "callPriority": {
+    "label": "Call Priority",
+    "description": "When multiple plugins provide equivalent capabilities, prefer higher-priority plugins and fall back to medium or low if needed. Auto leaves the decision to the model.",
+    "options": {
+      "auto": "Auto",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low"
+    }
+  },
   "methods": {
     "name": "Method Name",
     "title": "Title",
@@ -155,6 +165,7 @@
     "resetFailed": "Reset failed",
     "refreshFailed": "Refresh failed",
     "updateFailedWithMessage": "Update failed: {{message}}",
+    "callPriorityUpdated": "Plugin call priority updated",
     "activationStrategyUpdated": "Plugin activation strategy updated",
     "pluginNotFound": "Target plugin not found"
   },

--- a/frontend/src/locales/zh-CN/plugins.json
+++ b/frontend/src/locales/zh-CN/plugins.json
@@ -59,6 +59,16 @@
       "always_loaded": "始终完整可见"
     }
   },
+  "callPriority": {
+    "label": "调用优先级",
+    "description": "当多个插件提供相同或相似功能时，优先调用高优先级插件；高优先级插件无法完成时再尝试中、低优先级。自动表示由大模型自行判断。",
+    "options": {
+      "auto": "自动",
+      "high": "高",
+      "medium": "中",
+      "low": "低"
+    }
+  },
   "methods": {
     "name": "方法名",
     "title": "标题",
@@ -155,6 +165,7 @@
     "resetFailed": "重置失败",
     "refreshFailed": "刷新失败",
     "updateFailedWithMessage": "更新失败: {{message}}",
+    "callPriorityUpdated": "插件调用优先级已更新",
     "activationStrategyUpdated": "插件激活策略已更新",
     "pluginNotFound": "未找到目标插件"
   },

--- a/frontend/src/pages/plugins/management.tsx
+++ b/frontend/src/pages/plugins/management.tsx
@@ -65,7 +65,7 @@ import {
   OpenInNew as OpenInNewIcon,
 } from '@mui/icons-material'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Method, Plugin, pluginsApi } from '../../services/api/plugins'
+import { Method, Plugin, PluginCallPriority, pluginsApi } from '../../services/api/plugins'
 
 import { unifiedConfigApi, createConfigService } from '../../services/api/unified-config'
 import ConfigTable from '../../components/common/ConfigTable'
@@ -229,6 +229,19 @@ function PluginDetails({
     },
   })
 
+  const updateCallPriorityMutation = useMutation({
+    mutationFn: (priority: PluginCallPriority) =>
+      pluginsApi.updatePluginCallPriority(plugin.id, priority),
+    onSuccess: () => {
+      notification.success(t('messages.callPriorityUpdated'))
+      queryClient.invalidateQueries({ queryKey: ['plugins'] })
+      queryClient.invalidateQueries({ queryKey: ['plugin-detail', plugin.id] })
+    },
+    onError: (error: Error) => {
+      notification.error(error.message)
+    },
+  })
+
   const updateActivationStrategyMutation = useMutation({
     mutationFn: (strategy: 'auto' | 'allow_sleep' | 'forbid_sleep') =>
       pluginsApi.updatePluginActivationStrategy(plugin.id, strategy),
@@ -294,6 +307,8 @@ function PluginDetails({
     return t(`types.${type}`)
   }
 
+  const callPriority = plugin.callPriority
+  const callPriorityConfigurable = !!callPriority && !plugin.loadFailed
   const activationStrategy = plugin.activationStrategy
   const activationConfigurable =
     !!activationStrategy && !plugin.loadFailed && activationStrategy.canChangeStrategy
@@ -665,6 +680,8 @@ function PluginDetails({
                           direction={{ xs: 'column', sm: 'row' }}
                           spacing={1}
                           alignItems={{ xs: 'stretch', sm: 'center' }}
+                          useFlexGap
+                          sx={{ flexWrap: { xs: 'nowrap', sm: 'wrap' } }}
                         >
                           <Typography variant="body2" sx={{ whiteSpace: 'nowrap', minWidth: 'fit-content' }}>
                             <strong>{t('activation.strategyLabel')}：</strong>
@@ -691,6 +708,34 @@ function PluginDetails({
                             </MenuItem>
                             <MenuItem value="forbid_sleep">{t('activation.options.forbid_sleep')}</MenuItem>
                           </TextField>
+                          {callPriority && (
+                            <>
+                              <Typography variant="body2" sx={{ whiteSpace: 'nowrap', minWidth: 'fit-content' }}>
+                                <strong>{t('callPriority.label')}：</strong>
+                              </Typography>
+                              <Tooltip arrow placement="top" title={t('callPriority.description')}>
+                                <TextField
+                                  select
+                                  size="small"
+                                  value={callPriority.configured}
+                                  disabled={
+                                    !callPriorityConfigurable || updateCallPriorityMutation.isPending
+                                  }
+                                  onChange={e =>
+                                    updateCallPriorityMutation.mutate(
+                                      e.target.value as PluginCallPriority
+                                    )
+                                  }
+                                  sx={{ minWidth: { xs: '100%', sm: 112 }, maxWidth: { sm: 140 } }}
+                                >
+                                  <MenuItem value="auto">{t('callPriority.options.auto')}</MenuItem>
+                                  <MenuItem value="high">{t('callPriority.options.high')}</MenuItem>
+                                  <MenuItem value="medium">{t('callPriority.options.medium')}</MenuItem>
+                                  <MenuItem value="low">{t('callPriority.options.low')}</MenuItem>
+                                </TextField>
+                              </Tooltip>
+                            </>
+                          )}
                           {activationStrategyLoading ? (
                             <Chip
                               icon={<CircularProgress size={14} color="inherit" />}

--- a/frontend/src/services/api/plugins.ts
+++ b/frontend/src/services/api/plugins.ts
@@ -3,6 +3,7 @@ import { createEventStream } from './utils/stream'
 import { I18nDict } from './types'
 
 export type MethodType = 'tool' | 'behavior' | 'agent' | 'multimodal_agent'
+export type PluginCallPriority = 'auto' | 'high' | 'medium' | 'low'
 
 export interface Method {
   name: string
@@ -40,6 +41,9 @@ export interface Plugin {
   errorType?: string
   filePath?: string
   stackTrace?: string
+  callPriority?: {
+    configured: PluginCallPriority
+  } | null
   activationStrategy?: {
     configured: 'auto' | 'allow_sleep' | 'forbid_sleep'
     effective: 'sleep' | 'always_loaded'
@@ -127,6 +131,16 @@ export const pluginsApi = {
   ): Promise<boolean> => {
     const response = await axios.post<ActionResponse>(`/plugins/activation-strategy/${pluginId}`, {
       strategy,
+    })
+    return response.data.ok
+  },
+
+  updatePluginCallPriority: async (
+    pluginId: string,
+    priority: PluginCallPriority
+  ): Promise<boolean> => {
+    const response = await axios.post<ActionResponse>(`/plugins/call-priority/${pluginId}`, {
+      priority,
     })
     return response.data.ok
   },

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -2208,6 +2208,12 @@ class CoreConfig(ConfigBase):
         description="按插件 module_name 覆盖插件提示词激活策略",
         json_schema_extra=ExtraField(is_hidden=True).model_dump(),
     )
+    PLUGIN_CALL_PRIORITIES: Dict[str, Literal["high", "medium", "low"]] = Field(
+        default={},
+        title="插件调用优先级覆盖",
+        description="按插件 module_name 覆盖大模型在同类能力间的调用优先级",
+        json_schema_extra=ExtraField(is_hidden=True).model_dump(),
+    )
 
     def get_model_group_info(self, model_name: str) -> ModelConfigGroup:
         try:

--- a/nekro_agent/routers/plugins.py
+++ b/nekro_agent/routers/plugins.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from nekro_agent.models.db_plugin_data import DBPluginData
 from nekro_agent.models.db_user import DBUser
 from nekro_agent.schemas.errors import NotFoundError, PluginLoadError, PluginNotFoundError, ValidationError
+from nekro_agent.services.plugin.call_priority import PluginCallPriority
 from nekro_agent.services.plugin.collector import plugin_collector
 from nekro_agent.services.plugin.manager import (
     disable_plugin,
@@ -14,6 +15,7 @@ from nekro_agent.services.plugin.manager import (
     get_all_plugin_router_info,
     get_plugin_detail,
     update_plugin_activation_strategy,
+    update_plugin_call_priority,
 )
 from nekro_agent.services.user.deps import get_current_active_user
 from nekro_agent.services.user.perm import Role, require_role
@@ -39,6 +41,10 @@ class BatchUpdateConfig(BaseModel):
 
 class PluginActivationStrategyRequest(BaseModel):
     strategy: str
+
+
+class PluginCallPriorityRequest(BaseModel):
+    priority: PluginCallPriority
 
 
 class ActionResponse(BaseModel):
@@ -144,6 +150,19 @@ async def update_plugin_activation_strategy_handler(
     success, error = await update_plugin_activation_strategy(plugin_id, body.strategy)  # type: ignore[arg-type]
     if not success:
         raise ValidationError(reason=error or "插件激活策略更新失败")
+    return ActionResponse(ok=True)
+
+
+@router.post("/call-priority/{plugin_id}", summary="更新插件调用优先级", response_model=ActionResponse)
+@require_role(Role.Admin)
+async def update_plugin_call_priority_handler(
+    plugin_id: str,
+    body: PluginCallPriorityRequest = Body(...),
+    _current_user: DBUser = Depends(get_current_active_user),
+) -> ActionResponse:
+    success, error = await update_plugin_call_priority(plugin_id, body.priority)
+    if not success:
+        raise ValidationError(reason=error or "插件调用优先级更新失败")
     return ActionResponse(ok=True)
 
 

--- a/nekro_agent/services/agent/run_agent.py
+++ b/nekro_agent/services/agent/run_agent.py
@@ -13,6 +13,7 @@ from nekro_agent.models.db_chat_channel import DBChatChannel
 from nekro_agent.models.db_exec_code import ExecStopType
 from nekro_agent.schemas.agent_ctx import AgentCtx
 from nekro_agent.schemas.chat_message import ChatMessage
+from nekro_agent.services.plugin.call_priority import build_plugin_call_priority_rules
 from nekro_agent.services.plugin.collector import plugin_collector
 from nekro_agent.services.plugin.prompt_activation import build_plugin_activation_rules
 from nekro_agent.services.sandbox.runner import limited_run_code
@@ -130,6 +131,7 @@ async def run_agent(
         plugins_prompt=rendered_plugins.system_prompt,
         plugins_runtime_prompt=runtime_prompt,
         plugin_activation_rules=build_plugin_activation_rules() if activation_enabled else "",
+        plugin_call_priority_rules=build_plugin_call_priority_rules(),
         enable_cot=used_model_group.ENABLE_COT,
         chat_key_rules="\n".join(f"- {r}" for r in db_chat_channel.adapter.chat_key_rules),
         enable_at=db_chat_channel.adapter.config.SESSION_ENABLE_AT,

--- a/nekro_agent/services/agent/templates/compiler.py
+++ b/nekro_agent/services/agent/templates/compiler.py
@@ -39,6 +39,7 @@ class PromptCompiler:
         plugins_prompt: str,
         plugins_runtime_prompt: str,
         plugin_activation_rules: str,
+        plugin_call_priority_rules: str,
         enable_cot: bool,
         chat_key_rules: str,
         enable_at: bool,
@@ -49,6 +50,7 @@ class PromptCompiler:
         self.plugins_prompt = plugins_prompt
         self.plugins_runtime_prompt = plugins_runtime_prompt
         self.plugin_activation_rules = plugin_activation_rules
+        self.plugin_call_priority_rules = plugin_call_priority_rules
         self.enable_cot = enable_cot
         self.chat_key_rules = chat_key_rules
         self.enable_at = enable_at
@@ -64,6 +66,7 @@ class PromptCompiler:
                 chat_key_rules=self.chat_key_rules,
                 enable_at=self.enable_at,
                 plugin_activation_rules=self.plugin_activation_rules,
+                plugin_call_priority_rules=self.plugin_call_priority_rules,
             ).render(default_env),
         )
 

--- a/nekro_agent/services/agent/templates/j2/plugin.j2
+++ b/nekro_agent/services/agent/templates/j2/plugin.j2
@@ -1,5 +1,5 @@
-{% macro plugin_prompt(plugin_name, module_name, state, rounds_left, activation_hint, plugin_brief, plugin_injected_prompt, plugin_method_prompt) %}
-<plugin name="{{ plugin_name }}" module_name="{{ module_name }}" state="{{ state }}"{% if rounds_left is not none %} rounds_left="{{ rounds_left }}"{% endif %}>
+{% macro plugin_prompt(plugin_name, module_name, call_priority, state, rounds_left, activation_hint, plugin_brief, plugin_injected_prompt, plugin_method_prompt) %}
+<plugin name="{{ plugin_name }}" module_name="{{ module_name }}" call_priority="{{ call_priority }}" state="{{ state }}"{% if rounds_left is not none %} rounds_left="{{ rounds_left }}"{% endif %}>
 
 {% if state == "sleeping" and plugin_brief %}
 <capability_brief>

--- a/nekro_agent/services/agent/templates/j2/runtime_contract.j2
+++ b/nekro_agent/services/agent/templates/j2/runtime_contract.j2
@@ -1,4 +1,4 @@
-{% macro runtime_contract_prompt(platform_name, bot_platform_id, enable_cot, chat_key_rules, enable_at, plugin_activation_rules) %}
+{% macro runtime_contract_prompt(platform_name, bot_platform_id, enable_cot, chat_key_rules, enable_at, plugin_activation_rules, plugin_call_priority_rules) %}
 Your {{ platform_name }} Id: {{ bot_platform_id }} (Useful for identifying the sender of the message)
 
 You are in a multi-user chat environment. Always be aware of who sent each message.
@@ -172,6 +172,11 @@ send_msg_text(chat_key, "I have to ...") # BAD EXAMPLE: This line will not be ex
 {% if plugin_activation_rules %}
 #### Plugin Activation Rules:
 {{ plugin_activation_rules }}
+{% endif %}
+
+{% if plugin_call_priority_rules %}
+#### Plugin Call Priority Rules:
+{{ plugin_call_priority_rules }}
 {% endif %}
 
 ### Warning:

--- a/nekro_agent/services/agent/templates/j2_zh/plugin.j2
+++ b/nekro_agent/services/agent/templates/j2_zh/plugin.j2
@@ -1,5 +1,5 @@
-{% macro plugin_prompt(plugin_name, module_name, state, rounds_left, activation_hint, plugin_brief, plugin_injected_prompt, plugin_method_prompt) %}
-<plugin name="{{ plugin_name }}" module_name="{{ module_name }}" state="{{ state }}"{% if rounds_left is not none %} rounds_left="{{ rounds_left }}"{% endif %}>
+{% macro plugin_prompt(plugin_name, module_name, call_priority, state, rounds_left, activation_hint, plugin_brief, plugin_injected_prompt, plugin_method_prompt) %}
+<plugin name="{{ plugin_name }}" module_name="{{ module_name }}" call_priority="{{ call_priority }}" state="{{ state }}"{% if rounds_left is not none %} rounds_left="{{ rounds_left }}"{% endif %}>
 
 {% if state == "sleeping" and plugin_brief %}
 <capability_brief>

--- a/nekro_agent/services/agent/templates/j2_zh/runtime_contract.j2
+++ b/nekro_agent/services/agent/templates/j2_zh/runtime_contract.j2
@@ -1,4 +1,4 @@
-{% macro runtime_contract_prompt(platform_name, bot_platform_id, enable_cot, chat_key_rules, enable_at, plugin_activation_rules) %}
+{% macro runtime_contract_prompt(platform_name, bot_platform_id, enable_cot, chat_key_rules, enable_at, plugin_activation_rules, plugin_call_priority_rules) %}
 你的 {{ platform_name }} Id：{{ bot_platform_id }}（可用于识别消息发送者）
 
 你处于一个多用户聊天环境中。务必始终清楚每条消息是谁发送的。
@@ -172,6 +172,11 @@ send_msg_text(chat_key, "我必须要……") # 错误示例：这一行不会�
 {% if plugin_activation_rules %}
 #### 插件激活规则：
 {{ plugin_activation_rules }}
+{% endif %}
+
+{% if plugin_call_priority_rules %}
+#### 插件调用优先级规则：
+{{ plugin_call_priority_rules }}
 {% endif %}
 
 ### 警告：

--- a/nekro_agent/services/agent/templates/plugin.py
+++ b/nekro_agent/services/agent/templates/plugin.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from nekro_agent.schemas.agent_ctx import AgentCtx
 from nekro_agent.services.plugin.base import NekroPlugin
+from nekro_agent.services.plugin.call_priority import PluginCallPriority, get_plugin_call_priority
 from nekro_agent.services.plugin.prompt_activation import build_prompt_disclosure_view
 
 from .base import PromptTemplate, env, register_template
@@ -15,6 +16,7 @@ class PluginPrompt(PromptTemplate):
     plugin_name: str
     module_name: str
     state: str
+    call_priority: PluginCallPriority = "auto"
     rounds_left: Optional[int] = None
     activation_hint: str = ""
     plugin_brief: str = ""
@@ -26,6 +28,7 @@ class PluginPromptRenderUnit(BaseModel):
     plugin_name: str
     module_name: str
     state: str
+    call_priority: PluginCallPriority = "auto"
     rounds_left: Optional[int] = None
     activation_hint: str = ""
     plugin_brief: str = ""
@@ -43,6 +46,7 @@ async def _render_plugin_prompt(unit: PluginPromptRenderUnit) -> str:
     return PluginPrompt(
         plugin_name=unit.plugin_name,
         module_name=unit.module_name,
+        call_priority=unit.call_priority,
         state=unit.state,
         rounds_left=unit.rounds_left,
         activation_hint=unit.activation_hint,
@@ -122,6 +126,7 @@ async def render_plugins_prompt_legacy(plugins: List[NekroPlugin], ctx: AgentCtx
             PluginPromptRenderUnit(
                 plugin_name=plugin.name,
                 module_name=plugin.module_name,
+                call_priority=get_plugin_call_priority(plugin.module_name),
                 state="always_awake",
                 plugin_method_prompt=await plugin.render_sandbox_methods_prompt(ctx),
             ),

--- a/nekro_agent/services/agent/templates/system.py
+++ b/nekro_agent/services/agent/templates/system.py
@@ -14,6 +14,7 @@ class RuntimeContractPrompt(PromptTemplate):
     chat_key_rules: str
     enable_at: bool
     plugin_activation_rules: str
+    plugin_call_priority_rules: str
 
 
 @register_template("persona.j2", "persona_prompt")

--- a/nekro_agent/services/plugin/call_priority.py
+++ b/nekro_agent/services/plugin/call_priority.py
@@ -1,0 +1,41 @@
+from typing import Literal
+
+from nekro_agent.core.config import CONFIG_PATH, config
+from nekro_agent.services.config_service import ConfigService
+
+PluginCallPriority = Literal["auto", "high", "medium", "low"]
+
+
+def get_plugin_call_priority(module_name: str) -> PluginCallPriority:
+    """获取插件调用优先级，未配置或配置异常时回退为自动。"""
+    priority = (config.PLUGIN_CALL_PRIORITIES or {}).get(module_name, "auto")
+    if priority not in {"auto", "high", "medium", "low"}:
+        return "auto"
+    return priority
+
+
+def set_plugin_call_priority(module_name: str, priority: PluginCallPriority) -> None:
+    """设置插件调用优先级；自动策略不保存覆盖项。"""
+    priorities = dict(config.PLUGIN_CALL_PRIORITIES or {})
+    if priority == "auto":
+        priorities.pop(module_name, None)
+    else:
+        priorities[module_name] = priority
+    config.PLUGIN_CALL_PRIORITIES = priorities
+    ConfigService.save_config(config, CONFIG_PATH)
+
+
+def build_plugin_call_priority_rules() -> str:
+    """构建供大模型执行的插件调用优先级规则。"""
+    return (
+        "Plugin call priority is a preference only when multiple available plugins "
+        "provide equivalent capabilities.\n"
+        "- Explicit priorities rank equivalent plugins as high, then medium, then low.\n"
+        "- Try the highest applicable explicit-priority plugin first. If it cannot complete the task, "
+        "returns an error, "
+        "or lacks required capability or constraints, try the next applicable lower-priority plugin.\n"
+        "- Do not redundantly call a lower-priority equivalent plugin after a higher-priority plugin "
+        "has completed the task.\n"
+        "- A plugin with call_priority=auto is selected by your own task-fit judgment and is not forced "
+        "into the explicit ranking."
+    )

--- a/nekro_agent/services/plugin/call_priority.py
+++ b/nekro_agent/services/plugin/call_priority.py
@@ -14,25 +14,32 @@ def get_plugin_call_priority(module_name: str) -> PluginCallPriority:
     return priority
 
 
-def set_plugin_call_priority(module_name: str, priority: PluginCallPriority) -> None:
-    """设置插件调用优先级；自动策略不保存覆盖项。"""
-    priorities = dict(config.PLUGIN_CALL_PRIORITIES or {})
+def set_plugin_call_priority(module_name: str, priority: PluginCallPriority) -> tuple[bool, str | None]:
+    """设置并持久化插件调用优先级；自动策略不保存覆盖项。"""
+    previous_priorities = config.PLUGIN_CALL_PRIORITIES
+    priorities = dict(previous_priorities or {})
     if priority == "auto":
         priorities.pop(module_name, None)
     else:
         priorities[module_name] = priority
+
     config.PLUGIN_CALL_PRIORITIES = priorities
-    ConfigService.save_config(config, CONFIG_PATH)
+    success, error = ConfigService.save_config(config, CONFIG_PATH)
+    if not success:
+        config.PLUGIN_CALL_PRIORITIES = previous_priorities
+    return success, error
 
 
 def build_plugin_call_priority_rules() -> str:
     """构建供大模型执行的插件调用优先级规则。"""
     return (
-        "Plugin call priority is a preference only when multiple available plugins "
+        "Plugin call priority is a preference only when multiple enabled plugins "
         "provide equivalent capabilities.\n"
-        "- Explicit priorities rank equivalent plugins as high, then medium, then low.\n"
-        "- Try the highest applicable explicit-priority plugin first. If it cannot complete the task, "
-        "returns an error, "
+        "- Explicit priorities rank equivalent plugins as high, then medium, then low. Within the same tier, "
+        "choose by task fit.\n"
+        "- Try the highest applicable explicit-priority plugin first. If that plugin is sleeping and its "
+        "capability brief matches the task, activate it before selecting a lower-priority equivalent plugin.\n"
+        "- If the selected plugin cannot complete the task, returns an error, cannot be activated, "
         "or lacks required capability or constraints, try the next applicable lower-priority plugin.\n"
         "- Do not redundantly call a lower-priority equivalent plugin after a higher-priority plugin "
         "has completed the task.\n"

--- a/nekro_agent/services/plugin/manager.py
+++ b/nekro_agent/services/plugin/manager.py
@@ -10,6 +10,11 @@ from nekro_agent.core.config import CONFIG_PATH, config
 from nekro_agent.core.core_utils import ConfigBase
 from nekro_agent.core.logger import get_sub_logger
 from nekro_agent.services.config_service import ConfigService
+from nekro_agent.services.plugin.call_priority import (
+    PluginCallPriority,
+    get_plugin_call_priority,
+    set_plugin_call_priority,
+)
 from nekro_agent.services.plugin.collector import plugin_collector
 from nekro_agent.services.plugin.prompt_activation import (
     PluginActivationStrategy,
@@ -45,6 +50,10 @@ def _build_activation_strategy_meta(plugin) -> dict:
         "sleepBrief": plugin.sleep_brief,
         "controller": _get_activation_controller_meta(),
     }
+
+
+def _build_call_priority_meta(plugin) -> dict:
+    return {"configured": get_plugin_call_priority(plugin.module_name)}
 
 
 async def _notify_commands_changed_after_plugin_toggle(plugin_key: str, plugin_name: str) -> None:
@@ -84,6 +93,7 @@ async def get_all_ext_meta_data() -> List[dict]:
             "i18n_name": plugin.i18n_name,
             "i18n_description": plugin.i18n_description,
             "activationStrategy": _build_activation_strategy_meta(plugin),
+            "callPriority": _build_call_priority_meta(plugin),
             "loadFailed": False,  # 标记加载状态
         }
         for plugin in plugins
@@ -108,6 +118,7 @@ async def get_all_ext_meta_data() -> List[dict]:
                 "i18n_name": None,
                 "i18n_description": None,
                 "activationStrategy": None,
+                "callPriority": None,
                 "loadFailed": True,  # 标记加载失败，前端根据此字段隐藏开关并显示"加载失败"
                 "errorMessage": failed_plugin.error_message,  # 完整错误信息
                 "errorType": failed_plugin.error_type,  # 错误类型
@@ -147,6 +158,7 @@ async def get_plugin_detail(plugin_id: str) -> Optional[dict]:
                 "isBuiltin": failed_plugin.is_builtin,
                 "isPackage": failed_plugin.is_package,
                 "activationStrategy": None,
+                "callPriority": None,
                 "loadFailed": True,  # 前端根据此字段隐藏开关并显示"加载失败"
                 "errorMessage": failed_plugin.error_message,  # 完整错误信息
                 "errorType": failed_plugin.error_type,  # 错误类型
@@ -206,6 +218,7 @@ async def get_plugin_detail(plugin_id: str) -> Optional[dict]:
         "isBuiltin": plugin.is_builtin,
         "isPackage": plugin.is_package,
         "activationStrategy": _build_activation_strategy_meta(plugin),
+        "callPriority": _build_call_priority_meta(plugin),
         "loadFailed": False,
     }
 
@@ -228,6 +241,18 @@ async def update_plugin_activation_strategy(
         return False, f"插件 {plugin.module_name} 未提供休眠提示词，无法开启休眠"
 
     set_plugin_activation_strategy(plugin.module_name, strategy)
+    return True, None
+
+
+async def update_plugin_call_priority(
+    plugin_id: str,
+    priority: PluginCallPriority,
+) -> tuple[bool, Optional[str]]:
+    plugin = plugin_collector.get_plugin(plugin_id)
+    if not plugin:
+        return False, f"插件 {plugin_id} 不存在"
+
+    set_plugin_call_priority(plugin.module_name, priority)
     return True, None
 
 

--- a/nekro_agent/services/plugin/manager.py
+++ b/nekro_agent/services/plugin/manager.py
@@ -252,8 +252,7 @@ async def update_plugin_call_priority(
     if not plugin:
         return False, f"插件 {plugin_id} 不存在"
 
-    set_plugin_call_priority(plugin.module_name, priority)
-    return True, None
+    return set_plugin_call_priority(plugin.module_name, priority)
 
 
 async def get_all_plugin_router_info() -> Dict[str, Any]:

--- a/nekro_agent/services/plugin/prompt_activation.py
+++ b/nekro_agent/services/plugin/prompt_activation.py
@@ -9,6 +9,7 @@ from nekro_agent.models.db_plugin_data import DBPluginData
 from nekro_agent.schemas.agent_ctx import AgentCtx
 from nekro_agent.services.config_service import ConfigService
 from nekro_agent.services.plugin.base import NekroPlugin
+from nekro_agent.services.plugin.call_priority import get_plugin_call_priority
 
 _STORE_PLUGIN_KEY = "__prompt_activation__"
 _STORE_KEY = "module_rounds"
@@ -143,6 +144,7 @@ async def render_plugin_prompt_for_agent(plugin: NekroPlugin, ctx: AgentCtx, rou
         PluginPromptRenderUnit(
             plugin_name=plugin.name,
             module_name=plugin.module_name,
+            call_priority=get_plugin_call_priority(plugin.module_name),
             state="active",
             rounds_left=rounds_left,
             activation_hint=(
@@ -180,6 +182,7 @@ async def build_prompt_disclosure_view(plugins: List[NekroPlugin], ctx: AgentCtx
                     PluginPromptRenderUnit(
                         plugin_name=plugin.name,
                         module_name=plugin.module_name,
+                        call_priority=get_plugin_call_priority(plugin.module_name),
                         state="sleeping",
                         rounds_left=0,
                         plugin_brief=brief,
@@ -191,6 +194,7 @@ async def build_prompt_disclosure_view(plugins: List[NekroPlugin], ctx: AgentCtx
                 PluginPromptRenderUnit(
                     plugin_name=plugin.name,
                     module_name=plugin.module_name,
+                    call_priority=get_plugin_call_priority(plugin.module_name),
                     state="active",
                     rounds_left=rounds_snapshot.get(plugin.module_name, 0),
                     activation_hint=(
@@ -208,6 +212,7 @@ async def build_prompt_disclosure_view(plugins: List[NekroPlugin], ctx: AgentCtx
             PluginPromptRenderUnit(
                 plugin_name=plugin.name,
                 module_name=plugin.module_name,
+                call_priority=get_plugin_call_priority(plugin.module_name),
                 state="always_awake",
                 plugin_method_prompt=await plugin.render_sandbox_methods_prompt(ctx),
             ),

--- a/tests/test_plugin_call_priority.py
+++ b/tests/test_plugin_call_priority.py
@@ -1,0 +1,59 @@
+import asyncio
+
+from nekro_agent.core.config import config
+from nekro_agent.services.agent.templates.plugin import PluginPromptRenderUnit, render_plugin_prompt_unit
+from nekro_agent.services.config_service import ConfigService
+from nekro_agent.services.plugin.call_priority import (
+    build_plugin_call_priority_rules,
+    get_plugin_call_priority,
+    set_plugin_call_priority,
+)
+
+
+def test_get_plugin_call_priority_defaults_to_auto(monkeypatch) -> None:
+    monkeypatch.setattr(config, "PLUGIN_CALL_PRIORITIES", {})
+
+    assert get_plugin_call_priority("example") == "auto"
+
+
+def test_set_plugin_call_priority_persists_override(monkeypatch) -> None:
+    saved: list[object] = []
+    monkeypatch.setattr(config, "PLUGIN_CALL_PRIORITIES", {})
+    monkeypatch.setattr(ConfigService, "save_config", lambda *_args: saved.append(True))
+
+    set_plugin_call_priority("example", "high")
+
+    assert config.PLUGIN_CALL_PRIORITIES == {"example": "high"}
+    assert saved == [True]
+
+
+def test_set_plugin_call_priority_auto_removes_override(monkeypatch) -> None:
+    monkeypatch.setattr(config, "PLUGIN_CALL_PRIORITIES", {"example": "low"})
+    monkeypatch.setattr(ConfigService, "save_config", lambda *_args: None)
+
+    set_plugin_call_priority("example", "auto")
+
+    assert config.PLUGIN_CALL_PRIORITIES == {}
+
+
+def test_plugin_prompt_exposes_call_priority() -> None:
+    prompt = asyncio.run(
+        render_plugin_prompt_unit(
+            PluginPromptRenderUnit(
+                plugin_name="Example",
+                module_name="example",
+                state="always_awake",
+                call_priority="high",
+            ),
+        ),
+    )
+
+    assert 'call_priority="high"' in prompt
+
+
+def test_call_priority_rules_define_fallback_and_auto_semantics() -> None:
+    rules = build_plugin_call_priority_rules()
+
+    assert "high, then medium, then low" in rules
+    assert "try the next applicable lower-priority plugin" in rules
+    assert "call_priority=auto" in rules

--- a/tests/test_plugin_call_priority.py
+++ b/tests/test_plugin_call_priority.py
@@ -19,21 +19,33 @@ def test_get_plugin_call_priority_defaults_to_auto(monkeypatch) -> None:
 def test_set_plugin_call_priority_persists_override(monkeypatch) -> None:
     saved: list[object] = []
     monkeypatch.setattr(config, "PLUGIN_CALL_PRIORITIES", {})
-    monkeypatch.setattr(ConfigService, "save_config", lambda *_args: saved.append(True))
+    monkeypatch.setattr(ConfigService, "save_config", lambda *_args: (saved.append(True) or (True, None)))
 
-    set_plugin_call_priority("example", "high")
+    result = set_plugin_call_priority("example", "high")
 
+    assert result == (True, None)
     assert config.PLUGIN_CALL_PRIORITIES == {"example": "high"}
     assert saved == [True]
 
 
 def test_set_plugin_call_priority_auto_removes_override(monkeypatch) -> None:
     monkeypatch.setattr(config, "PLUGIN_CALL_PRIORITIES", {"example": "low"})
-    monkeypatch.setattr(ConfigService, "save_config", lambda *_args: None)
+    monkeypatch.setattr(ConfigService, "save_config", lambda *_args: (True, None))
 
     set_plugin_call_priority("example", "auto")
 
     assert config.PLUGIN_CALL_PRIORITIES == {}
+
+
+def test_set_plugin_call_priority_rolls_back_when_persistence_fails(monkeypatch) -> None:
+    original = {"example": "low"}
+    monkeypatch.setattr(config, "PLUGIN_CALL_PRIORITIES", original)
+    monkeypatch.setattr(ConfigService, "save_config", lambda *_args: (False, "disk full"))
+
+    result = set_plugin_call_priority("example", "high")
+
+    assert result == (False, "disk full")
+    assert config.PLUGIN_CALL_PRIORITIES is original
 
 
 def test_plugin_prompt_exposes_call_priority() -> None:
@@ -56,4 +68,5 @@ def test_call_priority_rules_define_fallback_and_auto_semantics() -> None:
 
     assert "high, then medium, then low" in rules
     assert "try the next applicable lower-priority plugin" in rules
+    assert "activate it before selecting a lower-priority equivalent plugin" in rules
     assert "call_priority=auto" in rules


### PR DESCRIPTION
### 在插件管理页“激活策略”旁新增“调用优先级”选择器：
  - 自动
  - 高
  - 中
  - 低

- 支持中英文界面，并增加优先级规则说明 Tooltip。
- 新增后端接口：POST /plugins/call-priority/{plugin_id}

- 优先级按插件 module_name 持久化到现有配置系统，无需数据库迁移。
- 选择“自动”时会删除显式覆盖配置，由大模型根据任务适配度自行选择。
- 每个插件的模型提示块新增：
  - `call_priority="auto|high|medium|low"`

- 模型运行时规则已经覆盖：
  - 仅在插件能力相同或等价时比较优先级。
  - 显式优先级按高 → 中 → 低选择。
  - 高优先级插件报错、能力不足或无法满足约束时，继续尝试中、低优先级插件。
  - 高优先级插件已经完成任务后，不再重复调用低优先级等价插件。
  - 自动优先级不强制参与固定排序。

## Summary by Sourcery

为插件添加可配置的调用优先级，并在提示词和运行时规则中体现。

New Features:
- 在插件管理界面中引入插件调用优先级设置（auto、high、medium、low），并通过工具提示进行说明。
- 在代理模型的插件提示块中暴露插件调用优先级，并定义相应的执行规则。
- 添加后端 API 端点，用于更新插件的调用优先级，并在现有配置系统中持久化覆写设置。

Enhancements:
- 在插件列表和详情响应中加入插件调用优先级元数据，并将其集成到英文和中文模版的运行时契约提示词中。

Tests:
- 添加单元测试，覆盖插件调用优先级的持久化语义、在提示词中的暴露，以及规则文本内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable call priority for plugins and surface it in prompts and runtime rules.

New Features:
- Introduce plugin call priority settings (auto, high, medium, low) in the plugin management UI with tooltip explanation.
- Expose plugin call priority in plugin prompt blocks for the agent model and define corresponding execution rules.
- Add backend API endpoint to update a plugin's call priority and persist overrides in the existing config system.

Enhancements:
- Include plugin call priority metadata in plugin list and detail responses and integrate it into the runtime contract prompts for both English and Chinese templates.

Tests:
- Add unit tests covering plugin call priority persistence semantics, prompt exposure, and rule text content.

</details>