### PR TITLE
feat(kb): 知识库批量上传异步化 + 索引并发可配置

### DIFF
--- a/frontend/src/locales/en-US/workspace.json
+++ b/frontend/src/locales/en-US/workspace.json
@@ -1138,7 +1138,6 @@
     "batchStatus": {
       "waiting": "Waiting",
       "uploading": "Uploading",
-      "indexing": "Indexing",
       "done": "Done",
       "error": "Failed",
       "edit": "Edit metadata"
@@ -1370,7 +1369,6 @@
     "batchStatus": {
       "waiting": "Waiting",
       "uploading": "Uploading",
-      "indexing": "Indexing",
       "done": "Done",
       "error": "Failed",
       "edit": "Edit metadata"

--- a/frontend/src/locales/zh-CN/workspace.json
+++ b/frontend/src/locales/zh-CN/workspace.json
@@ -1138,7 +1138,6 @@
     "batchStatus": {
       "waiting": "等待中",
       "uploading": "上传中",
-      "indexing": "索引中",
       "done": "完成",
       "error": "失败",
       "edit": "编辑元数据"
@@ -1370,7 +1369,6 @@
     "batchStatus": {
       "waiting": "等待中",
       "uploading": "上传中",
-      "indexing": "索引中",
       "done": "完成",
       "error": "失败",
       "edit": "编辑元数据"

--- a/frontend/src/pages/workspace/kb-library.tsx
+++ b/frontend/src/pages/workspace/kb-library.tsx
@@ -92,7 +92,7 @@ import {
 import { buildCategoryTree, type KBCategoryTreeNode } from './kbCategoryTree'
 
 type FilterStatus = 'all' | 'ready' | 'indexing' | 'failed'
-type BatchItemStatus = 'waiting' | 'uploading' | 'indexing' | 'done' | 'error'
+type BatchItemStatus = 'waiting' | 'uploading' | 'done' | 'error'
 
 interface BatchQueueItem {
   id: string
@@ -109,6 +109,9 @@ interface BatchQueueItem {
 }
 
 const SUPPORTED_UPLOAD_EXTENSIONS = ['.md', '.txt', '.html', '.htm', '.json', '.yaml', '.yml', '.csv', '.xlsx', '.pdf', '.docx']
+
+/** 批量上传并发数（建议 3~10），受网络带宽与后端内存限制 */
+const BATCH_UPLOAD_CONCURRENCY = 5
 const EMPTY_ASSETS: KBAssetListItem[] = []
 const EMPTY_WORKSPACES: Awaited<ReturnType<typeof workspaceApi.getList>> = []
 const TEXT_FORMAT_OPTIONS: Array<{ value: 'markdown' | 'text'; label: string }> = [
@@ -756,45 +759,46 @@ export default function KbLibraryPage() {
     setBatchPanelVisible(true)
     let uploadedAny = false
     try {
-      for (const item of items) {
-        if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) break
-        if (!batchQueueRef.current.some(queueItem => queueItem.id === item.id && queueItem.status === 'waiting')) continue
-        setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'uploading', uploadProgress: 0 } : i))
-        try {
-          const data = await kbLibraryApi.uploadFile(
-            {
-              file: item.file,
-              title: item.title || item.file.name.replace(/\.[^.]+$/, ''),
-              source_path: item.source_path ?? '',
-              category: item.category,
-              tags: item.tags ? item.tags.split(',').map((s: string) => s.trim()).filter(Boolean) : [],
-              summary: item.summary,
-              is_enabled: true,
-            },
-            pct => setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, uploadProgress: pct } : i)),
-          )
-          if (batchRunVersionRef.current !== runVersion) break
-          uploadedAny = true
-          setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'indexing', assetId: data.asset.id } : i))
-          const deadline = Date.now() + 300_000
-          while (Date.now() < deadline) {
-            if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) break
-            await new Promise(r => setTimeout(r, 1500))
-            if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) break
-            const detail = await kbLibraryApi.getAsset(data.asset.id)
-            if (detail.asset.sync_status === 'ready' || detail.asset.sync_status === 'failed') break
+      // 有限并发工作池：共享游标逐文件分配任务，最多 BATCH_UPLOAD_CONCURRENCY 个文件同时上传
+      let nextIndex = 0
+      const workerCount = Math.min(BATCH_UPLOAD_CONCURRENCY, items.length)
+      const workers = Array.from({ length: workerCount }, async () => {
+        while (true) {
+          if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) return
+          const index = nextIndex
+          nextIndex += 1
+          if (index >= items.length) return
+          const item = items[index]
+          if (!batchQueueRef.current.some(queueItem => queueItem.id === item.id && queueItem.status === 'waiting')) continue
+          setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'uploading', uploadProgress: 0 } : i))
+          try {
+            const data = await kbLibraryApi.uploadFile(
+              {
+                file: item.file,
+                title: item.title || item.file.name.replace(/\.[^.]+$/, ''),
+                source_path: item.source_path ?? '',
+                category: item.category,
+                tags: item.tags ? item.tags.split(',').map((s: string) => s.trim()).filter(Boolean) : [],
+                summary: item.summary,
+                is_enabled: true,
+              },
+              pct => setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, uploadProgress: pct } : i)),
+            )
+            if (batchRunVersionRef.current !== runVersion) return
+            uploadedAny = true
+            // 上传成功即视为该文件处理完成，索引由后端后台任务异步执行，无需在此等待
+            setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'done', assetId: data.asset.id } : i))
+          } catch (err) {
+            if (batchRunVersionRef.current !== runVersion) return
+            setBatchQueue(prev => prev.map(i => i.id === item.id ? {
+              ...i,
+              status: 'error',
+              errorMessage: err instanceof Error ? err.message : String(err),
+            } : i))
           }
