### PR TITLE
docs: 修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,4 +272,4 @@ NekroAgent 采用 [自定义的开源协议](./LICENSE)（基于 Apache License 
 
 ## ⭐ Star 历史
 
-![Star History Chart](https://api.star-history.com/svg?repos=KroMiose/nekro-agent&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=KroMiose/nekro-agent&type=Date)

--- a/README_en.md
+++ b/README_en.md
@@ -262,4 +262,4 @@ Thanks to the following developers for their contributions to this project.
 
 ## ⭐ Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=KroMiose/nekro-agent&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=KroMiose/nekro-agent&type=Date)


### PR DESCRIPTION
README 中的 Star 历史图表因 GitHub stargazer API 访问限制已无法正常显示，属于明显的功能缺失。本次提交将图表地址切换到可正常工作的服务，恢复 Star 历史展示，请尽快合并以修复该问题。

## Summary by Sourcery

文档：
- 调整中文和英文 README 中的 star 历史图表图片 URL，使其指向可正常使用的图表服务提供方。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Adjust star history chart image URLs in both Chinese and English READMEs to point to a functioning chart provider.

</details>