### PR TITLE
fix(kb): zip 上传显式指定 multipart Content-Type

### DIFF
--- a/frontend/src/pages/workspace/components/KBGraphDialog.tsx
+++ b/frontend/src/pages/workspace/components/KBGraphDialog.tsx
@@ -88,6 +88,9 @@ const CATEGORY_LEVEL_X = 210
 const ENTRY_SPACING = 34
 const ROOT_GAP = 28
 
+/** 图谱自动折叠阈值：文档+资产总数超过该值时，默认折叠所有分类，仅显示根节点 */
+const AUTO_COLLAPSE_GRAPH_SIZE = 2000
+
 // ─── utils ────────────────────────────────────────────────────────────────────
 
 function categoryHue(name: string): number {
@@ -834,7 +837,23 @@ export default function KBGraphDialog({
   const [size, setSize] = useState({ w: 600, h: 400 })
   const [transform, setTransform] = useState({ x: 0, y: 0, scale: 1 })
   const [hoveredId, setHoveredId] = useState<string | null>(null)
-  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(() => new Set())
+  // 条目总数超过阈值时默认折叠所有分类（仅显示根节点），避免一次性渲染海量节点卡死；
+  // 用户点击任意分类可展开，展开状态由 collapsedCategories 正常管理
+  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(() => {
+    const totalCount = documents.length + boundGlobalAssets.length
+    if (totalCount <= AUTO_COLLAPSE_GRAPH_SIZE) return new Set<string>()
+    const collapsed = new Set<string>()
+    const collectCategory = (category: string) => {
+      let path = ''
+      for (const segment of splitCategoryPath(category)) {
+        path = `${path}${segment}/`
+        collapsed.add(path)
+      }
+    }
+    documents.forEach(doc => collectCategory(doc.category ?? ''))
+    boundGlobalAssets.forEach(asset => collectCategory(asset.category ?? ''))
+    return collapsed
+  })
   const [showAllReferences, setShowAllReferences] = useState(false)
 
   useEffect(() => {

--- a/frontend/src/pages/workspace/tabs/KnowledgeTab.tsx
+++ b/frontend/src/pages/workspace/tabs/KnowledgeTab.tsx
@@ -227,6 +227,12 @@ function kbProgressLabel(phase: string, t: (key: string, options?: Record<string
   return t(`knowledge.progress.phase.${phase}`, { defaultValue: phase })
 }
 
+/**
+ * 图谱引用批量拉取上限：文档+资产总数超过该值时，图谱默认折叠只显示根节点，
+ * 此时跳过对每个条目发起引用请求（否则大知识库会触发成千上万个并发请求导致卡死）。
+ */
+const GRAPH_REFERENCE_FETCH_LIMIT = 2000
+
 
 export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail }) {
   const theme = useTheme()
@@ -262,11 +268,13 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   const [reuseOpen, setReuseOpen] = useState(false)
   const [listView, setListView] = useState<'grouped' | 'graph'>('graph')
   const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
+  const [userToggledCategories, setUserToggledCategories] = useState<Set<string>>(new Set())
   const [selectedEntryKeys, setSelectedEntryKeys] = useState<Set<string>>(new Set())
   const [addMenuAnchorEl, setAddMenuAnchorEl] = useState<HTMLElement | null>(null)
   const [reuseSearch, setReuseSearch] = useState('')
   const [reuseAssetIds, setReuseAssetIds] = useState<number[]>([])
   const [reuseCollapsedCategories, setReuseCollapsedCategories] = useState<Set<string>>(new Set())
+  const [userToggledReuseCategories, setUserToggledReuseCategories] = useState<Set<string>>(new Set())
 
   const [editMetaOpen, setEditMetaOpen] = useState(false)
   const [editMetaForm, setEditMetaForm] = useState({ title: '', category: '', tagsInput: '', summary: '' })
@@ -1137,6 +1145,7 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   }
 
   const toggleCategoryCollapse = useCallback((category: string) => {
+    setUserToggledCategories(prev => new Set(prev).add(category))
     setCollapsedCategories(prev => {
       const next = new Set(prev)
       if (next.has(category)) next.delete(category)
@@ -1175,6 +1184,7 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   }
 
   const toggleReuseCategoryCollapse = useCallback((categoryKey: string) => {
+    setUserToggledReuseCategories(prev => new Set(prev).add(categoryKey))
     setReuseCollapsedCategories(prev => {
       const next = new Set(prev)
       if (next.has(categoryKey)) next.delete(categoryKey)
@@ -1222,9 +1232,11 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
     return next
   }, [workspaceProgresses])
 
-  // Batch-fetch all document references when the graph view is active
+  // Batch-fetch all document references when the graph view is active.
+  // 条目总数超过阈值时图谱默认折叠只显示根节点，跳过批量拉取，避免请求风暴
+  const graphReferencesDisabled = defaultListEntries.length > GRAPH_REFERENCE_FETCH_LIMIT
   const docRefResults = useQueries({
-    queries: listView === 'graph' && !hasSearchResult
+    queries: listView === 'graph' && !hasSearchResult && !graphReferencesDisabled
       ? documents.map(doc => ({
           queryKey: ['kb-document-references', workspace.id, doc.id],
           queryFn: () => knowledgeBaseApi.getReferences(workspace.id, doc.id),
@@ -1234,7 +1246,7 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   })
 
   const assetRefResults = useQueries({
-    queries: listView === 'graph' && !hasSearchResult
+    queries: listView === 'graph' && !hasSearchResult && !graphReferencesDisabled
       ? boundGlobalAssets.map(asset => ({
           queryKey: ['kb-asset-references', asset.id] as const,
           queryFn: () => kbLibraryApi.getReferences(asset.id),
@@ -1465,7 +1477,8 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   }
 
   const renderCategoryNode = (node: KBCategoryTreeNode<(typeof defaultListEntries)[number]>) => {
-    const isCollapsed = collapsedCategories.has(node.key)
+    // 用户手动操作过的分类尊重用户状态；未操作过的默认收起，避免大列表一次性渲染卡顿
+    const isCollapsed = userToggledCategories.has(node.key) ? collapsedCategories.has(node.key) : true
     const categoryEntryKeys = node.allItems.map(entry => getKnowledgeEntrySelectionKey(entry.kind, entry.id))
     const selectedCount = categoryEntryKeys.filter(key => selectedEntryKeys.has(key)).length
     const categoryChecked = selectedCount > 0 && selectedCount === categoryEntryKeys.length
@@ -1605,7 +1618,8 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   }
 
   const renderReuseCategoryNode = (node: KBCategoryTreeNode<KBAssetListItem>) => {
-    const isCollapsed = reuseCollapsedCategories.has(node.key)
+    // 用户手动操作过的分类尊重用户状态；未操作过的默认收起，避免大列表一次性渲染卡顿
+    const isCollapsed = userToggledReuseCategories.has(node.key) ? reuseCollapsedCategories.has(node.key) : true
     const categoryAssetIds = node.allItems.map(asset => asset.id)
     const selectedCount = categoryAssetIds.filter(id => reuseAssetIdSet.has(id)).length
     const categoryChecked = selectedCount > 0 && selectedCount === categoryAssetIds.length

--- a/frontend/src/services/api/workspace.ts
+++ b/frontend/src/services/api/workspace.ts
@@ -895,7 +895,11 @@ export const workspaceApi = {
 const postZipImport = async (url: string, file: File): Promise<KBZipImportResponse> => {
   const formData = new FormData()
   formData.append('file', file)
-  const response = await axios.post<KBZipImportResponse>(url, formData)
+  const response = await axios.post<KBZipImportResponse>(url, formData, {
+    // 必须显式指定 multipart：axios 实例默认 Content-Type 为 application/json，
+    // axios 1.15 会因此把 FormData 序列化成 JSON（File 被转成空对象 {}）导致后端 422
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
   return response.data
 }
 


### PR DESCRIPTION
## 问题

zip 批量导入上传失败，后端返回 `422 请求参数无效: body.file: Field required`。

**根因**：axios 实例默认 `Content-Type: application/json`（frontend/src/services/api/axios.ts），而 axios 1.15 的 transformRequest 在检测到 JSON Content-Type 时会把 FormData 序列化成 JSON，formDataToJSON 将 File 对象转为空对象 {}，实际请求体变成 {"file":{}}，后端 multipart 解析不到 file 字段。

postZipImport 是全项目唯一遗漏 multipart header 的 FormData 上传（uploadFile / assets / skills / chat-channel 等均已显式指定）。

## 修复

为 postZipImport 显式指定 `Content-Type: multipart/form-data`，与项目既有上传用法对齐。

## 验证

- tsc --noEmit 通过
- eslint 0 警告

## Summary by Sourcery

Bug Fixes:
- 通过在 FormData 请求中显式将请求的 Content-Type 设置为 `multipart/form-data`，修复了 ZIP 导入上传因返回 422 错误而失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix ZIP import uploads failing with 422 errors by explicitly setting the request Content-Type to multipart/form-data for the FormData request.

</details>
- 修复 ZIP 导入上传问题：在发送 `FormData` 时，通过显式将请求的 `Content-Type` 设置为 `multipart/form-data` 来解决。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 通过在 FormData 请求中显式将请求的 Content-Type 设置为 `multipart/form-data`，修复了 ZIP 导入上传因返回 422 错误而失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix ZIP import uploads failing with 422 errors by explicitly setting the request Content-Type to multipart/form-data for the FormData request.

</details>

</details>