-          if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) break
-          setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'done' } : i))
-        } catch (err) {
-          if (batchRunVersionRef.current !== runVersion) break
-          setBatchQueue(prev => prev.map(i => i.id === item.id ? {
-            ...i,
-            status: 'error',
-            errorMessage: err instanceof Error ? err.message : String(err),
-          } : i))
         }
-      }
+      })
+      await Promise.all(workers)
     } finally {
       const isCurrentRun = batchRunVersionRef.current === runVersion
       const cancelRequested = batchCancelRequestedRef.current
@@ -1785,7 +1789,6 @@ export default function KbLibraryPage() {
                           </>
                         )}
                         {item.status === 'uploading' && <CircularProgress size={14} />}
-                        {item.status === 'indexing' && <CircularProgress size={14} color="warning" />}
                         {item.status === 'done' && <CheckCircleIcon sx={{ fontSize: 16, color: 'success.main' }} />}
                         {item.status === 'error' && <ErrorOutlineIcon sx={{ fontSize: 16, color: 'error.main' }} />}
                       </Stack>
@@ -1951,15 +1954,11 @@ export default function KbLibraryPage() {
                     </>
                   )}
                   {item.status === 'uploading' && <CircularProgress size={14} />}
-                  {item.status === 'indexing' && <CircularProgress size={14} color="warning" />}
                   {item.status === 'done' && <CheckCircleIcon sx={{ fontSize: 16, color: 'success.main' }} />}
                   {item.status === 'error' && <ErrorOutlineIcon sx={{ fontSize: 16, color: 'error.main' }} />}
                 </Stack>
                 {item.status === 'uploading' && (
                   <LinearProgress variant="determinate" value={item.uploadProgress} sx={{ height: 3, borderRadius: 999 }} />
-                )}
-                {item.status === 'indexing' && (
-                  <LinearProgress color="warning" sx={{ height: 3, borderRadius: 999 }} />
                 )}
                 {item.status === 'error' && item.errorMessage && (
                   <Typography variant="caption" color="error" noWrap title={item.errorMessage}>{item.errorMessage}</Typography>

--- a/frontend/src/pages/workspace/kb-library.tsx
+++ b/frontend/src/pages/workspace/kb-library.tsx
@@ -85,6 +85,7 @@ import KBGraphDialog from './components/KBGraphDialog'
 import ReferenceGraph from './components/ReferenceGraph'
 import KBBatchActionsButton from './components/KBBatchActionsButton'
 import {
+  BATCH_UPLOAD_CONCURRENCY,
   findCategoryLengthOverflow,
   getFolderImportMetadata,
   KB_CATEGORY_MAX_LENGTH,
@@ -109,9 +110,6 @@ interface BatchQueueItem {
 }
 
 const SUPPORTED_UPLOAD_EXTENSIONS = ['.md', '.txt', '.html', '.htm', '.json', '.yaml', '.yml', '.csv', '.xlsx', '.pdf', '.docx']
-
-/** 批量上传并发数（建议 3~10），受网络带宽与后端内存限制 */
-const BATCH_UPLOAD_CONCURRENCY = 5
 const EMPTY_ASSETS: KBAssetListItem[] = []
 const EMPTY_WORKSPACES: Awaited<ReturnType<typeof workspaceApi.getList>> = []
 const TEXT_FORMAT_OPTIONS: Array<{ value: 'markdown' | 'text'; label: string }> = [
@@ -784,7 +782,7 @@ export default function KbLibraryPage() {
               },
               pct => setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, uploadProgress: pct } : i)),
             )
-            if (batchRunVersionRef.current !== runVersion) return
+            if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) return
             uploadedAny = true
             // 上传成功即视为该文件处理完成，索引由后端后台任务异步执行，无需在此等待
             setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'done', assetId: data.asset.id } : i))
