### PR TITLE
fix(web): 修复聊天频道名称刷新不及时

### DIFF
--- a/frontend/src/hooks/useChannelDirectory.ts
+++ b/frontend/src/hooks/useChannelDirectory.ts
@@ -5,6 +5,7 @@ import {
   type ChannelDirectoryEntry,
   type ChannelListStreamEvent,
 } from '../services/api/chat-channel'
+import { CHANNEL_DIRECTORY_KEY, CHAT_CHANNEL_LIST_KEY } from '../pages/chat-channel/queryKeys'
 
 export type { ChannelDirectoryEntry }
 
@@ -63,7 +64,7 @@ export function useChannelDirectory(): ChannelDirectoryState {
   const [channels, setChannels] = useState<ChannelDirectoryEntry[]>([])
 
   const { data, isLoading } = useQuery({
-    queryKey: ['channel-directory'],
+    queryKey: [CHANNEL_DIRECTORY_KEY],
     queryFn: () => chatChannelApi.getDirectory(),
     staleTime: 5 * 60 * 1000,
   })
@@ -76,8 +77,8 @@ export function useChannelDirectory(): ChannelDirectoryState {
   useEffect(() => {
     const cancel = chatChannelApi.streamChannels((event) => {
       setChannels(prev => applyChannelStreamEvent(prev, event))
-      queryClient.invalidateQueries({ queryKey: ['channel-directory'] })
-      queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })
+      queryClient.invalidateQueries({ queryKey: [CHANNEL_DIRECTORY_KEY] })
+      queryClient.invalidateQueries({ queryKey: [CHAT_CHANNEL_LIST_KEY] })
     })
     return () => cancel()
   }, [queryClient])

