### PR TITLE
feat(kb): 大知识库自动折叠与图谱请求风暴修复

### DIFF
--- a/frontend/src/pages/workspace/components/KBGraphDialog.tsx
+++ b/frontend/src/pages/workspace/components/KBGraphDialog.tsx
@@ -88,6 +88,9 @@ const CATEGORY_LEVEL_X = 210
 const ENTRY_SPACING = 34
 const ROOT_GAP = 28
 
+/** 图谱自动折叠阈值：文档+资产总数超过该值时，默认折叠所有分类，仅显示根节点 */
+const AUTO_COLLAPSE_GRAPH_SIZE = 2000
+
 // ─── utils ────────────────────────────────────────────────────────────────────
 
 function categoryHue(name: string): number {
@@ -834,7 +837,23 @@ export default function KBGraphDialog({
   const [size, setSize] = useState({ w: 600, h: 400 })
   const [transform, setTransform] = useState({ x: 0, y: 0, scale: 1 })
   const [hoveredId, setHoveredId] = useState<string | null>(null)
-  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(() => new Set())
+  // 条目总数超过阈值时默认折叠所有分类（仅显示根节点），避免一次性渲染海量节点卡死；
+  // 用户点击任意分类可展开，展开状态由 collapsedCategories 正常管理
+  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(() => {
+    const totalCount = documents.length + boundGlobalAssets.length
+    if (totalCount <= AUTO_COLLAPSE_GRAPH_SIZE) return new Set<string>()
+    const collapsed = new Set<string>()
+    const collectCategory = (category: string) => {
+      let path = ''
+      for (const segment of splitCategoryPath(category)) {
+        path = `${path}${segment}/`
+        collapsed.add(path)
+      }
+    }
+    documents.forEach(doc => collectCategory(doc.category ?? ''))
+    boundGlobalAssets.forEach(asset => collectCategory(asset.category ?? ''))
+    return collapsed
+  })
   const [showAllReferences, setShowAllReferences] = useState(false)
 
   useEffect(() => {

--- a/frontend/src/pages/workspace/tabs/KnowledgeTab.tsx
+++ b/frontend/src/pages/workspace/tabs/KnowledgeTab.tsx
@@ -227,6 +227,12 @@ function kbProgressLabel(phase: string, t: (key: string, options?: Record<string
   return t(`knowledge.progress.phase.${phase}`, { defaultValue: phase })
 }
 
+/**
+ * 图谱引用批量拉取上限：文档+资产总数超过该值时，图谱默认折叠只显示根节点，
+ * 此时跳过对每个条目发起引用请求（否则大知识库会触发成千上万个并发请求导致卡死）。
+ */
+const GRAPH_REFERENCE_FETCH_LIMIT = 2000
+
 
 export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail }) {
   const theme = useTheme()
@@ -262,11 +268,13 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   const [reuseOpen, setReuseOpen] = useState(false)
   const [listView, setListView] = useState<'grouped' | 'graph'>('graph')
   const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set())
+  const [userToggledCategories, setUserToggledCategories] = useState<Set<string>>(new Set())
   const [selectedEntryKeys, setSelectedEntryKeys] = useState<Set<string>>(new Set())
   const [addMenuAnchorEl, setAddMenuAnchorEl] = useState<HTMLElement | null>(null)
   const [reuseSearch, setReuseSearch] = useState('')
   const [reuseAssetIds, setReuseAssetIds] = useState<number[]>([])
   const [reuseCollapsedCategories, setReuseCollapsedCategories] = useState<Set<string>>(new Set())
+  const [userToggledReuseCategories, setUserToggledReuseCategories] = useState<Set<string>>(new Set())
 
   const [editMetaOpen, setEditMetaOpen] = useState(false)
   const [editMetaForm, setEditMetaForm] = useState({ title: '', category: '', tagsInput: '', summary: '' })
@@ -1137,6 +1145,7 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   }
 
   const toggleCategoryCollapse = useCallback((category: string) => {
+    setUserToggledCategories(prev => new Set(prev).add(category))
     setCollapsedCategories(prev => {
       const next = new Set(prev)
       if (next.has(category)) next.delete(category)
@@ -1175,6 +1184,7 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   }
 
   const toggleReuseCategoryCollapse = useCallback((categoryKey: string) => {
+    setUserToggledReuseCategories(prev => new Set(prev).add(categoryKey))
     setReuseCollapsedCategories(prev => {
       const next = new Set(prev)
       if (next.has(categoryKey)) next.delete(categoryKey)
@@ -1222,9 +1232,11 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
     return next
   }, [workspaceProgresses])
 
-  // Batch-fetch all document references when the graph view is active
+  // Batch-fetch all document references when the graph view is active.
+  // 条目总数超过阈值时图谱默认折叠只显示根节点，跳过批量拉取，避免请求风暴
+  const graphReferencesDisabled = defaultListEntries.length > GRAPH_REFERENCE_FETCH_LIMIT
   const docRefResults = useQueries({
-    queries: listView === 'graph' && !hasSearchResult
+    queries: listView === 'graph' && !hasSearchResult && !graphReferencesDisabled
       ? documents.map(doc => ({
           queryKey: ['kb-document-references', workspace.id, doc.id],
           queryFn: () => knowledgeBaseApi.getReferences(workspace.id, doc.id),
@@ -1234,7 +1246,7 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   })
 
   const assetRefResults = useQueries({
-    queries: listView === 'graph' && !hasSearchResult
+    queries: listView === 'graph' && !hasSearchResult && !graphReferencesDisabled
       ? boundGlobalAssets.map(asset => ({
           queryKey: ['kb-asset-references', asset.id] as const,
           queryFn: () => kbLibraryApi.getReferences(asset.id),
@@ -1465,7 +1477,8 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   }
 
   const renderCategoryNode = (node: KBCategoryTreeNode<(typeof defaultListEntries)[number]>) => {
-    const isCollapsed = collapsedCategories.has(node.key)
+    // 用户手动操作过的分类尊重用户状态；未操作过的默认收起，避免大列表一次性渲染卡顿
+    const isCollapsed = userToggledCategories.has(node.key) ? collapsedCategories.has(node.key) : true
     const categoryEntryKeys = node.allItems.map(entry => getKnowledgeEntrySelectionKey(entry.kind, entry.id))
     const selectedCount = categoryEntryKeys.filter(key => selectedEntryKeys.has(key)).length
     const categoryChecked = selectedCount > 0 && selectedCount === categoryEntryKeys.length
@@ -1605,7 +1618,8 @@ export default function KnowledgeTab({ workspace }: { workspace: WorkspaceDetail
   }
 
   const renderReuseCategoryNode = (node: KBCategoryTreeNode<KBAssetListItem>) => {
-    const isCollapsed = reuseCollapsedCategories.has(node.key)
+    // 用户手动操作过的分类尊重用户状态；未操作过的默认收起，避免大列表一次性渲染卡顿
+    const isCollapsed = userToggledReuseCategories.has(node.key) ? reuseCollapsedCategories.has(node.key) : true
     const categoryAssetIds = node.allItems.map(asset => asset.id)
     const selectedCount = categoryAssetIds.filter(id => reuseAssetIdSet.has(id)).length
     const categoryChecked = selectedCount > 0 && selectedCount === categoryAssetIds.length


### PR DESCRIPTION
## 问题

大知识库（数千至数万条文档）下前端卡死：

1. **知识图谱**：条目总数大时一次性渲染全部文档节点，且对**每个条目**发起引用请求（13,000+ 条 → 13,000+ 并发请求），前后端全部卡死
2. **列表视图**：未操作过的分类全部展开，数千行一次性渲染

## 修复

- **知识图谱**：文档+资产总数超过 2000 时，初始默认折叠所有分类，仅显示中心节点与根分类节点；点击分类圆圈逐级展开（KBGraphDialog）
- **图谱引用请求**：总数超过 2000 时跳过对每个条目发起 getReferences 批量请求（原逻辑会产生请求风暴）
- **列表视图**：未手动操作过的分类默认收起，操作过的尊重用户状态（KnowledgeTab）

## 验证

- tsc --noEmit 通过
- eslint 0 警告

## 由 Sourcery 提供的摘要

通过自动折叠图形和列表视图并限制引用获取次数，缓解超大型知识库的性能问题。

新功能：
- 当文档和资产的总数量超过阈值时，自动折叠知识图谱中的所有类别，初始仅显示根节点。
- 当条目总数超过阈值时，在图形视图中禁用批量引用获取，以避免过多的并发请求。
- 在列表视图中默认将各类别设置为折叠状态，除非用户已显式切换过；同时保留用户针对展开/折叠状态的个性化设置。

错误修复：
- 防止在图形和列表视图中同时渲染和获取数千条知识库条目引用时导致的界面卡死问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Mitigate performance issues for very large knowledge bases by auto-collapsing graph and list views and limiting reference fetches.

New Features:
- Automatically collapse all categories in the knowledge graph when the combined document and asset count exceeds a threshold, initially showing only the root node.
- Disable batch reference fetching for the graph view when the total entry count exceeds a threshold to avoid excessive concurrent requests.
- Default list view categories to a collapsed state unless the user has explicitly toggled them, preserving user-specific expand/collapse state.

Bug Fixes:
- Prevent UI freezes caused by rendering and fetching references for thousands of knowledge base entries at once in both graph and list views.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

通过自动折叠图形和列表视图并限制引用获取次数，缓解超大型知识库的性能问题。

新功能：
- 当文档和资产的总数量超过阈值时，自动折叠知识图谱中的所有类别，初始仅显示根节点。
- 当条目总数超过阈值时，在图形视图中禁用批量引用获取，以避免过多的并发请求。
- 在列表视图中默认将各类别设置为折叠状态，除非用户已显式切换过；同时保留用户针对展开/折叠状态的个性化设置。

错误修复：
- 防止在图形和列表视图中同时渲染和获取数千条知识库条目引用时导致的界面卡死问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Mitigate performance issues for very large knowledge bases by auto-collapsing graph and list views and limiting reference fetches.

New Features:
- Automatically collapse all categories in the knowledge graph when the combined document and asset count exceeds a threshold, initially showing only the root node.
- Disable batch reference fetching for the graph view when the total entry count exceeds a threshold to avoid excessive concurrent requests.
- Default list view categories to a collapsed state unless the user has explicitly toggled them, preserving user-specific expand/collapse state.

Bug Fixes:
- Prevent UI freezes caused by rendering and fetching references for thousands of knowledge base entries at once in both graph and list views.

</details>

</details>