@@ -809,7 +807,7 @@ export default function KbLibraryPage() {
         setBatchCancelRequested(false)
         if (cancelRequested) {
           setExpandedBatchItemId(null)
-          setBatchQueue(prev => prev.filter(item => item.status !== 'waiting'))
+          setBatchQueue(prev => prev.filter(item => item.status !== 'waiting' && item.status !== 'uploading'))
         }
         if (uploadedAny && items.some(i => Boolean(i.source_path))) {
           setListView('grouped')

--- a/frontend/src/pages/workspace/kbFolderImport.ts
+++ b/frontend/src/pages/workspace/kbFolderImport.ts
@@ -1,5 +1,8 @@
 export const KB_CATEGORY_MAX_LENGTH = 64
 
+/** 批量上传并发数（建议 3~10），受网络带宽与后端内存限制 */
+export const BATCH_UPLOAD_CONCURRENCY = 5
+
 export interface FolderImportMetadata {
   category: string
   sourcePath: string

--- a/frontend/src/pages/workspace/tabs/KnowledgeTab.tsx
+++ b/frontend/src/pages/workspace/tabs/KnowledgeTab.tsx
@@ -99,6 +99,9 @@ const EMPTY_GLOBAL_ASSETS: KBAssetListItem[] = []
 const EMPTY_SEARCH_DOCUMENTS: KBSearchResponse['documents'] = []
 const SUPPORTED_UPLOAD_EXTENSIONS = ['.md', '.txt', '.html', '.htm', '.json', '.yaml', '.yml', '.csv', '.xlsx', '.pdf', '.docx']
 
+/** 批量上传并发数（建议 3~10），受网络带宽与后端内存限制 */
+const BATCH_UPLOAD_CONCURRENCY = 5
+
 
 function getFileExtension(fileName: string): string {
   const match = fileName.toLowerCase().match(/(\.[^.]+)$/)
@@ -110,7 +113,7 @@ function isSupportedUploadFile(file: File): boolean {
   return SUPPORTED_UPLOAD_EXTENSIONS.includes(getFileExtension(file.name))
 }
 
-type BatchItemStatus = 'waiting' | 'uploading' | 'indexing' | 'done' | 'error'
+type BatchItemStatus = 'waiting' | 'uploading' | 'done' | 'error'
 
 interface BatchQueueItem {
   id: string
@@ -1029,46 +1032,47 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
     setBatchPanelVisible(true)
     let uploadedAny = false
     try {
-      for (const item of items) {
-        if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) break
-        if (!batchQueueRef.current.some(queueItem => queueItem.id === item.id && queueItem.status === 'waiting')) continue
-        setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'uploading', uploadProgress: 0 } : i))
-        try {
-          const data = await knowledgeBaseApi.uploadFile(
-            workspace.id,
-            {
-              file: item.file,
-              title: item.title || item.file.name.replace(/\.[^.]+$/, ''),
-              source_path: item.source_path || '',
-              category: item.category,
-              tags: normalizeTagsInput(item.tags),
-              summary: item.summary,
-              is_enabled: true,
-            },
-            pct => setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, uploadProgress: pct } : i)),
-          )
-          if (batchRunVersionRef.current !== runVersion) break
-          uploadedAny = true
-          setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'indexing', documentId: data.document.id } : i))
-          const deadline = Date.now() + 300_000
-          while (Date.now() < deadline) {
-            if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) break
-            await new Promise(r => setTimeout(r, 1500))
-            if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) break
-            const detail = await knowledgeBaseApi.getDocument(workspace.id, data.document.id)
-            if (detail.document.sync_status === 'ready' || detail.document.sync_status === 'failed') break
+      // 有限并发工作池：共享游标逐文件分配任务，最多 BATCH_UPLOAD_CONCURRENCY 个文件同时上传
+      let nextIndex = 0
+      const workerCount = Math.min(BATCH_UPLOAD_CONCURRENCY, items.length)
+      const workers = Array.from({ length: workerCount }, async () => {
+        while (true) {
+          if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) return
+          const index = nextIndex
+          nextIndex += 1
+          if (index >= items.length) return
+          const item = items[index]
+          if (!batchQueueRef.current.some(queueItem => queueItem.id === item.id && queueItem.status === 'waiting')) continue
+          setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'uploading', uploadProgress: 0 } : i))
+          try {
+            const data = await knowledgeBaseApi.uploadFile(
+              workspace.id,
+              {
+                file: item.file,
+                title: item.title || item.file.name.replace(/\.[^.]+$/, ''),
+                source_path: item.source_path || '',
+                category: item.category,
+                tags: normalizeTagsInput(item.tags),
+                summary: item.summary,
+                is_enabled: true,
+              },
+              pct => setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, uploadProgress: pct } : i)),
+            )
+            if (batchRunVersionRef.current !== runVersion) return
+            uploadedAny = true
+            // 上传成功即视为该文件处理完成，索引由后端后台任务异步执行，无需在此等待
+            setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'done', documentId: data.document.id } : i))
+          } catch (err) {
+            if (batchRunVersionRef.current !== runVersion) return
+            setBatchQueue(prev => prev.map(i => i.id === item.id ? {
+              ...i,
+              status: 'error',
+              errorMessage: err instanceof Error ? err.message : String(err),
+            } : i))
           }
-          if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) break
-          setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'done' } : i))
-        } catch (err) {
-          if (batchRunVersionRef.current !== runVersion) break
-          setBatchQueue(prev => prev.map(i => i.id === item.id ? {
-            ...i,
-            status: 'error',
-            errorMessage: err instanceof Error ? err.message : String(err),
-          } : i))
         }
-      }
+      })
+      await Promise.all(workers)
     } finally {
       const isCurrentRun = batchRunVersionRef.current === runVersion
       const cancelRequested = batchCancelRequestedRef.current
@@ -2487,7 +2491,6 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
                           </>
                         )}
                         {item.status === 'uploading' && <CircularProgress size={14} />}
-                        {item.status === 'indexing' && <CircularProgress size={14} color="warning" />}
                         {item.status === 'done' && <CheckCircleIcon sx={{ fontSize: 16, color: 'success.main' }} />}
                         {item.status === 'error' && <ErrorOutlineIcon sx={{ fontSize: 16, color: 'error.main' }} />}
                       </Stack>