--- a/frontend/src/locales/en-US/chat-channel.json
+++ b/frontend/src/locales/en-US/chat-channel.json
@@ -81,6 +81,7 @@
   "channelDetail": {
     "unnamedChat": "Unnamed Chat",
     "refreshInfo": "Refresh chat info",
+    "refreshFallback": "Failed to sync channel info, fell back to refreshing from database",
     "group": "Group",
     "private": "Private",
     "activate": "Activate",

--- a/frontend/src/locales/en-US/chat-channel.json
+++ b/frontend/src/locales/en-US/chat-channel.json
@@ -82,6 +82,7 @@
     "unnamedChat": "Unnamed Chat",
     "refreshInfo": "Refresh chat info",
     "refreshFallback": "Failed to sync channel info ({{reason}}), fell back to refreshing from database",
+    "refreshFallbackGeneric": "Failed to sync channel info, fell back to refreshing from database",
     "group": "Group",
     "private": "Private",
     "activate": "Activate",

--- a/frontend/src/locales/en-US/chat-channel.json
+++ b/frontend/src/locales/en-US/chat-channel.json
@@ -81,7 +81,7 @@
   "channelDetail": {
     "unnamedChat": "Unnamed Chat",
     "refreshInfo": "Refresh chat info",
-    "refreshFallback": "Failed to sync channel info, fell back to refreshing from database",
+    "refreshFallback": "Failed to sync channel info ({{reason}}), fell back to refreshing from database",
     "group": "Group",
     "private": "Private",
     "activate": "Activate",

--- a/frontend/src/locales/zh-CN/chat-channel.json
+++ b/frontend/src/locales/zh-CN/chat-channel.json
@@ -81,6 +81,7 @@
   "channelDetail": {
     "unnamedChat": "未命名聊天",
     "refreshInfo": "刷新聊天信息",
+    "refreshFallback": "频道信息同步失败，已回退为从数据库刷新",
     "group": "群聊",
     "private": "私聊",
     "activate": "激活",

--- a/frontend/src/locales/zh-CN/chat-channel.json
+++ b/frontend/src/locales/zh-CN/chat-channel.json
@@ -81,7 +81,7 @@
   "channelDetail": {
     "unnamedChat": "未命名聊天",
     "refreshInfo": "刷新聊天信息",
-    "refreshFallback": "频道信息同步失败，已回退为从数据库刷新",
+    "refreshFallback": "频道信息同步失败（{{reason}}），已回退为从数据库刷新",
     "group": "群聊",
     "private": "私聊",
     "activate": "激活",

--- a/frontend/src/locales/zh-CN/chat-channel.json
+++ b/frontend/src/locales/zh-CN/chat-channel.json
@@ -82,6 +82,7 @@
     "unnamedChat": "未命名聊天",
     "refreshInfo": "刷新聊天信息",
     "refreshFallback": "频道信息同步失败（{{reason}}），已回退为从数据库刷新",
+    "refreshFallbackGeneric": "频道信息同步失败，已回退为从数据库刷新",
     "group": "群聊",
     "private": "私聊",
     "activate": "激活",

--- a/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
+++ b/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
@@ -100,9 +100,10 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
   const handleRefresh = async () => {
     setIsRefreshing(true)
     try {
-      // 先请求后端从平台实时同步频道名称（适配器不支持或获取失败时保留原名称），再刷新各列表缓存
-      await chatChannelApi.refreshDetail(chatKey)
-      await queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
+      // 先请求后端从平台实时同步频道名称（适配器不支持或获取失败时保留原名称）
+      const refreshedDetail = await chatChannelApi.refreshDetail(chatKey)
+      // 直接用返回的最新详情更新详情缓存，避免额外的重新拉取
+      queryClient.setQueryData(['chat-channel-detail', chatKey], refreshedDetail)
       await queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })
       await queryClient.invalidateQueries({ queryKey: ['channel-directory'] })
     } finally {

--- a/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
+++ b/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
@@ -43,6 +43,7 @@ import { useTranslation } from 'react-i18next'
 import { type ChatChannelDetailTab } from '../../../router/routes'
 import ActionButton from '../../../components/common/ActionButton'
 import IconActionButton from '../../../components/common/IconActionButton'
+import { useNotification } from '../../../hooks/useNotification'
 
 interface ChatChannelDetailProps {
   chatKey: string
@@ -65,6 +66,7 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const { t } = useTranslation('chat-channel')
+  const notification = useNotification()
 
   // 查询聊天详情
   const { data: channel, isLoading, isFetching } = useQuery({
@@ -105,8 +107,10 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
         const refreshedDetail = await chatChannelApi.refreshDetail(chatKey)
         // 返回的详情已是后端同步后的权威数据，直接更新详情缓存；仅使列表失效以同步名称展示
         queryClient.setQueryData(['chat-channel-detail', chatKey], refreshedDetail)
-      } catch {
-        // 平台同步失败时回退为普通缓存失效，仍从数据库刷新当前状态
+      } catch (error) {
+        // 平台同步失败时回退为普通缓存失效，仍从数据库刷新当前状态；记录失败原因避免被静默掩盖
+        console.error('[ChatChannelDetail] refreshDetail failed, falling back to invalidateQueries', { chatKey, error })
+        notification.warning(t('channelDetail.refreshFallback'))
         await queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
       }
       await queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })

--- a/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
+++ b/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
@@ -30,7 +30,7 @@ import {
   ArrowBack as ArrowBackIcon,
 } from '@mui/icons-material'
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
-import { chatChannelApi, getChannelDisplayName, type ChatChannelDetail } from '../../../services/api/chat-channel'
+import { chatChannelApi, getChannelDisplayName } from '../../../services/api/chat-channel'
 import BasicInfo from './detail-tabs/BasicInfo'
 import MessageHistory from './detail-tabs/MessageHistory'
 import OverrideSettings from './detail-tabs/OverrideSettings'
@@ -43,7 +43,7 @@ import { useTranslation } from 'react-i18next'
 import { type ChatChannelDetailTab } from '../../../router/routes'
 import ActionButton from '../../../components/common/ActionButton'
 import IconActionButton from '../../../components/common/IconActionButton'
-import { useNotification } from '../../../hooks/useNotification'
+import { useChatChannelRefresh } from './chat-channel-refresh'
 
 interface ChatChannelDetailProps {
   chatKey: string
@@ -66,7 +66,7 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const { t } = useTranslation('chat-channel')
-  const notification = useNotification()
+  const { refresh } = useChatChannelRefresh(chatKey)
 
   // 查询聊天详情
   const { data: channel, isLoading, isFetching } = useQuery({
@@ -102,25 +102,7 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
   const handleRefresh = async () => {
     setIsRefreshing(true)
     try {
-      // 平台同步与缓存更新分离：同步失败不影响缓存失效回退
-      let refreshedDetail: ChatChannelDetail | null = null
-      try {
-        // 请求后端从平台实时同步频道名称（适配器不支持或获取失败时保留原名称）
-        refreshedDetail = await chatChannelApi.refreshDetail(chatKey)
-      } catch (error) {
-        const reason = error instanceof Error ? error.message : String(error)
-        console.error('[ChatChannelDetail] refreshDetail failed, falling back to invalidateQueries', { chatKey, error })
-        notification.warning(t('channelDetail.refreshFallback', { reason }))
-      }
-      if (refreshedDetail) {
-        // 返回的详情已是后端同步后的权威数据，直接更新详情缓存；仅使列表失效以同步名称展示
-        queryClient.setQueryData(['chat-channel-detail', chatKey], refreshedDetail)
-      } else {
-        // 同步失败时回退为普通缓存失效，仍从数据库刷新当前状态
-        await queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
-      }
-      await queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })
-      await queryClient.invalidateQueries({ queryKey: ['channel-directory'] })
+      await refresh()
     } finally {
       setIsRefreshing(false)
     }

--- a/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
+++ b/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
@@ -30,7 +30,7 @@ import {
   ArrowBack as ArrowBackIcon,
 } from '@mui/icons-material'
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
-import { chatChannelApi, getChannelDisplayName } from '../../../services/api/chat-channel'
+import { chatChannelApi, getChannelDisplayName, type ChatChannelDetail } from '../../../services/api/chat-channel'
 import BasicInfo from './detail-tabs/BasicInfo'
 import MessageHistory from './detail-tabs/MessageHistory'
 import OverrideSettings from './detail-tabs/OverrideSettings'
@@ -102,15 +102,21 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
   const handleRefresh = async () => {
     setIsRefreshing(true)
     try {
+      // 平台同步与缓存更新分离：同步失败不影响缓存失效回退
+      let refreshedDetail: ChatChannelDetail | null = null
       try {
         // 请求后端从平台实时同步频道名称（适配器不支持或获取失败时保留原名称）
-        const refreshedDetail = await chatChannelApi.refreshDetail(chatKey)
+        refreshedDetail = await chatChannelApi.refreshDetail(chatKey)
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error)
+        console.error('[ChatChannelDetail] refreshDetail failed, falling back to invalidateQueries', { chatKey, error })
+        notification.warning(t('channelDetail.refreshFallback', { reason }))
+      }
+      if (refreshedDetail) {
         // 返回的详情已是后端同步后的权威数据，直接更新详情缓存；仅使列表失效以同步名称展示
         queryClient.setQueryData(['chat-channel-detail', chatKey], refreshedDetail)
-      } catch (error) {
-        // 平台同步失败时回退为普通缓存失效，仍从数据库刷新当前状态；记录失败原因避免被静默掩盖
-        console.error('[ChatChannelDetail] refreshDetail failed, falling back to invalidateQueries', { chatKey, error })
-        notification.warning(t('channelDetail.refreshFallback'))
+      } else {
+        // 同步失败时回退为普通缓存失效，仍从数据库刷新当前状态
         await queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
       }
       await queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })

--- a/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
+++ b/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
@@ -100,10 +100,15 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
   const handleRefresh = async () => {
     setIsRefreshing(true)
     try {
-      // 先请求后端从平台实时同步频道名称（适配器不支持或获取失败时保留原名称）
-      const refreshedDetail = await chatChannelApi.refreshDetail(chatKey)
-      // 返回的详情已是后端同步后的权威数据，直接更新详情缓存；仅使列表失效以同步名称展示
-      queryClient.setQueryData(['chat-channel-detail', chatKey], refreshedDetail)
+      try {
+        // 请求后端从平台实时同步频道名称（适配器不支持或获取失败时保留原名称）
+        const refreshedDetail = await chatChannelApi.refreshDetail(chatKey)
+        // 返回的详情已是后端同步后的权威数据，直接更新详情缓存；仅使列表失效以同步名称展示
+        queryClient.setQueryData(['chat-channel-detail', chatKey], refreshedDetail)
+      } catch {
+        // 平台同步失败时回退为普通缓存失效，仍从数据库刷新当前状态
+        await queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
+      }
       await queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })
       await queryClient.invalidateQueries({ queryKey: ['channel-directory'] })
     } finally {

--- a/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
+++ b/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
@@ -102,9 +102,8 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
     try {
       // 先请求后端从平台实时同步频道名称（适配器不支持或获取失败时保留原名称）
       const refreshedDetail = await chatChannelApi.refreshDetail(chatKey)
-      // 用返回的最新详情即时更新缓存，同时使详情与列表失效，与其他依赖重获取的流程保持一致
+      // 返回的详情已是后端同步后的权威数据，直接更新详情缓存；仅使列表失效以同步名称展示
       queryClient.setQueryData(['chat-channel-detail', chatKey], refreshedDetail)
-      await queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
       await queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })
       await queryClient.invalidateQueries({ queryKey: ['channel-directory'] })
     } finally {

--- a/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
+++ b/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
@@ -100,6 +100,8 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
   const handleRefresh = async () => {
     setIsRefreshing(true)
     try {
+      // 先请求后端从平台实时同步频道名称（适配器不支持或获取失败时保留原名称），再刷新各列表缓存
+      await chatChannelApi.refreshDetail(chatKey)
       await queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
       await queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })
       await queryClient.invalidateQueries({ queryKey: ['channel-directory'] })

--- a/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
+++ b/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
@@ -102,8 +102,9 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
     try {
       // 先请求后端从平台实时同步频道名称（适配器不支持或获取失败时保留原名称）
       const refreshedDetail = await chatChannelApi.refreshDetail(chatKey)
-      // 直接用返回的最新详情更新详情缓存，避免额外的重新拉取
+      // 用返回的最新详情即时更新缓存，同时使详情与列表失效，与其他依赖重获取的流程保持一致
       queryClient.setQueryData(['chat-channel-detail', chatKey], refreshedDetail)
+      await queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
       await queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })
       await queryClient.invalidateQueries({ queryKey: ['channel-directory'] })
     } finally {

--- a/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
+++ b/frontend/src/pages/chat-channel/components/ChatChannelDetail.tsx
@@ -44,6 +44,7 @@ import { type ChatChannelDetailTab } from '../../../router/routes'
 import ActionButton from '../../../components/common/ActionButton'
 import IconActionButton from '../../../components/common/IconActionButton'
 import { useChatChannelRefresh } from './chat-channel-refresh'
+import { CHANNEL_DIRECTORY_KEY, CHAT_CHANNEL_DETAIL_KEY, CHAT_CHANNEL_LIST_KEY } from '../queryKeys'
 
 interface ChatChannelDetailProps {
   chatKey: string
@@ -70,7 +71,7 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
 
   // 查询聊天详情
   const { data: channel, isLoading, isFetching } = useQuery({
-    queryKey: ['chat-channel-detail', chatKey],
+    queryKey: [CHAT_CHANNEL_DETAIL_KEY, chatKey],
     queryFn: () => chatChannelApi.getDetail(chatKey),
     staleTime: 30_000,
     placeholderData: keepPreviousData,
@@ -83,9 +84,9 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
   const { mutate: setChannelStatus, isPending: isToggling } = useMutation({
     mutationFn: (status: 'active' | 'observe' | 'disabled') => chatChannelApi.setStatus(chatKey, status),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
-      queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })
-      queryClient.invalidateQueries({ queryKey: ['channel-directory'] })
+      queryClient.invalidateQueries({ queryKey: [CHAT_CHANNEL_DETAIL_KEY, chatKey] })
+      queryClient.invalidateQueries({ queryKey: [CHAT_CHANNEL_LIST_KEY] })
+      queryClient.invalidateQueries({ queryKey: [CHANNEL_DIRECTORY_KEY] })
     },
   })
 
@@ -93,7 +94,7 @@ export default function ChatChannelDetail({ chatKey, currentTab, onTabChange, on
   const { mutate: resetChannel, isPending: isResetting } = useMutation({
     mutationFn: () => chatChannelApi.reset(chatKey),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
+      queryClient.invalidateQueries({ queryKey: [CHAT_CHANNEL_DETAIL_KEY, chatKey] })
       setResetDialogOpen(false)
     },
   })

--- a/frontend/src/pages/chat-channel/components/chat-channel-refresh.ts
+++ b/frontend/src/pages/chat-channel/components/chat-channel-refresh.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { chatChannelApi, type ChatChannelDetail } from '../../../services/api/chat-channel'
 import { useNotification } from '../../../hooks/useNotification'
+import { CHANNEL_DIRECTORY_KEY, CHAT_CHANNEL_DETAIL_KEY, CHAT_CHANNEL_LIST_KEY } from '../queryKeys'
 
 /**
  * 聊天频道信息刷新编排：平台同步频道名称 + 失败回退 + 缓存更新。
@@ -18,20 +19,24 @@ export function useChatChannelRefresh(chatKey: string) {
       // 请求后端从平台实时同步频道名称（适配器不支持或获取失败时保留原名称）
       refreshedDetail = await chatChannelApi.refreshDetail(chatKey)
     } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error)
       console.error('[ChatChannelDetail] refreshDetail failed, falling back to invalidateQueries', { chatKey, error })
-      notification.warning(t('channelDetail.refreshFallback', { reason }))
+      // axios 拦截器已统一转换为带本地化消息的 ApiError，message 可直接展示；兜底使用通用文案
+      const message =
+        error instanceof Error && error.message
+          ? t('channelDetail.refreshFallback', { reason: error.message })
+          : t('channelDetail.refreshFallbackGeneric')
+      notification.warning(message)
     }
 
     if (refreshedDetail) {
       // 返回的详情已是后端同步后的权威数据，直接更新详情缓存；仅使列表失效以同步名称展示
-      queryClient.setQueryData(['chat-channel-detail', chatKey], refreshedDetail)
+      queryClient.setQueryData([CHAT_CHANNEL_DETAIL_KEY, chatKey], refreshedDetail)
     } else {
       // 同步失败时回退为普通缓存失效，仍从数据库刷新当前状态
-      await queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
+      await queryClient.invalidateQueries({ queryKey: [CHAT_CHANNEL_DETAIL_KEY, chatKey] })
     }
-    await queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })
-    await queryClient.invalidateQueries({ queryKey: ['channel-directory'] })
+    await queryClient.invalidateQueries({ queryKey: [CHAT_CHANNEL_LIST_KEY] })
+    await queryClient.invalidateQueries({ queryKey: [CHANNEL_DIRECTORY_KEY] })
   }
 
   return { refresh }

--- a/frontend/src/pages/chat-channel/components/chat-channel-refresh.ts
+++ b/frontend/src/pages/chat-channel/components/chat-channel-refresh.ts
@@ -1,0 +1,38 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { chatChannelApi, type ChatChannelDetail } from '../../../services/api/chat-channel'
+import { useNotification } from '../../../hooks/useNotification'
+
+/**
+ * 聊天频道信息刷新编排：平台同步频道名称 + 失败回退 + 缓存更新。
+ * 组件只需调用 refresh 并自行管理加载状态。
+ */
+export function useChatChannelRefresh(chatKey: string) {
+  const queryClient = useQueryClient()
+  const notification = useNotification()
+  const { t } = useTranslation('chat-channel')
+
+  const refresh = async (): Promise<void> => {
+    let refreshedDetail: ChatChannelDetail | null = null
+    try {
+      // 请求后端从平台实时同步频道名称（适配器不支持或获取失败时保留原名称）
+      refreshedDetail = await chatChannelApi.refreshDetail(chatKey)
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      console.error('[ChatChannelDetail] refreshDetail failed, falling back to invalidateQueries', { chatKey, error })
+      notification.warning(t('channelDetail.refreshFallback', { reason }))
+    }
+
+    if (refreshedDetail) {
+      // 返回的详情已是后端同步后的权威数据，直接更新详情缓存；仅使列表失效以同步名称展示
+      queryClient.setQueryData(['chat-channel-detail', chatKey], refreshedDetail)
+    } else {
+      // 同步失败时回退为普通缓存失效，仍从数据库刷新当前状态
+      await queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', chatKey] })
+    }
+    await queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })
+    await queryClient.invalidateQueries({ queryKey: ['channel-directory'] })
+  }
+
+  return { refresh }
+}

--- a/frontend/src/pages/chat-channel/components/detail-tabs/BasicInfo.tsx
+++ b/frontend/src/pages/chat-channel/components/detail-tabs/BasicInfo.tsx
@@ -37,6 +37,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { copyText } from '../../../../utils/clipboard'
 import ActionButton from '../../../../components/common/ActionButton'
+import { CHANNEL_DIRECTORY_KEY, CHAT_CHANNEL_DETAIL_KEY, CHAT_CHANNEL_LIST_KEY } from '../../queryKeys'
 
 interface BasicInfoProps {
   channel: ChatChannelDetail
@@ -111,9 +112,9 @@ export default function BasicInfo({ channel }: BasicInfoProps) {
       await chatChannelApi.setCustomChannelName(channel.chat_key, nextName || null)
       enqueueSnackbar(t('basicInfo.saveCustomNameSuccess'), { variant: 'success' })
       setCustomNameDialogOpen(false)
-      queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', channel.chat_key] })
-      queryClient.invalidateQueries({ queryKey: ['chat-channel-management-list'] })
-      queryClient.invalidateQueries({ queryKey: ['channel-directory'] })
+      queryClient.invalidateQueries({ queryKey: [CHAT_CHANNEL_DETAIL_KEY, channel.chat_key] })
+      queryClient.invalidateQueries({ queryKey: [CHAT_CHANNEL_LIST_KEY] })
+      queryClient.invalidateQueries({ queryKey: [CHANNEL_DIRECTORY_KEY] })
     } catch (_error) {
       enqueueSnackbar(t('basicInfo.saveCustomNameFailed'), { variant: 'error' })
     } finally {
@@ -138,7 +139,7 @@ export default function BasicInfo({ channel }: BasicInfoProps) {
       setPresetDialogOpen(false)
 
       // 刷新聊天频道详情
-      queryClient.invalidateQueries({ queryKey: ['chat-channel-detail', channel.chat_key] })
+      queryClient.invalidateQueries({ queryKey: [CHAT_CHANNEL_DETAIL_KEY, channel.chat_key] })
     } catch (_error) {
       enqueueSnackbar(t('basicInfo.setPresetFailed'), { variant: 'error' })
     } finally {

--- a/frontend/src/pages/chat-channel/index.tsx
+++ b/frontend/src/pages/chat-channel/index.tsx
@@ -33,6 +33,7 @@ import {
   chatChannelApi,
   type ChatChannel,
 } from '../../services/api/chat-channel'
+import { CHAT_CHANNEL_LIST_KEY } from './queryKeys'
 
 export default function ChatChannelPage() {
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -60,7 +61,7 @@ export default function ChatChannelPage() {
   const deferredSearch = useDeferredValue(search)
 
   const { data, isLoading } = useQuery({
-    queryKey: ['chat-channel-management-list', deferredSearch, chatType, status],
+    queryKey: [CHAT_CHANNEL_LIST_KEY, deferredSearch, chatType, status],
     queryFn: () =>
       chatChannelApi.getList({
         page: 1,

--- a/frontend/src/pages/chat-channel/queryKeys.ts
+++ b/frontend/src/pages/chat-channel/queryKeys.ts
@@ -1,0 +1,4 @@
+/** 聊天频道相关 React Query 查询键（集中管理，避免各处硬编码不一致） */
+export const CHAT_CHANNEL_DETAIL_KEY = 'chat-channel-detail'
+export const CHAT_CHANNEL_LIST_KEY = 'chat-channel-management-list'
+export const CHANNEL_DIRECTORY_KEY = 'channel-directory'

--- a/frontend/src/services/api/chat-channel.ts
+++ b/frontend/src/services/api/chat-channel.ts
@@ -186,7 +186,7 @@ export const chatChannelApi = {
   },
 
   refreshDetail: async (chatKey: string): Promise<ChatChannelDetail> => {
-    const response = await axios.post<ChatChannelDetail>(`/chat-channel/detail/${chatKey}/refresh`)
+    const response = await axios.get<ChatChannelDetail>(`/chat-channel/detail/${chatKey}/refresh`)
     return response.data
   },
 

--- a/frontend/src/services/api/chat-channel.ts
+++ b/frontend/src/services/api/chat-channel.ts
@@ -186,7 +186,7 @@ export const chatChannelApi = {
   },
 
   refreshDetail: async (chatKey: string): Promise<ChatChannelDetail> => {
-    const response = await axios.get<ChatChannelDetail>(`/chat-channel/detail/${chatKey}/refresh`)
+    const response = await axios.post<ChatChannelDetail>(`/chat-channel/detail/${chatKey}/refresh`)
     return response.data
   },
 

--- a/frontend/src/services/api/chat-channel.ts
+++ b/frontend/src/services/api/chat-channel.ts
@@ -185,6 +185,11 @@ export const chatChannelApi = {
     return response.data
   },
 
+  refreshDetail: async (chatKey: string): Promise<ChatChannelDetail> => {
+    const response = await axios.post<ChatChannelDetail>(`/chat-channel/detail/${chatKey}/refresh`)
+    return response.data
+  },
+
   getDirectory: async (): Promise<ChannelDirectoryEntry[]> => {
     const response = await axios.get<{ items: ChannelDirectoryEntry[] }>('/chat-channel/directory')
     return response.data.items

--- a/nekro_agent/routers/chat_channel.py
+++ b/nekro_agent/routers/chat_channel.py
@@ -346,7 +346,7 @@ async def get_chat_channel_detail(chat_key: str, _current_user: DBUser = Depends
     return await _build_chat_channel_detail(channel)
 
 
-@router.get("/detail/{chat_key}/refresh", summary="刷新聊天频道信息", response_model=ChatChannelDetail)
+@router.post("/detail/{chat_key}/refresh", summary="刷新聊天频道信息", response_model=ChatChannelDetail)
 @require_role(Role.Admin)
 async def refresh_chat_channel_detail(
     chat_key: str, _current_user: DBUser = Depends(get_current_active_user)

--- a/nekro_agent/routers/chat_channel.py
+++ b/nekro_agent/routers/chat_channel.py
@@ -356,10 +356,8 @@ async def refresh_chat_channel_detail(
     if not channel:
         raise NotFoundError(resource="聊天频道")
     await channel.sync_channel_name()
-    # 重新读取以返回数据库中的最新状态（含 ORM 自动更新的字段）
-    channel = await DBChatChannel.get_or_none(id=channel.id)
-    if not channel:
-        raise NotFoundError(resource="聊天频道")
+    # 复用同一实例并从数据库刷新字段，确保返回最新状态（含 ORM 自动更新的 update_time）
+    await channel.refresh_from_db()
     return await _build_chat_channel_detail(channel)
 
 

--- a/nekro_agent/routers/chat_channel.py
+++ b/nekro_agent/routers/chat_channel.py
@@ -346,7 +346,7 @@ async def get_chat_channel_detail(chat_key: str, _current_user: DBUser = Depends
     return await _build_chat_channel_detail(channel)
 
 
-@router.post("/detail/{chat_key}/refresh", summary="刷新聊天频道信息", response_model=ChatChannelDetail)
+@router.get("/detail/{chat_key}/refresh", summary="刷新聊天频道信息", response_model=ChatChannelDetail)
 @require_role(Role.Admin)
 async def refresh_chat_channel_detail(
     chat_key: str, _current_user: DBUser = Depends(get_current_active_user)

--- a/nekro_agent/routers/chat_channel.py
+++ b/nekro_agent/routers/chat_channel.py
@@ -356,6 +356,10 @@ async def refresh_chat_channel_detail(
     if not channel:
         raise NotFoundError(resource="聊天频道")
     await channel.sync_channel_name()
+    # 重新读取以返回数据库中的最新状态（含 ORM 自动更新的字段）
+    channel = await DBChatChannel.get_or_none(id=channel.id)
+    if not channel:
+        raise NotFoundError(resource="聊天频道")
     return await _build_chat_channel_detail(channel)
 
 

--- a/nekro_agent/routers/chat_channel.py
+++ b/nekro_agent/routers/chat_channel.py
@@ -355,9 +355,8 @@ async def refresh_chat_channel_detail(
     channel = await DBChatChannel.filter(chat_key=chat_key).first()
     if not channel:
         raise NotFoundError(resource="聊天频道")
+    # sync_channel_name 成功时更新内存实例并持久化（含 update_time），失败时不改动，实例始终与数据库一致
     await channel.sync_channel_name()
-    # 复用同一实例并从数据库刷新字段，确保返回最新状态（含 ORM 自动更新的 update_time）
-    await channel.refresh_from_db()
     return await _build_chat_channel_detail(channel)
 
 

--- a/nekro_agent/routers/chat_channel.py
+++ b/nekro_agent/routers/chat_channel.py
@@ -291,18 +291,14 @@ async def stream_chat_channel_list(
     )
 
 
-@router.get("/detail/{chat_key}", summary="获取聊天频道详情")
-@require_role(Role.Admin)
-async def get_chat_channel_detail(chat_key: str, _current_user: DBUser = Depends(get_current_active_user)) -> ChatChannelDetail:
-    """获取聊天频道详情"""
-    channel = await DBChatChannel.filter(chat_key=chat_key).first()
-    if not channel:
-        raise NotFoundError(resource="聊天频道")
-
-    message_count = await DBChatMessage.filter(chat_key=chat_key, create_time__gte=channel.conversation_start_time).count()
-    last_message = await DBChatMessage.filter(chat_key=chat_key).order_by("-create_time").first()
+async def _build_chat_channel_detail(channel: DBChatChannel) -> ChatChannelDetail:
+    """构建聊天频道详情响应"""
+    message_count = await DBChatMessage.filter(
+        chat_key=channel.chat_key, create_time__gte=channel.conversation_start_time
+    ).count()
+    last_message = await DBChatMessage.filter(chat_key=channel.chat_key).order_by("-create_time").first()
     last_message_time = last_message.create_time if last_message else None
-    unique_users = await DBChatMessage.filter(chat_key=chat_key).distinct().values_list("sender_id", flat=True)
+    unique_users = await DBChatMessage.filter(chat_key=channel.chat_key).distinct().values_list("sender_id", flat=True)
 
     # 检测适配器是否支持 WebUI 发送
     can_send = False
@@ -315,7 +311,7 @@ async def get_chat_channel_detail(chat_key: str, _current_user: DBUser = Depends
     # 获取频道有效配置
     ai_always_include_msg_id = False
     try:
-        effective_config = await config_resolver.get_effective_config(chat_key)
+        effective_config = await config_resolver.get_effective_config(channel.chat_key)
         ai_always_include_msg_id = effective_config.AI_ALWAYS_INCLUDE_MSG_ID
     except Exception:
         pass
@@ -338,6 +334,29 @@ async def get_chat_channel_detail(chat_key: str, _current_user: DBUser = Depends
         can_send=can_send,
         ai_always_include_msg_id=ai_always_include_msg_id,
     )
+
+
+@router.get("/detail/{chat_key}", summary="获取聊天频道详情")
+@require_role(Role.Admin)
+async def get_chat_channel_detail(chat_key: str, _current_user: DBUser = Depends(get_current_active_user)) -> ChatChannelDetail:
+    """获取聊天频道详情"""
+    channel = await DBChatChannel.filter(chat_key=chat_key).first()
+    if not channel:
+        raise NotFoundError(resource="聊天频道")
+    return await _build_chat_channel_detail(channel)
+
+
+@router.post("/detail/{chat_key}/refresh", summary="刷新聊天频道信息", response_model=ChatChannelDetail)
+@require_role(Role.Admin)
+async def refresh_chat_channel_detail(
+    chat_key: str, _current_user: DBUser = Depends(get_current_active_user)
+) -> ChatChannelDetail:
+    """从平台实时同步频道名称并返回最新详情（适配器不支持或获取失败时保留原名称）"""
+    channel = await DBChatChannel.filter(chat_key=chat_key).first()
+    if not channel:
+        raise NotFoundError(resource="聊天频道")
+    await channel.sync_channel_name()
+    return await _build_chat_channel_detail(channel)
 
 
 @router.post("/{chat_key}/active", summary="设置聊天频道激活状态")


### PR DESCRIPTION
# 🌟 PR 提交说明

## 📋 许可确认

- [x] 我已仔细阅读并同意 [NekroAgent 开源协议](../../LICENSE) 中的所有条款并理解我的贡献将受到该协议的约束，特别是"贡献者条款"部分
- [x] 我确认我提交的代码不会侵犯任何第三方的知识产权

## 💯 代码质量确认

- [x] 我已执行静态类型检查，确保代码不含基本类型错误：
  - 后端：ruff + basedpyright（0 errors / 0 warnings）
  - 前端：TypeScript 严格模式（tsc --noEmit）+ ESLint（--max-warnings 0）
- [x] 对于难以解决的必要类型忽略标记，我已添加注释说明原因：
<!-- 无类型忽略标记 -->

## 🔍 变更类型 (勾选所有适用项)

- [x] 🐛 Bug 修复 (修复一个问题)
- [ ] ✨ 新功能 (添加新功能)
- [ ] 🔄 重构 (不改变功能的代码调整)
- [ ] 📝 文档更新
- [ ] 🔧 配置变更
- [ ] 🎨 代码风格优化
- [ ] 💅 样式调整 (UI/UX 外观变化)
- [ ] 🚀 性能提升
- [ ] ✅ 测试相关
- [ ] 🌐 国际化/本地化
- [ ] 🔗 依赖更新
- [ ] 🧩 插件系统相关
- [ ] 🤖 AI 模型/提示词相关
- [ ] 🔄 其他...

## 📄 PR 描述

### 问题

WebUI 上的群聊名称 / 私聊名称有时不能及时刷新：群名在平台上更新后，点击"刷新聊天信息"按钮仍显示旧名称。

### 根因

频道名称（`DBChatChannel.channel_name`）仅在收到新消息时按消息携带的名称更新（`get_or_create`）；WebUI 的"刷新聊天信息"按钮此前只做前端缓存失效（`invalidateQueries` 重新读取数据库），**不会从平台实时拉取**名称。因此群名/昵称在平台侧更新后，只要没有新消息触发入库更新，界面就一直显示旧名称。

### 修复

1. **后端**：新增 `POST /chat-channel/detail/{chat_key}/refresh` 接口，调用已有的 `DBChatChannel.sync_channel_name()`（内部经 `adapter.get_channel_info` 实时从平台拉取群名/昵称并落库）；适配器不支持或获取失败时保留原名称，不报错
2. **后端**：聊天详情构建逻辑抽取为 `_build_chat_channel_detail()` helper，原详情接口与刷新接口复用
3. **前端**："刷新聊天信息"按钮改为先调用 `refreshDetail` 从平台同步名称，再刷新详情与列表缓存

### 影响范围

- 仅影响 WebUI 频道详情页的刷新行为，不改变消息处理、名称入库等既有逻辑
- 各适配器按自身 `get_channel_info` 实现能力生效（OneBot/Telegram 等支持实时获取；不支持实时获取的适配器保持原名称）

## 🔗 相关 Issue

无

## 📸 修改效果截图

无（行为修复，无 UI 结构变化）

## 🛠️ 实现复杂度

- [x] 简单 (小改动，影响有限)
- [ ] 中等 (需要一些技术考量)
- [ ] 复杂 (涉及多个组件或系统)

## 📋 实现细节 (可选)

- `sync_channel_name()` 为既有方法（模型层），本次仅暴露为 API 并在前端触发，无新增同步逻辑
- 刷新接口失败时不抛出错误：`sync_channel_name` 内部捕获异常并保留原名称，符合"刷新失败不破坏现有显示"的容错预期

## 🧪 测试步骤 (可选)

1. 在 QQ/群聊平台侧修改群名称或昵称
2. 打开 WebUI 对应频道详情页，点击"刷新聊天信息"
3. 观察频道名称更新为平台最新名称（列表页与详情页同步更新）
4. 适配器不支持实时获取时，名称保持不变且无报错

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

</details>

新功能：
- 引入一个 POST 端点，用于刷新聊天频道详情：通过从平台同步频道名称并返回最新的元数据来实现。
- 更新 WebUI 的刷新操作，使其调用新的后端刷新端点，并立即更新缓存的频道详情和相关列表。

缺陷修复：
- 确保当底层平台的频道标题发生变化时，即使没有新消息到达，WebUI 中的聊天频道名称也能得到更新。

改进：
- 将构建聊天频道详情响应的通用逻辑提取为可复用的助手方法，供标准详情端点和新的刷新端点共同使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

</details>

</details>

Bug Fixes（错误修复）:
- 修复当底层平台上的频道标题已更新但没有新消息到达时，WebUI 中聊天频道名称仍然陈旧的问题。

Enhancements（增强）:
- 将构建聊天频道详情响应的共享逻辑抽取到一个可复用的辅助函数中，使标准详情端点和刷新端点都使用该辅助函数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

</details>

新功能：
- 引入一个 POST 端点，用于刷新聊天频道详情：通过从平台同步频道名称并返回最新的元数据来实现。
- 更新 WebUI 的刷新操作，使其调用新的后端刷新端点，并立即更新缓存的频道详情和相关列表。

缺陷修复：
- 确保当底层平台的频道标题发生变化时，即使没有新消息到达，WebUI 中的聊天频道名称也能得到更新。

改进：
- 将构建聊天频道详情响应的通用逻辑提取为可复用的助手方法，供标准详情端点和新的刷新端点共同使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

</details>

新功能：
- 引入一个 POST 端点，用于刷新聊天频道详情：通过从平台同步频道名称并返回最新的元数据来实现。
- 更新 WebUI 的刷新操作，使其调用新的后端刷新端点，并立即更新缓存的频道详情和相关列表。

缺陷修复：
- 确保当底层平台的频道标题发生变化时，即使没有新消息到达，WebUI 中的聊天频道名称也能得到更新。

改进：
- 将构建聊天频道详情响应的通用逻辑提取为可复用的助手方法，供标准详情端点和新的刷新端点共同使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

</details>

</details>

Bug Fixes（错误修复）:
- 修复当底层平台上的频道标题已更新但没有新消息到达时，WebUI 中聊天频道名称仍然陈旧的问题。

Enhancements（增强）:
- 将构建聊天频道详情响应的共享逻辑抽取到一个可复用的辅助函数中，使标准详情端点和刷新端点都使用该辅助函数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

</details>

新功能：
- 引入一个 POST 端点，用于刷新聊天频道详情：通过从平台同步频道名称并返回最新的元数据来实现。
- 更新 WebUI 的刷新操作，使其调用新的后端刷新端点，并立即更新缓存的频道详情和相关列表。

缺陷修复：
- 确保当底层平台的频道标题发生变化时，即使没有新消息到达，WebUI 中的聊天频道名称也能得到更新。

改进：
- 将构建聊天频道详情响应的通用逻辑提取为可复用的助手方法，供标准详情端点和新的刷新端点共同使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

新功能：
- 引入一个 POST 端点，通过从平台同步最新频道名称并返回更新后的元数据来刷新聊天频道详情。
- 添加前端 API 方法，并将 WebUI 中的“刷新聊天信息”操作连接到新的后端刷新端点，以更新缓存的频道详情和频道列表。

错误修复：
- 确保当平台端标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新，防止频道名称显示过时。

增强优化：
- 将构建聊天频道详情响应的共享逻辑提取到一个可复用的辅助工具中，使标准详情端点和新的刷新端点都能复用该逻辑。
- 添加前端回退逻辑：当平台端刷新调用失败时，使查询失效并显示警告通知，在保留当前行为的同时让失败情况可见。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加一个后端端点和前端联动，用于主动从底层平台刷新聊天频道详情，这样即使没有新消息，WebUI 标题也能保持同步。

New Features:
- 引入 `POST /chat-channel/detail/{chat_key}/refresh` 端点，从平台同步频道名称并返回更新后的聊天频道元数据。
- 将 WebUI 的“刷新聊天信息”操作接入新刷新端点，并更新缓存的频道详情和列表条目。

Bug Fixes:
- 确保当上游平台的标题发生变化时，即使没有收到新消息，WebUI 中的聊天频道名称也会被更新。

Enhancements:
- 抽取构建聊天频道详情响应的通用逻辑到一个可复用的 helper 中，使标准详情和刷新端点都能使用它。
- 在前端添加回退处理：当平台侧刷新失败时显示警告通知，同时仍然使相关查询失效以保持数据一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a backend endpoint and frontend wiring to actively refresh chat channel details from the underlying platform so WebUI titles stay in sync even without new messages.

New Features:
- Introduce a POST /chat-channel/detail/{chat_key}/refresh endpoint that syncs the channel name from the platform and returns updated chat channel metadata.
- Wire the WebUI "refresh chat info" action to call the new refresh endpoint and update cached channel detail and list entries.

Bug Fixes:
- Ensure chat channel names in the WebUI are updated when the upstream platform title changes, even if no new messages are received.

Enhancements:
- Extract shared logic for building chat channel detail responses into a reusable helper used by both the standard detail and refresh endpoints.
- Add frontend fallback handling with a warning notification when platform-side refresh fails, while still invalidating queries to keep data consistent.

</details>

</details>

</details>

</details>

</details>

</details>

</details>