@@ -2668,15 +2671,11 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
                     </>
                   )}
                   {item.status === 'uploading' && <CircularProgress size={14} />}
-                  {item.status === 'indexing' && <CircularProgress size={14} color="warning" />}
                   {item.status === 'done' && <CheckCircleIcon sx={{ fontSize: 16, color: 'success.main' }} />}
                   {item.status === 'error' && <ErrorOutlineIcon sx={{ fontSize: 16, color: 'error.main' }} />}
                 </Stack>
                 {item.status === 'uploading' && (
                   <LinearProgress variant="determinate" value={item.uploadProgress} sx={{ height: 3, borderRadius: 999 }} />
-                )}
-                {item.status === 'indexing' && (
-                  <LinearProgress color="warning" sx={{ height: 3, borderRadius: 999 }} />
                 )}
                 {item.status === 'error' && item.errorMessage && (
                   <Typography variant="caption" color="error" noWrap title={item.errorMessage}>{item.errorMessage}</Typography>

--- a/frontend/src/pages/workspace/tabs/KnowledgeTab.tsx
+++ b/frontend/src/pages/workspace/tabs/KnowledgeTab.tsx
@@ -77,6 +77,7 @@ import ReferenceGraph from '../components/ReferenceGraph'
 import KBGraphDialog from '../components/KBGraphDialog'
 import KBBatchActionsButton from '../components/KBBatchActionsButton'
 import {
+  BATCH_UPLOAD_CONCURRENCY,
   findCategoryLengthOverflow,
   getFolderImportMetadata,
   KB_CATEGORY_MAX_LENGTH,
@@ -98,9 +99,6 @@ const EMPTY_DOCUMENTS: KBDocumentDetailResponse['document'][] = []
 const EMPTY_GLOBAL_ASSETS: KBAssetListItem[] = []
 const EMPTY_SEARCH_DOCUMENTS: KBSearchResponse['documents'] = []
 const SUPPORTED_UPLOAD_EXTENSIONS = ['.md', '.txt', '.html', '.htm', '.json', '.yaml', '.yml', '.csv', '.xlsx', '.pdf', '.docx']
-
-/** 批量上传并发数（建议 3~10），受网络带宽与后端内存限制 */
-const BATCH_UPLOAD_CONCURRENCY = 5
 
 
 function getFileExtension(fileName: string): string {
@@ -1058,7 +1056,7 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
               },
               pct => setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, uploadProgress: pct } : i)),
             )
-            if (batchRunVersionRef.current !== runVersion) return
+            if (batchRunVersionRef.current !== runVersion || batchCancelRequestedRef.current) return
             uploadedAny = true
             // 上传成功即视为该文件处理完成，索引由后端后台任务异步执行，无需在此等待
             setBatchQueue(prev => prev.map(i => i.id === item.id ? { ...i, status: 'done', documentId: data.document.id } : i))
@@ -1083,7 +1081,7 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
         setBatchCancelRequested(false)
         if (cancelRequested) {
           setExpandedBatchItemId(null)
-          setBatchQueue(prev => prev.filter(item => item.status !== 'waiting'))
+          setBatchQueue(prev => prev.filter(item => item.status !== 'waiting' && item.status !== 'uploading'))
         }
         if (uploadedAny) {
           setListView('grouped')

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -482,13 +482,13 @@ class CoreConfig(ConfigBase):
     KB_INDEX_CONCURRENCY: int = Field(
         default=3,
         title="知识库索引并发数",
-        description="同时进行的知识库索引任务数（工作区文档与全局资产各按此值限制）。设为 1 时逐个串行索引，调大可加快批量索引，但会增加 Embedding 服务与 Qdrant 负载",
+        description="同时进行的知识库索引任务数（工作区文档与全局资产各按此值限制）。设为 1 时逐个串行索引，调大可加快批量索引，但会增加 Embedding 服务与 Qdrant 负载。修改后需重启服务生效",
         json_schema_extra=ExtraField(
             i18n_category=i18n_text(zh_CN="知识库", en_US="Knowledge Base"),
             i18n_title=i18n_text(zh_CN="知识库索引并发数", en_US="Knowledge Base Index Concurrency"),
             i18n_description=i18n_text(
-                zh_CN="同时进行的知识库索引任务数（工作区文档与全局资产各按此值限制）。设为 1 时逐个串行索引，调大可加快批量索引，但会增加 Embedding 服务与 Qdrant 负载",
-                en_US="Number of concurrent knowledge base indexing tasks (workspace documents and global assets are each limited by this value). Set to 1 for fully serial indexing; higher values speed up batch indexing at the cost of heavier Embedding service and Qdrant load",
+                zh_CN="同时进行的知识库索引任务数（工作区文档与全局资产各按此值限制）。设为 1 时逐个串行索引，调大可加快批量索引，但会增加 Embedding 服务与 Qdrant 负载。修改后需重启服务生效",
+                en_US="Number of concurrent knowledge base indexing tasks (workspace documents and global assets are each limited by this value). Set to 1 for fully serial indexing; higher values speed up batch indexing at the cost of heavier Embedding service and Qdrant load. Restart required after changing",
             ),
             placeholder="建议 1~8",
         ).model_dump(),

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -479,6 +479,20 @@ class CoreConfig(ConfigBase):
             ),
         ).model_dump(),
     )
+    KB_INDEX_CONCURRENCY: int = Field(
+        default=3,
+        title="知识库索引并发数",
+        description="同时进行的知识库索引任务数（工作区文档与全局资产各按此值限制）。设为 1 时逐个串行索引，调大可加快批量索引，但会增加 Embedding 服务与 Qdrant 负载",
+        json_schema_extra=ExtraField(
+            i18n_category=i18n_text(zh_CN="知识库", en_US="Knowledge Base"),
+            i18n_title=i18n_text(zh_CN="知识库索引并发数", en_US="Knowledge Base Index Concurrency"),
+            i18n_description=i18n_text(
+                zh_CN="同时进行的知识库索引任务数（工作区文档与全局资产各按此值限制）。设为 1 时逐个串行索引，调大可加快批量索引，但会增加 Embedding 服务与 Qdrant 负载",
+                en_US="Number of concurrent knowledge base indexing tasks (workspace documents and global assets are each limited by this value). Set to 1 for fully serial indexing; higher values speed up batch indexing at the cost of heavier Embedding service and Qdrant load",
+            ),
+            placeholder="建议 1~8",
+        ).model_dump(),
+    )
     MEMORY_CONSOLIDATION_FORCE_JSON_OUTPUT: bool = Field(
         default=True,
         title="强制沉淀模型输出 JSON",

--- a/nekro_agent/services/kb/index_service.py
+++ b/nekro_agent/services/kb/index_service.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from tortoise.backends.base.client import BaseDBAsyncClient
 
+from nekro_agent.core.config import config
 from nekro_agent.core.logger import get_sub_logger
 from nekro_agent.models.db_kb_chunk import DBKBChunk
 from nekro_agent.models.db_kb_document import DBKBDocument
@@ -23,10 +24,21 @@ logger = get_sub_logger("kb.index")
 
 PREVIEW_MAX_CHARS = 360
 _INDEX_BATCH_SIZE = 10
-_INDEX_CONCURRENCY = 3
-_index_semaphore = asyncio.Semaphore(_INDEX_CONCURRENCY)
 _index_tasks: dict[int, Any] = {}
 _pending_rebuilds: set[int] = set()
+_index_semaphore_cache: tuple[int, asyncio.Semaphore] | None = None
+
+
+def _get_index_semaphore() -> asyncio.Semaphore:
+    """获取索引并发信号量，并发数配置（KB_INDEX_CONCURRENCY）变更时自动重建。"""
+    global _index_semaphore_cache
+
+    concurrency = max(1, int(config.KB_INDEX_CONCURRENCY))
+    if _index_semaphore_cache is not None and _index_semaphore_cache[0] == concurrency:
+        return _index_semaphore_cache[1]
+    semaphore = asyncio.Semaphore(concurrency)
+    _index_semaphore_cache = (concurrency, semaphore)
+    return semaphore
 
 
 def _hash_text(text: str) -> str:
@@ -248,7 +260,7 @@ async def rebuild_document(document: DBKBDocument) -> int:
 async def _run_rebuild_document_task(document_id: int) -> None:
     task = _index_tasks.get(document_id)
     try:
-        async with _index_semaphore:
+        async with _get_index_semaphore():
             while True:
                 _pending_rebuilds.discard(document_id)
                 document = await DBKBDocument.get_or_none(id=document_id)

--- a/nekro_agent/services/kb/index_service.py
+++ b/nekro_agent/services/kb/index_service.py
@@ -27,23 +27,13 @@ _INDEX_BATCH_SIZE = 10
 _INDEX_CONCURRENCY_DEFAULT = 3
 _index_tasks: dict[int, Any] = {}
 _pending_rebuilds: set[int] = set()
-_index_semaphore_cache: tuple[int, asyncio.Semaphore] | None = None
 
-
-def _get_index_semaphore() -> asyncio.Semaphore:
-    """获取索引并发信号量，并发数配置（KB_INDEX_CONCURRENCY）变更时自动重建。"""
-    global _index_semaphore_cache
-
-    try:
-        concurrency = max(1, int(config.KB_INDEX_CONCURRENCY))
-    except (TypeError, ValueError):
-        # 配置值非法时回退默认并发，避免索引任务因错误配置而崩溃
-        concurrency = _INDEX_CONCURRENCY_DEFAULT
-    if _index_semaphore_cache is not None and _index_semaphore_cache[0] == concurrency:
-        return _index_semaphore_cache[1]
-    semaphore = asyncio.Semaphore(concurrency)
-    _index_semaphore_cache = (concurrency, semaphore)
-    return semaphore
+try:
+    _INDEX_CONCURRENCY = max(1, int(config.KB_INDEX_CONCURRENCY))
+except (TypeError, ValueError):
+    # 配置值非法时回退默认并发，避免索引任务因错误配置而崩溃
+    _INDEX_CONCURRENCY = _INDEX_CONCURRENCY_DEFAULT
+_index_semaphore = asyncio.Semaphore(_INDEX_CONCURRENCY)
 
 
 def _hash_text(text: str) -> str:
@@ -265,7 +255,7 @@ async def rebuild_document(document: DBKBDocument) -> int:
 async def _run_rebuild_document_task(document_id: int) -> None:
     task = _index_tasks.get(document_id)
     try:
-        async with _get_index_semaphore():
+        async with _index_semaphore:
             while True:
                 _pending_rebuilds.discard(document_id)
                 document = await DBKBDocument.get_or_none(id=document_id)

--- a/nekro_agent/services/kb/index_service.py
+++ b/nekro_agent/services/kb/index_service.py
@@ -24,6 +24,7 @@ logger = get_sub_logger("kb.index")
 
 PREVIEW_MAX_CHARS = 360
 _INDEX_BATCH_SIZE = 10
+_INDEX_CONCURRENCY_DEFAULT = 3
 _index_tasks: dict[int, Any] = {}
 _pending_rebuilds: set[int] = set()
 _index_semaphore_cache: tuple[int, asyncio.Semaphore] | None = None
@@ -33,7 +34,11 @@ def _get_index_semaphore() -> asyncio.Semaphore:
     """获取索引并发信号量，并发数配置（KB_INDEX_CONCURRENCY）变更时自动重建。"""
     global _index_semaphore_cache
 
-    concurrency = max(1, int(config.KB_INDEX_CONCURRENCY))
+    try:
+        concurrency = max(1, int(config.KB_INDEX_CONCURRENCY))
+    except (TypeError, ValueError):
+        # 配置值非法时回退默认并发，避免索引任务因错误配置而崩溃
+        concurrency = _INDEX_CONCURRENCY_DEFAULT
     if _index_semaphore_cache is not None and _index_semaphore_cache[0] == concurrency:
         return _index_semaphore_cache[1]
     semaphore = asyncio.Semaphore(concurrency)

--- a/nekro_agent/services/kb/library_index_service.py
+++ b/nekro_agent/services/kb/library_index_service.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from tortoise.backends.base.client import BaseDBAsyncClient
 
+from nekro_agent.core.config import config
 from nekro_agent.core.logger import get_sub_logger
 from nekro_agent.models.db_kb_asset import DBKBAsset
 from nekro_agent.models.db_kb_asset_chunk import DBKBAssetChunk
@@ -26,10 +27,21 @@ logger = get_sub_logger("kb.library_index")
 
 PREVIEW_MAX_CHARS = 360
 INDEX_BATCH_SIZE = 10
-_INDEX_CONCURRENCY = 3
-_index_semaphore = asyncio.Semaphore(_INDEX_CONCURRENCY)
 _index_tasks: dict[int, Any] = {}
 _pending_rebuilds: set[int] = set()
+_index_semaphore_cache: tuple[int, asyncio.Semaphore] | None = None
+
+
+def _get_index_semaphore() -> asyncio.Semaphore:
+    """获取索引并发信号量，并发数配置（KB_INDEX_CONCURRENCY）变更时自动重建。"""
+    global _index_semaphore_cache
+
+    concurrency = max(1, int(config.KB_INDEX_CONCURRENCY))
+    if _index_semaphore_cache is not None and _index_semaphore_cache[0] == concurrency:
+        return _index_semaphore_cache[1]
+    semaphore = asyncio.Semaphore(concurrency)
+    _index_semaphore_cache = (concurrency, semaphore)
+    return semaphore
 
 
 def _hash_text(text: str) -> str:
@@ -246,7 +258,7 @@ async def rebuild_asset(asset: DBKBAsset) -> int:
 async def _run_rebuild_asset_task(asset_id: int) -> None:
     task = _index_tasks.get(asset_id)
     try:
-        async with _index_semaphore:
+        async with _get_index_semaphore():
             while True:
                 _pending_rebuilds.discard(asset_id)
                 asset = await DBKBAsset.get_or_none(id=asset_id)

--- a/nekro_agent/services/kb/library_index_service.py
+++ b/nekro_agent/services/kb/library_index_service.py
@@ -30,23 +30,13 @@ INDEX_BATCH_SIZE = 10
 _INDEX_CONCURRENCY_DEFAULT = 3
 _index_tasks: dict[int, Any] = {}
 _pending_rebuilds: set[int] = set()
-_index_semaphore_cache: tuple[int, asyncio.Semaphore] | None = None
 
-
-def _get_index_semaphore() -> asyncio.Semaphore:
-    """获取索引并发信号量，并发数配置（KB_INDEX_CONCURRENCY）变更时自动重建。"""
-    global _index_semaphore_cache
-
-    try:
-        concurrency = max(1, int(config.KB_INDEX_CONCURRENCY))
-    except (TypeError, ValueError):
-        # 配置值非法时回退默认并发，避免索引任务因错误配置而崩溃
-        concurrency = _INDEX_CONCURRENCY_DEFAULT
-    if _index_semaphore_cache is not None and _index_semaphore_cache[0] == concurrency:
-        return _index_semaphore_cache[1]
-    semaphore = asyncio.Semaphore(concurrency)
-    _index_semaphore_cache = (concurrency, semaphore)
-    return semaphore
+try:
+    _INDEX_CONCURRENCY = max(1, int(config.KB_INDEX_CONCURRENCY))
+except (TypeError, ValueError):
+    # 配置值非法时回退默认并发，避免索引任务因错误配置而崩溃
+    _INDEX_CONCURRENCY = _INDEX_CONCURRENCY_DEFAULT
+_index_semaphore = asyncio.Semaphore(_INDEX_CONCURRENCY)
 
 
 def _hash_text(text: str) -> str:
@@ -263,7 +253,7 @@ async def rebuild_asset(asset: DBKBAsset) -> int:
 async def _run_rebuild_asset_task(asset_id: int) -> None:
     task = _index_tasks.get(asset_id)
     try:
-        async with _get_index_semaphore():
+        async with _index_semaphore:
             while True:
                 _pending_rebuilds.discard(asset_id)
                 asset = await DBKBAsset.get_or_none(id=asset_id)

--- a/nekro_agent/services/kb/library_index_service.py
+++ b/nekro_agent/services/kb/library_index_service.py
@@ -27,6 +27,7 @@ logger = get_sub_logger("kb.library_index")
 
 PREVIEW_MAX_CHARS = 360
 INDEX_BATCH_SIZE = 10
+_INDEX_CONCURRENCY_DEFAULT = 3
 _index_tasks: dict[int, Any] = {}
 _pending_rebuilds: set[int] = set()
 _index_semaphore_cache: tuple[int, asyncio.Semaphore] | None = None
@@ -36,7 +37,11 @@ def _get_index_semaphore() -> asyncio.Semaphore:
     """获取索引并发信号量，并发数配置（KB_INDEX_CONCURRENCY）变更时自动重建。"""
     global _index_semaphore_cache
 
-    concurrency = max(1, int(config.KB_INDEX_CONCURRENCY))
+    try:
+        concurrency = max(1, int(config.KB_INDEX_CONCURRENCY))
+    except (TypeError, ValueError):
+        # 配置值非法时回退默认并发，避免索引任务因错误配置而崩溃
+        concurrency = _INDEX_CONCURRENCY_DEFAULT
     if _index_semaphore_cache is not None and _index_semaphore_cache[0] == concurrency:
         return _index_semaphore_cache[1]
     semaphore = asyncio.Semaphore(concurrency)

--- a/nekro_agent/services/kb/library_service.py
+++ b/nekro_agent/services/kb/library_service.py
@@ -4,6 +4,7 @@ import asyncio
 from pathlib import Path
 
 from fastapi import UploadFile
+from tortoise.exceptions import IntegrityError
 
 from nekro_agent.core.logger import get_sub_logger
 from nekro_agent.core.os_env import OsEnv
@@ -238,6 +239,13 @@ async def create_asset_from_upload(
             file_size=len(content),
         )
         return asset, False
+    except IntegrityError:
+        # 并发上传同内容文件时，多个请求可能同时查不到已有记录；
+        # 唯一约束冲突后回退复用已存在的资产，避免被误判为上传失败
+        existing = await DBKBAsset.get_or_none(content_hash=content_hash)
+        if existing is not None:
+            return existing, True
+        raise
     except Exception:
         if target.exists():
             target.unlink()


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：ruff + basedpyright（0 errors / 0 warnings）
  - 前端：TypeScript 严格模式（tsc --noEmit）+ ESLint（--max-warnings 0）
- [x] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 无类型忽略标记 -->

## 🔍 变更类型 (勾选所有适用项)

- [x] ✨ 新功能 (添加新功能)
- [x] 🚀 性能提升
- [x] 🌐 国际化/本地化
- [ ] 🐛 Bug 修复 (修复一个问题)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] ✅ 测试相关
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

### 背景

知识库批量上传原本采用"逐文件串行"流程：上传一个文件 → 轮询等待其索引完成（每 1.5s 查一次，最长 300s）→ 再上传下一个。大批量文件时整体耗时 = Σ(上传 + 索引)，随文件数线性放大，体验较差。

### 改动

1. **批量上传异步化**（前端 `KnowledgeTab.tsx` / `kb-library.tsx`）：上传成功即标记完成，不再轮询等待索引；索引由后端既有后台任务（`schedule_rebuild_document` / `schedule_rebuild_asset`）异步执行
2. **批量上传有限并发**：串行循环改为共享游标工作池，默认并发 5（`BATCH_UPLOAD_CONCURRENCY`，注释标明建议 3~10），文件数少于并发时自动收缩；取消/版本失效语义与原来一致
3. **索引并发可配置**（后端）：新增配置项 `KB_INDEX_CONCURRENCY`（默认 3，与原硬编码 `_INDEX_CONCURRENCY` 一致），工作区文档与全局资产索引各按此值限制并发；修改配置后重启服务生效
4. **清理**：移除批量队列中不再使用的 `indexing` 状态及对应 UI 分支、`batchStatus.indexing` i18n 死 key（zh-CN/en-US 同步）

### 效果

- 批量上传整体耗时从 Σ(上传+索引) 降为 ≈ 上传时间 / 并发，大批量场景显著提速
- 索引并发可由运维按 Embedding 服务与 Qdrant 负载灵活调优

## 🔗 相关 Issue

无

## 📸 修改效果截图

无（无 UI 结构变化，仅流程与性能调整；批量队列状态图标展示保留）

## 🛠️ 实现复杂度

- [ ] 简单 (小改动，影响有限)
- [x] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

- 前端工作池：`nextIndex` 游标原子递增分配任务，`Math.min(并发数, 文件数)` 个 worker 并行执行 `uploadFile`，`Promise.all` 收尾；`batchRunVersionRef` + `batchCancelRequestedRef` 保留原取消语义
- 后端信号量：模块加载时按 `config.KB_INDEX_CONCURRENCY` 创建（`max(1, int(...))`，非法配置值回退默认 3），修改配置后需重启服务生效，避免运行中重建信号量导致新旧并发限制共存
- 后端索引框架本身未改动：仍按文档/资产独立排队，`_pending_rebuilds` 合并重复重建请求

## 🧪 测试步骤 (可选)

1. 进入 工作区 → 知识库 → 批量上传（多选文件 / 导入文件夹），观察队列"上传完成即 done"，列表中文档依次进入 pending → indexing → ready 状态
2. 全局知识库页面重复上述操作，验证 `content_hash` 去重与并发上传
3. 设置页将 `KB_INDEX_CONCURRENCY` 调为 1 / 6，批量重建索引，并重启服务，观察后台索引任务并发随之变化

## Summary by Sourcery

使知识库批量上传变为异步处理，在前端采用有界并发，在后端采用可配置的索引并发度。

New Features:
- 允许通过 `KB_INDEX_CONCURRENCY` 设置配置知识库索引并发度，适用于工作区文档和全局资源。

Enhancements:
- 修改工作区和全局知识库批量上传流程，在上传成功后立即将条目标记为已完成，并将索引工作委托给已有的后端异步任务。
- 为工作区和全局知识库批量上传引入共享的、有界并发的上传工作池，以加速批量操作。
- 支持在运行时通过重建后端索引信号量来动态调整索引并行度，当 `KB_INDEX_CONCURRENCY` 发生变化时生效。

Documentation:
- 在核心配置中为 `KB_INDEX_CONCURRENCY` 设置添加配置元数据和国际化文案。

Chores:
- 从知识库上传界面中移除已废弃的批量条目“indexing”状态及其相关进度指示和国际化键。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make knowledge base batch uploads asynchronous with bounded front-end concurrency and configurable back-end indexing concurrency.

New Features:
- Allow configuring knowledge base indexing concurrency via the KB_INDEX_CONCURRENCY setting for both workspace documents and global assets.

Enhancements:
- Change workspace and global knowledge base batch upload flows to mark items as completed once upload succeeds, delegating indexing to existing asynchronous back-end tasks.
- Introduce a shared bounded-concurrency upload worker pool for workspace and global knowledge base batch uploads to speed up bulk operations.
- Support dynamic adjustment of indexing parallelism at runtime by rebuilding the back-end index semaphore when KB_INDEX_CONCURRENCY changes.

Documentation:
- Add configuration metadata and i18n text for the KB_INDEX_CONCURRENCY setting in the core configuration.

Chores:
- Remove the obsolete batch item 'indexing' status and its associated progress indicators and i18n keys from the knowledge base upload UI.

</details>

新功能：
- 通过 `KB_INDEX_CONCURRENCY` 设置，为工作区文档和全局资源引入可配置的知识库索引并发度。

优化：
- 修改知识库批量上传流程，在上传成功后立即将条目标记为已完成，而不再等待索引，从而提升界面响应速度的体验。
- 在前端用有界并发的工作池替代串行的批量上传循环，应用于工作区和全局库上传。
- 当 `KB_INDEX_CONCURRENCY` 发生变化时，通过重建后端信号量动态调整索引并发度。

杂项：
- 移除未使用的批量队列索引状态以及相关的 UI 指示和工作区、全局知识库上传的国际化键。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使知识库批量上传变为异步处理，在前端采用有界并发，在后端采用可配置的索引并发度。

New Features:
- 允许通过 `KB_INDEX_CONCURRENCY` 设置配置知识库索引并发度，适用于工作区文档和全局资源。

Enhancements:
- 修改工作区和全局知识库批量上传流程，在上传成功后立即将条目标记为已完成，并将索引工作委托给已有的后端异步任务。
- 为工作区和全局知识库批量上传引入共享的、有界并发的上传工作池，以加速批量操作。
- 支持在运行时通过重建后端索引信号量来动态调整索引并行度，当 `KB_INDEX_CONCURRENCY` 发生变化时生效。

Documentation:
- 在核心配置中为 `KB_INDEX_CONCURRENCY` 设置添加配置元数据和国际化文案。

Chores:
- 从知识库上传界面中移除已废弃的批量条目“indexing”状态及其相关进度指示和国际化键。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make knowledge base batch uploads asynchronous with bounded front-end concurrency and configurable back-end indexing concurrency.

New Features:
- Allow configuring knowledge base indexing concurrency via the KB_INDEX_CONCURRENCY setting for both workspace documents and global assets.

Enhancements:
- Change workspace and global knowledge base batch upload flows to mark items as completed once upload succeeds, delegating indexing to existing asynchronous back-end tasks.
- Introduce a shared bounded-concurrency upload worker pool for workspace and global knowledge base batch uploads to speed up bulk operations.
- Support dynamic adjustment of indexing parallelism at runtime by rebuilding the back-end index semaphore when KB_INDEX_CONCURRENCY changes.

Documentation:
- Add configuration metadata and i18n text for the KB_INDEX_CONCURRENCY setting in the core configuration.

Chores:
- Remove the obsolete batch item 'indexing' status and its associated progress indicators and i18n keys from the knowledge base upload UI.

</details>

</details>
