### PR TITLE
feat(config): 新增 rerank 模型类型

### DIFF
--- a/frontend/src/components/common/ConfigTable.tsx
+++ b/frontend/src/components/common/ConfigTable.tsx
@@ -1327,7 +1327,7 @@ export default function ConfigTable({
               disabled={disabled}
             >
               {t('configTable.ModelGroup', {
-                label: t(`configTable.modelTypes.${typeOption.value as 'chat' | 'embedding' | 'draw'}`, {
+                label: t(`configTable.modelTypes.${typeOption.value as 'chat' | 'embedding' | 'draw' | 'rerank'}`, {
                   defaultValue: typeOption.label,
                 }),
               })}

--- a/frontend/src/locales/en-US/common.json
+++ b/frontend/src/locales/en-US/common.json
@@ -197,7 +197,8 @@
     "modelTypes": {
       "chat": "Chat",
       "embedding": "Embedding",
-      "draw": "Drawing"
+      "draw": "Drawing",
+      "rerank": "Rerank"
     },
     "newItemPlaceholder": "Enter key name and press Enter",
     "headerEnableOverride": "Enable Override",

--- a/frontend/src/locales/en-US/settings.json
+++ b/frontend/src/locales/en-US/settings.json
@@ -60,7 +60,8 @@
       "topP": "Top P",
       "presencePenalty": "Presence Penalty",
       "frequencyPenalty": "Frequency Penalty",
-      "extraBody": "Extra Body (JSON)"
+      "extraBody": "Extra Body (JSON)",
+      "rerankEndpoint": "Rerank Endpoint"
     },
     "placeholders": {
       "apiAddress": "https://api.nekro.ai/v1",
@@ -82,7 +83,8 @@
       "topP": "Controls diversity of output (0-1)",
       "presencePenalty": "Penalty for new tokens based on their presence in the text so far (-2 to 2)",
       "frequencyPenalty": "Penalty for new tokens based on their frequency in the text so far (-2 to 2)",
-      "extraBody": "Additional request parameters (JSON format)"
+      "extraBody": "Additional request parameters (JSON format)",
+      "rerankEndpoint": "Rerank endpoint path relative to the API base URL. Default /rerank for SiliconFlow / Jina; use /reranks for Alibaba Cloud Bailian compatible-api"
     },
     "actions": {
       "fetchModels": "Fetch Model List",

--- a/frontend/src/locales/en-US/settings.json
+++ b/frontend/src/locales/en-US/settings.json
@@ -38,12 +38,14 @@
     "types": {
       "chat": "Chat",
       "embedding": "Embedding",
-      "draw": "Drawing"
+      "draw": "Drawing",
+      "rerank": "Rerank"
     },
     "typeDescriptions": {
       "chat": "Model for conversation",
       "embedding": "Model for converting text to vectors",
-      "draw": "Model for image generation"
+      "draw": "Model for image generation",
+      "rerank": "Model for relevance reranking of retrieval results"
     },
     "form": {
       "groupName": "Group Name",

--- a/frontend/src/locales/zh-CN/common.json
+++ b/frontend/src/locales/zh-CN/common.json
@@ -197,7 +197,8 @@
     "modelTypes": {
       "chat": "聊天",
       "embedding": "嵌入",
-      "draw": "绘图"
+      "draw": "绘图",
+      "rerank": "重排"
     },
     "addNewItem": "添加新{{name}}",
     "newItemPlaceholder": "输入新键名，按回车添加",

--- a/frontend/src/locales/zh-CN/settings.json
+++ b/frontend/src/locales/zh-CN/settings.json
@@ -38,12 +38,14 @@
     "types": {
       "chat": "聊天",
       "embedding": "嵌入",
-      "draw": "绘图"
+      "draw": "绘图",
+      "rerank": "重排"
     },
     "typeDescriptions": {
       "chat": "用于对话的模型",
       "embedding": "用于将文本转换为向量的模型",
-      "draw": "用于生成图像的模型"
+      "draw": "用于生成图像的模型",
+      "rerank": "用于对检索结果进行相关性重排的模型"
     },
     "form": {
       "groupName": "组名",

--- a/frontend/src/locales/zh-CN/settings.json
+++ b/frontend/src/locales/zh-CN/settings.json
@@ -60,7 +60,8 @@
       "topP": "Top P (多样性)",
       "presencePenalty": "Presence Penalty (新话题)",
       "frequencyPenalty": "Frequency Penalty (重复度)",
-      "extraBody": "Extra Body (JSON参数)"
+      "extraBody": "Extra Body (JSON参数)",
+      "rerankEndpoint": "重排接口路径"
     },
     "placeholders": {
       "apiAddress": "https://api.nekro.ai/v1",
@@ -82,7 +83,8 @@
       "topP": "控制输出的多样性 (0-1)",
       "presencePenalty": "基于生成文本中已出现的内容对新内容的惩罚 (-2 到 2)",
       "frequencyPenalty": "基于生成文本中出现的内容频率对新内容的惩罚 (-2 到 2)",
-      "extraBody": "额外的请求参数 (JSON 格式)"
+      "extraBody": "额外的请求参数 (JSON 格式)",
+      "rerankEndpoint": "重排接口路径（相对 API 地址）。默认 /rerank 兼容 SiliconFlow / Jina；阿里云百炼 compatible-api 填 /reranks"
     },
     "actions": {
       "fetchModels": "拉取模型列表",

--- a/frontend/src/pages/settings/model_group.tsx
+++ b/frontend/src/pages/settings/model_group.tsx
@@ -92,6 +92,7 @@ function EditDialog({
     PRESENCE_PENALTY: null,
     FREQUENCY_PENALTY: null,
     EXTRA_BODY: null,
+    RERANK_ENDPOINT: '/rerank',
     ENABLE_VISION: true,
     ENABLE_COT: false,
   })
@@ -207,6 +208,7 @@ function EditDialog({
       setConfig({
         ...initialConfig,
         MODEL_TYPE: initialConfig.MODEL_TYPE || 'chat',
+        RERANK_ENDPOINT: initialConfig.RERANK_ENDPOINT || '/rerank',
         ENABLE_VISION:
           initialConfig.ENABLE_VISION !== undefined ? initialConfig.ENABLE_VISION : true,
         ENABLE_COT: initialConfig.ENABLE_COT !== undefined ? initialConfig.ENABLE_COT : false,
@@ -224,6 +226,7 @@ function EditDialog({
         PRESENCE_PENALTY: null,
         FREQUENCY_PENALTY: null,
         EXTRA_BODY: null,
+        RERANK_ENDPOINT: '/rerank',
         ENABLE_VISION: true,
         ENABLE_COT: false,
       })
@@ -304,6 +307,7 @@ function EditDialog({
       API_KEY: (config.API_KEY || '').trim(),
       MODEL_TYPE: (config.MODEL_TYPE || 'chat').trim(),
       EXTRA_BODY: config.EXTRA_BODY ? config.EXTRA_BODY.trim() || null : null,
+      RERANK_ENDPOINT: (config.RERANK_ENDPOINT || '/rerank').trim(),
     }
 
     // 验证组名
@@ -695,6 +699,14 @@ function EditDialog({
                 rows={3}
                 helperText={t('modelGroup.helpers.extraBody') || '额外的请求参数 (JSON 格式)'}
               />
+              <TextField
+                label={t('modelGroup.form.rerankEndpoint')}
+                value={config.RERANK_ENDPOINT ?? '/rerank'}
+                onChange={e => setConfig({ ...config, RERANK_ENDPOINT: e.target.value })}
+                fullWidth
+                size={isSmall ? 'small' : 'medium'}
+                helperText={t('modelGroup.helpers.rerankEndpoint')}
+              />
             </Stack>
           )}
 
@@ -936,6 +948,7 @@ export default function ModelGroupsPage() {
       API_KEY: (config.API_KEY || '').trim(),
       MODEL_TYPE: (config.MODEL_TYPE || 'chat').trim(),
       EXTRA_BODY: config.EXTRA_BODY ? config.EXTRA_BODY.trim() || null : null,
+      RERANK_ENDPOINT: (config.RERANK_ENDPOINT || '/rerank').trim(),
     }
     // 检查新模型组名称是否已存在
     if (modelGroups[trimmedName] && !editingGroup.isCopy && editingGroup.name === trimmedName) {

--- a/frontend/src/pages/settings/model_group.tsx
+++ b/frontend/src/pages/settings/model_group.tsx
@@ -44,6 +44,7 @@ import {
   Chat as ChatIcon,
   Code as CodeIcon,
   Brush as BrushIcon,
+  FilterAlt as FilterAltIcon,
   EmojiObjects as EmojiObjectsIcon,
   ContentCopy as ContentCopyIcon,
   NetworkCheck as NetworkCheckIcon,
@@ -194,6 +195,7 @@ function EditDialog({
       Chat: <ChatIcon fontSize="small" />,
       Code: <CodeIcon fontSize="small" />,
       Brush: <BrushIcon fontSize="small" />,
+      FilterAlt: <FilterAltIcon fontSize="small" />,
       EmojiObjects: <EmojiObjectsIcon fontSize="small" />,
     }
 
@@ -864,6 +866,7 @@ export default function ModelGroupsPage() {
       Chat: <ChatIcon fontSize="small" />,
       Code: <CodeIcon fontSize="small" />,
       Brush: <BrushIcon fontSize="small" />,
+      FilterAlt: <FilterAltIcon fontSize="small" />,
       EmojiObjects: <EmojiObjectsIcon fontSize="small" />,
     }
 

--- a/frontend/src/pages/settings/model_group.tsx
+++ b/frontend/src/pages/settings/model_group.tsx
@@ -527,7 +527,7 @@ function EditDialog({
                   {getModelTypeIcon(type.value)}
                   <Box sx={{ ml: 1 }}>
                     <Typography variant="body2" sx={{ fontSize: isSmall ? '0.8rem' : 'inherit' }}>
-                      {t(`modelGroup.types.${type.value as 'chat' | 'embedding' | 'draw'}`, {
+                      {t(`modelGroup.types.${type.value as 'chat' | 'embedding' | 'draw' | 'rerank'}`, {
                         defaultValue: type.label,
                       })}
                     </Typography>
@@ -538,7 +538,7 @@ function EditDialog({
                         sx={{ fontSize: isSmall ? '0.7rem' : 'inherit' }}
                       >
                         {t(
-                          `modelGroup.typeDescriptions.${type.value as 'chat' | 'embedding' | 'draw'}`,
+                          `modelGroup.typeDescriptions.${type.value as 'chat' | 'embedding' | 'draw' | 'rerank'}`,
                           {
                             defaultValue: type.description,
                           }
@@ -823,7 +823,7 @@ export default function ModelGroupsPage() {
   // 获取模型类型的显示名称
   const getModelTypeLabel = (type: string | undefined) => {
     if (!type) return t('modelGroup.types.chat', { ns: 'settings', defaultValue: '聊天' })
-    return t(`modelGroup.types.${type as 'chat' | 'embedding' | 'draw'}`, {
+    return t(`modelGroup.types.${type as 'chat' | 'embedding' | 'draw' | 'rerank'}`, {
       ns: 'settings',
       defaultValue: modelTypes.find(mt => mt.value === type)?.label || type,
     })

--- a/frontend/src/services/api/config.ts
+++ b/frontend/src/services/api/config.ts
@@ -33,6 +33,7 @@ export interface ModelGroupConfig {
   PRESENCE_PENALTY?: number | null
   FREQUENCY_PENALTY?: number | null
   EXTRA_BODY?: string | null
+  RERANK_ENDPOINT?: string
   ENABLE_VISION?: boolean
   ENABLE_COT?: boolean
 }

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -496,17 +496,31 @@ class CoreConfig(ConfigBase):
     KB_RERANK_MODEL_GROUP: str = Field(
         default="",
         title="知识库重排模型组",
-        description="用于知识库检索结果重排的 rerank 模型组（OpenAI 兼容 /v1/rerank 接口）。应选择 MODEL_TYPE 为 rerank 的模型组；留空则跳过重排",
+        description="用于知识库检索结果重排的 rerank 模型组（OpenAI 兼容接口）。应选择 MODEL_TYPE 为 rerank 的模型组；留空则跳过重排",
         json_schema_extra=ExtraField(
             i18n_category=i18n_text(zh_CN="知识库", en_US="Knowledge Base"),
             ref_model_groups=True,
             model_type="rerank",
             i18n_title=i18n_text(zh_CN="知识库重排模型组", en_US="Knowledge Base Rerank Model Group"),
             i18n_description=i18n_text(
-                zh_CN="用于知识库检索结果重排的 rerank 模型组（OpenAI 兼容 /v1/rerank 接口）。应选择 MODEL_TYPE 为 rerank 的模型组；留空则跳过重排",
-                en_US="Rerank model group used for re-ranking knowledge base retrieval results (OpenAI-compatible /v1/rerank endpoint). Should use a model group with MODEL_TYPE set to rerank; leave empty to skip reranking",
+                zh_CN="用于知识库检索结果重排的 rerank 模型组（OpenAI 兼容接口）。应选择 MODEL_TYPE 为 rerank 的模型组；留空则跳过重排",
+                en_US="Rerank model group used for re-ranking knowledge base retrieval results (OpenAI-compatible API). Should use a model group with MODEL_TYPE set to rerank; leave empty to skip reranking",
             ),
             placeholder="例: bge-reranker-v2-m3",
+        ).model_dump(),
+    )
+    KB_RERANK_ENDPOINT: str = Field(
+        default="/rerank",
+        title="知识库重排接口路径",
+        description="rerank 接口路径（相对模型组 BASE_URL）。默认 /rerank 兼容 SiliconFlow / Jina；阿里云百炼 compatible-api 请填 /reranks",
+        json_schema_extra=ExtraField(
+            i18n_category=i18n_text(zh_CN="知识库", en_US="Knowledge Base"),
+            i18n_title=i18n_text(zh_CN="知识库重排接口路径", en_US="Knowledge Base Rerank Endpoint"),
+            i18n_description=i18n_text(
+                zh_CN="rerank 接口路径（相对模型组 BASE_URL）。默认 /rerank 兼容 SiliconFlow / Jina；阿里云百炼 compatible-api 请填 /reranks",
+                en_US="Rerank endpoint path relative to the model group BASE_URL. Defaults to /rerank for SiliconFlow / Jina; use /reranks for Alibaba Cloud Bailian compatible-api",
+            ),
+            placeholder="例: /rerank 或 /reranks",
         ).model_dump(),
     )
     KB_ZIP_MAX_UPLOAD_SIZE_MB: int = Field(

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -23,10 +23,10 @@ class ModelConfigGroup(ConfigBase):
     CHAT_PROXY: str = Field(default="", title="聊天模型访问代理")
     BASE_URL: str = Field(default="", title="聊天模型 API 地址")
     API_KEY: str = Field(default="", title="聊天模型 API 密钥")
-    MODEL_TYPE: Literal["chat", "embedding", "draw"] = Field(
+    MODEL_TYPE: Literal["chat", "embedding", "draw", "rerank"] = Field(
         default="chat",
         title="模型类型",
-        description="模型的用途类型，可以是聊天(chat)、向量嵌入(embedding)或绘图(draw)",
+        description="模型的用途类型，可以是聊天(chat)、向量嵌入(embedding)、绘图(draw)或重排(rerank)",
     )
     ENABLE_VISION: bool = Field(
         default=False,

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -449,6 +449,19 @@ class CoreConfig(ConfigBase):
             ),
         ).model_dump(),
     )
+    MEMORY_RERANK_ENABLED: bool = Field(
+        default=False,
+        title="记忆检索重排开关",
+        description="开启后，记忆检索的有效权重排序结果会再经过重排模型二次打分排序。复用 KB_RERANK_MODEL_GROUP 模型组；重排失败时自动回退原排序",
+        json_schema_extra=ExtraField(
+            i18n_category=i18n_text(zh_CN="记忆系统", en_US="Memory System"),
+            i18n_title=i18n_text(zh_CN="记忆检索重排开关", en_US="Memory Retrieval Rerank Switch"),
+            i18n_description=i18n_text(
+                zh_CN="开启后，记忆检索的有效权重排序结果会再经过重排模型二次打分排序。复用 KB_RERANK_MODEL_GROUP 模型组；重排失败时自动回退原排序",
+                en_US="When enabled, memory retrieval results ranked by effective weight are re-scored by the rerank model. Reuses the KB_RERANK_MODEL_GROUP; falls back to original ranking on rerank failure",
+            ),
+        ).model_dump(),
+    )
     KB_EMBEDDING_MODEL_GROUP: str = Field(
         default="text-embedding",
         title="知识库 Embedding 模型组",
@@ -521,6 +534,19 @@ class CoreConfig(ConfigBase):
                 en_US="Rerank endpoint path relative to the model group BASE_URL. Defaults to /rerank for SiliconFlow / Jina; use /reranks for Alibaba Cloud Bailian compatible-api",
             ),
             placeholder="例: /rerank 或 /reranks",
+        ).model_dump(),
+    )
+    KB_RERANK_ENABLED: bool = Field(
+        default=False,
+        title="知识库检索重排开关",
+        description="开启后，知识库检索的融合结果会再经过重排模型二次打分排序。需同时配置 KB_RERANK_MODEL_GROUP；重排失败时自动回退原排序",
+        json_schema_extra=ExtraField(
+            i18n_category=i18n_text(zh_CN="知识库", en_US="Knowledge Base"),
+            i18n_title=i18n_text(zh_CN="知识库检索重排开关", en_US="Knowledge Base Rerank Switch"),
+            i18n_description=i18n_text(
+                zh_CN="开启后，知识库检索的融合结果会再经过重排模型二次打分排序。需同时配置 KB_RERANK_MODEL_GROUP；重排失败时自动回退原排序",
+                en_US="When enabled, fused knowledge base retrieval results are re-scored by the rerank model. Requires KB_RERANK_MODEL_GROUP; falls back to original ranking on rerank failure",
+            ),
         ).model_dump(),
     )
     KB_ZIP_MAX_UPLOAD_SIZE_MB: int = Field(

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -493,6 +493,22 @@ class CoreConfig(ConfigBase):
             placeholder="建议 1~8",
         ).model_dump(),
     )
+    KB_RERANK_MODEL_GROUP: str = Field(
+        default="",
+        title="知识库重排模型组",
+        description="用于知识库检索结果重排的 rerank 模型组（OpenAI 兼容 /v1/rerank 接口）。应选择 MODEL_TYPE 为 rerank 的模型组；留空则跳过重排",
+        json_schema_extra=ExtraField(
+            i18n_category=i18n_text(zh_CN="知识库", en_US="Knowledge Base"),
+            ref_model_groups=True,
+            model_type="rerank",
+            i18n_title=i18n_text(zh_CN="知识库重排模型组", en_US="Knowledge Base Rerank Model Group"),
+            i18n_description=i18n_text(
+                zh_CN="用于知识库检索结果重排的 rerank 模型组（OpenAI 兼容 /v1/rerank 接口）。应选择 MODEL_TYPE 为 rerank 的模型组；留空则跳过重排",
+                en_US="Rerank model group used for re-ranking knowledge base retrieval results (OpenAI-compatible /v1/rerank endpoint). Should use a model group with MODEL_TYPE set to rerank; leave empty to skip reranking",
+            ),
+            placeholder="例: bge-reranker-v2-m3",
+        ).model_dump(),
+    )
     KB_ZIP_MAX_UPLOAD_SIZE_MB: int = Field(
         default=100,
         title="知识库 Zip 单包大小上限 (MB)",

--- a/nekro_agent/core/config.py
+++ b/nekro_agent/core/config.py
@@ -47,6 +47,11 @@ class ModelConfigGroup(ConfigBase):
     PRESENCE_PENALTY: Optional[float] = Field(default=None, title="提示重复惩罚")
     FREQUENCY_PENALTY: Optional[float] = Field(default=None, title="补全重复惩罚")
     EXTRA_BODY: Optional[str] = Field(default=None, title="额外参数 (JSON)")
+    RERANK_ENDPOINT: str = Field(
+        default="/rerank",
+        title="重排接口路径",
+        description="重排接口路径（相对 BASE_URL）。默认 /rerank 兼容 SiliconFlow / Jina；阿里云百炼 compatible-api 请填 /reranks",
+    )
 
 
 class CoreConfig(ConfigBase):
@@ -520,20 +525,6 @@ class CoreConfig(ConfigBase):
                 en_US="Rerank model group used for re-ranking knowledge base retrieval results (OpenAI-compatible API). Should use a model group with MODEL_TYPE set to rerank; leave empty to skip reranking",
             ),
             placeholder="例: bge-reranker-v2-m3",
-        ).model_dump(),
-    )
-    KB_RERANK_ENDPOINT: str = Field(
-        default="/rerank",
-        title="知识库重排接口路径",
-        description="rerank 接口路径（相对模型组 BASE_URL）。默认 /rerank 兼容 SiliconFlow / Jina；阿里云百炼 compatible-api 请填 /reranks",
-        json_schema_extra=ExtraField(
-            i18n_category=i18n_text(zh_CN="知识库", en_US="Knowledge Base"),
-            i18n_title=i18n_text(zh_CN="知识库重排接口路径", en_US="Knowledge Base Rerank Endpoint"),
-            i18n_description=i18n_text(
-                zh_CN="rerank 接口路径（相对模型组 BASE_URL）。默认 /rerank 兼容 SiliconFlow / Jina；阿里云百炼 compatible-api 请填 /reranks",
-                en_US="Rerank endpoint path relative to the model group BASE_URL. Defaults to /rerank for SiliconFlow / Jina; use /reranks for Alibaba Cloud Bailian compatible-api",
-            ),
-            placeholder="例: /rerank 或 /reranks",
         ).model_dump(),
     )
     KB_RERANK_ENABLED: bool = Field(

--- a/nekro_agent/core/core_utils.py
+++ b/nekro_agent/core/core_utils.py
@@ -109,7 +109,7 @@ class ExtraField(BaseModel):
         title="引用启用发信的邮箱账户",
         description="设置为True时，表示该字段需要从 Email 适配器配置中已启用发信的邮箱账户列表中选择",
     )
-    model_type: Literal["chat", "embedding", "draw"] = Field(
+    model_type: Literal["chat", "embedding", "draw", "rerank"] = Field(
         default="chat",
         title="模型类型规范",
         description="指定引用的模型类型标识符，仅在ref_model_groups为True时生效",

--- a/nekro_agent/routers/config.py
+++ b/nekro_agent/routers/config.py
@@ -398,6 +398,12 @@ async def get_model_types(_current_user: DBUser = Depends(get_current_active_use
             "color": "warning",
             "icon": "Brush",
         },
+        "rerank": {
+            "label": "重排",
+            "description": "用于对检索结果进行相关性重排的模型",
+            "color": "success",
+            "icon": "Sort",
+        },
     }
 
     return [

--- a/nekro_agent/routers/config.py
+++ b/nekro_agent/routers/config.py
@@ -402,7 +402,7 @@ async def get_model_types(_current_user: DBUser = Depends(get_current_active_use
             "label": "重排",
             "description": "用于对检索结果进行相关性重排的模型",
             "color": "success",
-            "icon": "Sort",
+            "icon": "FilterAlt",
         },
     }
 

--- a/nekro_agent/services/kb/search_service.py
+++ b/nekro_agent/services/kb/search_service.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from nekro_agent.core.config import config
 from nekro_agent.core.logger import get_sub_logger
 from nekro_agent.models.db_kb_asset import DBKBAsset
 from nekro_agent.models.db_kb_asset_binding import DBKBAssetBinding
@@ -30,6 +31,7 @@ from nekro_agent.services.kb.library_service import (
 )
 from nekro_agent.services.kb.qdrant_manager import kb_qdrant_manager
 from nekro_agent.services.memory.embedding_service import embed_kb_text
+from nekro_agent.services.rerank_service import rerank as rerank_candidates
 from nekro_agent.services.workspace.manager import WorkspaceService
 
 logger = get_sub_logger("kb.search")
@@ -39,6 +41,8 @@ KEYWORD_HIT_FACTOR = 4
 KEYWORD_CHUNK_SCORE_THRESHOLD = 0.22
 KEYWORD_DOCUMENT_FALLBACK_THRESHOLD = 0.4
 FUSED_SCORE_CAP = 1.8
+# 重排候选池上限：融合结果中最多取前 N 条送重排模型二次打分
+RERANK_CANDIDATE_LIMIT = 60
 
 
 _SourceKind = Literal["document", "asset"]
@@ -323,6 +327,51 @@ def _merge_hits(vector_hits: list[_ScoredHit], keyword_hits: list[_ScoredHit]) -
     for hit in keyword_hits:
         _merge_one(hit)
     return list(merged.values())
+
+
+async def _apply_rerank(query: str, hits: list[_ScoredHit]) -> list[_ScoredHit] | None:
+    """对融合后的候选 chunk 做重排二次打分；返回重排后的列表，失败或不可用时返回 None。"""
+    candidates = sorted(hits, key=lambda item: item.score, reverse=True)[:RERANK_CANDIDATE_LIMIT]
+    if len(candidates) < 2:
+        return None
+
+    texts: list[str] = []
+    normalized_cache: dict[int, str] = {}
+    for hit in candidates:
+        if hit.source_kind == "document":
+            nc = await _read_normalized_cached(hit.source, normalized_cache)  # type: ignore[arg-type]
+            text = _extract_chunk_text(
+                document=hit.source,  # type: ignore[arg-type]
+                chunk=hit.chunk,  # type: ignore[arg-type]
+                normalized_content=nc,
+            )
+        else:
+            anc = await _read_asset_normalized_cached(hit.source, normalized_cache)  # type: ignore[arg-type]
+            text = _extract_chunk_text_from_asset(
+                asset=hit.source,  # type: ignore[arg-type]
+                chunk=hit.chunk,  # type: ignore[arg-type]
+                normalized_content=anc,
+            )
+        texts.append(text or hit.content_preview)
+
+    try:
+        reranked = await rerank_candidates(query=query, documents=texts)
+    except Exception as e:
+        logger.warning(f"知识库检索重排失败，回退融合分数排序: {e}")
+        return None
+    if not reranked:
+        return None
+
+    score_map = {result.index: result.score for result in reranked}
+    for index, hit in enumerate(candidates):
+        # 重排分数覆盖原融合分；未返回的候选视为 0 分（排在末尾）
+        hit.score = score_map.get(index, 0.0)
+
+    reranked_hits = [candidates[index] for index, _score in sorted(score_map.items(), key=lambda item: item[1], reverse=True)]
+    reranked_hits = [hit for hit in reranked_hits if hit.score > 0]
+    unranked_hits = [hit for hit in hits if hit not in candidates]
+    unranked_hits.sort(key=lambda item: item.score, reverse=True)
+    return reranked_hits + unranked_hits
 
 
 async def _collect_keyword_hits(
@@ -835,6 +884,10 @@ async def search_workspace_kb(
         )
 
     scored_hits = _merge_hits(vector_hits, keyword_hits)
+    if config.KB_RERANK_ENABLED:
+        reranked_hits = await _apply_rerank(query, scored_hits)
+        if reranked_hits is not None:
+            scored_hits = reranked_hits
     scored_hits.sort(key=lambda item: item.score, reverse=True)
 
     buckets: dict[tuple[_SourceKind, int], _DocumentBucket] = {}

--- a/nekro_agent/services/memory/retriever.py
+++ b/nekro_agent/services/memory/retriever.py
@@ -37,8 +37,12 @@ from nekro_agent.services.memory.recall_contract import (
     MemoryKnowledgeHint,
     MemoryTypeHint,
 )
+from nekro_agent.services.rerank_service import rerank as rerank_candidates
 
 logger = get_sub_logger("memory.retriever")
+
+# 记忆重排候选池上限：有效权重排序后最多取前 N 条送重排模型二次打分
+MEMORY_RERANK_CANDIDATE_LIMIT = 40
 
 
 @dataclass
@@ -217,6 +221,14 @@ class MemoryRetriever:
         )
 
         memories = list(paragraph_candidates.values()) + relation_memories + episode_memories
+        # 重排开关开启时，对有效权重排序后的候选做二次打分；失败自动回退原排序
+        if config.MEMORY_RERANK_ENABLED:
+            try:
+                reranked_memories = await self._rerank_memories(query, memories)
+                if reranked_memories is not None:
+                    memories = reranked_memories
+            except Exception as e:
+                logger.warning(f"记忆检索重排失败，回退有效权重排序: {e}")
         # 按有效权重排序
         memories.sort(key=lambda m: m.effective_weight, reverse=True)
         memories = memories[:resolved_limit]
@@ -268,6 +280,40 @@ class MemoryRetriever:
                 score *= config.MEMORY_RETRIEVAL_RECENT_BOOST_FACTOR
 
         return score
+
+    async def _rerank_memories(
+        self,
+        query: str,
+        memories: list[RetrievedMemory],
+    ) -> list[RetrievedMemory] | None:
+        """对候选记忆做重排二次打分；返回重排后的列表，失败或不可用时返回 None。"""
+        candidates = sorted(
+            memories,
+            key=lambda mem: mem.effective_weight,
+            reverse=True,
+        )[:MEMORY_RERANK_CANDIDATE_LIMIT]
+        if len(candidates) < 2:
+            return None
+
+        texts = [mem.content or mem.summary for mem in candidates]
+        results = await rerank_candidates(query=query, documents=texts)
+        if not results:
+            return None
+
+        score_map = {result.index: result.score for result in results}
+        for index, mem in enumerate(candidates):
+            score = score_map.get(index, 0.0)
+            # 重排分数覆盖相似度与有效权重，后续排序与配额筛选均以其为准
+            mem.similarity_score = score
+            mem.effective_weight = score
+
+        reranked = [
+            candidates[index]
+            for index, score in sorted(score_map.items(), key=lambda item: item[1], reverse=True)
+            if score > 0
+        ]
+        unranked = [mem for mem in memories if mem not in candidates]
+        return reranked + unranked
 
     @staticmethod
     def _normalize_datetime(value: datetime) -> datetime:

--- a/nekro_agent/services/rerank_service.py
+++ b/nekro_agent/services/rerank_service.py
@@ -38,6 +38,11 @@ def get_kb_rerank_model_group() -> str:
     return config.KB_RERANK_MODEL_GROUP.strip()
 
 
+def get_kb_rerank_endpoint() -> str:
+    """获取 rerank 接口路径（相对 BASE_URL，默认 /rerank；阿里云百炼为 /reranks）"""
+    return config.KB_RERANK_ENDPOINT.strip() or "/rerank"
+
+
 def validate_rerank_model_group() -> str:
     """校验知识库重排模型组存在且类型正确，返回模型组名。
 
@@ -117,7 +122,7 @@ async def rerank(
                 ) as client,
             ):
                 response = await client.post(
-                    "/rerank",
+                    get_kb_rerank_endpoint(),
                     cast_to=httpx.Response,
                     body=payload,
                 )

--- a/nekro_agent/services/rerank_service.py
+++ b/nekro_agent/services/rerank_service.py
@@ -1,0 +1,161 @@
+"""知识库 Rerank 服务（OpenAI 兼容 /v1/rerank 接口）
+
+复用项目现有的 openai SDK 客户端与模型组配置，支持 SiliconFlow / Jina 等
+提供 /v1/rerank 端点的服务，用于对检索候选进行相关性二次打分。
+
+未配置 KB_RERANK_MODEL_GROUP 时调用方应捕获 ValueError 并跳过重排。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import httpx
+from openai import APIStatusError, AsyncOpenAI
+
+from nekro_agent.core.config import config
+from nekro_agent.core.logger import get_sub_logger
+from nekro_agent.services.agent.openai import _OPENAI_BASE_URL, _create_http_client
+
+logger = get_sub_logger("kb.rerank")
+
+DEFAULT_TIMEOUT = 30
+MAX_RETRIES = 3
+RETRY_DELAY = 1.0
+
+
+@dataclass(frozen=True)
+class RerankResult:
+    """单条重排结果"""
+
+    index: int  # 在输入 documents 中的原始下标
+    score: float  # 相关性分数（服务端归一化范围，通常 0~1）
+
+
+def get_kb_rerank_model_group() -> str:
+    """获取知识库重排模型组名（可能为空字符串，表示未配置）"""
+    return config.KB_RERANK_MODEL_GROUP.strip()
+
+
+def validate_rerank_model_group() -> str:
+    """校验知识库重排模型组存在且类型正确，返回模型组名。
+
+    Raises:
+        ValueError: 未配置或模型组不存在 / 类型不是 rerank
+    """
+    group_name = get_kb_rerank_model_group()
+    if not group_name:
+        raise ValueError("知识库重排模型组未配置")
+
+    try:
+        model_group = config.get_model_group_info(group_name)
+    except KeyError as e:
+        raise ValueError(f"知识库重排模型组 '{group_name}' 不存在") from e
+
+    if model_group.MODEL_TYPE != "rerank":
+        raise ValueError(
+            f"知识库重排模型组 '{group_name}' 类型不是 rerank，当前为 {model_group.MODEL_TYPE}",
+        )
+
+    return group_name
+
+
+def _get_model_config(group_name: str) -> dict[str, str]:
+    """获取模型组的请求参数"""
+    model_group = config.get_model_group_info(group_name)
+    return {
+        "model": model_group.CHAT_MODEL,
+        "api_key": model_group.API_KEY,
+        "base_url": model_group.BASE_URL,
+        "proxy_url": model_group.CHAT_PROXY or "",
+    }
+
+
+async def rerank(
+    query: str,
+    documents: list[str],
+    top_n: int | None = None,
+) -> list[RerankResult]:
+    """对候选文档执行相关性重排（OpenAI 兼容 /v1/rerank）。
+
+    Args:
+        query: 查询文本
+        documents: 候选文档列表（最多可传数百条，具体上限取决于服务）
+        top_n: 只返回得分最高的前 N 条（不传则由服务端决定）
+
+    Returns:
+        按相关性降序排列的重排结果（原始下标 + 分数）
+
+    Raises:
+        ValueError: 重排模型组未配置 / 配置无效
+    """
+    group_name = validate_rerank_model_group()
+    model_config = _get_model_config(group_name)
+    payload: dict[str, object] = {
+        "model": model_config["model"],
+        "query": query,
+        "documents": documents,
+    }
+    if top_n is not None:
+        payload["top_n"] = top_n
+
+    last_error: Exception | None = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            async with (
+                _create_http_client(
+                    proxy_url=model_config["proxy_url"] or None,
+                    read_timeout=DEFAULT_TIMEOUT,
+                    write_timeout=DEFAULT_TIMEOUT,
+                ) as http_client,
+                AsyncOpenAI(
+                    api_key=model_config["api_key"].strip() or None,
+                    base_url=model_config["base_url"] or _OPENAI_BASE_URL,
+                    http_client=http_client,
+                    max_retries=0,
+                ) as client,
+            ):
+                response = await client.post(
+                    "/rerank",
+                    cast_to=httpx.Response,
+                    body=payload,
+                )
+
+            data = response.json()
+            raw_results = data.get("results", []) if isinstance(data, dict) else []
+            results = [
+                RerankResult(
+                    index=int(item["index"]),
+                    score=float(item.get("relevance_score", 0.0)),
+                )
+                for item in raw_results
+                if isinstance(item, dict) and "index" in item
+            ]
+            results.sort(key=lambda item: item.score, reverse=True)
+            if top_n is not None:
+                # 服务端可能不严格遵守 top_n，本地兜底截断
+                results = results[:top_n]
+            logger.debug(
+                f"知识库重排完成: query={query[:30]}..., candidates={len(documents)}, "
+                f"returned={len(results)}",
+            )
+            return results
+
+        except APIStatusError as e:
+            last_error = e
+            logger.warning(
+                f"Rerank 请求失败 (尝试 {attempt + 1}/{MAX_RETRIES}): "
+                f"status={e.status_code} detail={e.response.text[:300] if e.response else ''}",
+            )
+            if e.status_code < 500:
+                break
+            if attempt < MAX_RETRIES - 1:
+                await asyncio.sleep(RETRY_DELAY * (attempt + 1))
+        except Exception as e:
+            last_error = e
+            logger.warning(f"Rerank 请求失败 (尝试 {attempt + 1}/{MAX_RETRIES}): {e}")
+            if attempt < MAX_RETRIES - 1:
+                await asyncio.sleep(RETRY_DELAY * (attempt + 1))
+
+    raise last_error or Exception("Rerank 请求失败")

--- a/nekro_agent/services/rerank_service.py
+++ b/nekro_agent/services/rerank_service.py
@@ -38,11 +38,6 @@ def get_kb_rerank_model_group() -> str:
     return config.KB_RERANK_MODEL_GROUP.strip()
 
 
-def get_kb_rerank_endpoint() -> str:
-    """获取 rerank 接口路径（相对 BASE_URL，默认 /rerank；阿里云百炼为 /reranks）"""
-    return config.KB_RERANK_ENDPOINT.strip() or "/rerank"
-
-
 def validate_rerank_model_group() -> str:
     """校验知识库重排模型组存在且类型正确，返回模型组名。
 
@@ -74,6 +69,7 @@ def _get_model_config(group_name: str) -> dict[str, str]:
         "api_key": model_group.API_KEY,
         "base_url": model_group.BASE_URL,
         "proxy_url": model_group.CHAT_PROXY or "",
+        "endpoint": getattr(model_group, "RERANK_ENDPOINT", "") or "/rerank",
     }
 
 
@@ -122,7 +118,7 @@ async def rerank(
                 ) as client,
             ):
                 response = await client.post(
-                    get_kb_rerank_endpoint(),
+                    model_config["endpoint"],
                     cast_to=httpx.Response,
                     body=payload,
                 )


### PR DESCRIPTION
## 概述

为模型组配置新增 **rerank(重排)** 模型类型,让用户可以配置一个重排模型组(模型名/API 地址/密钥),为后续知识库与记忆检索接入 rerank 重排做准备。

## 改动

- 后端:`MODEL_TYPE` 增加 `rerank` 选项(config.py / core_utils.py)
- `/api/config/model-types` 返回 rerank 类型信息(标签/描述/颜色/图标)
- 前端:模型组表单类型下拉、配置表格支持 rerank 类型显示
- i18n:中英文文案补齐

## 说明

本 PR 仅添加类型支持(占位);rerank 的实际调用服务与检索流程接入将在后续 PR 中实现。

## Summary by Sourcery

在配置和 UI 中新增对全新「rerank」模型类型的支持，作为未来重排（reranking）功能的占位符。

新功能：
- 在模型组配置中引入「rerank」选项，用于对检索结果进行重新排序的模型。
- 通过配置 API 暴露「rerank」模型类型的元数据，包括标签、描述、颜色和图标。
- 更新前端的模型组和配置表格 UI，以展示并支持选择新的「rerank」模型类型。

增强改进：
- 扩展模型类型字面量和校验逻辑，使后端配置工具能够识别新的「rerank」类型。
- 为「rerank」模型类型在中英文语言环境中新增 i18n 文本条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a new "rerank" model type in configuration and UI as a placeholder for future reranking features.

New Features:
- Introduce a "rerank" option to model group configuration for models that reorder retrieval results.
- Expose the "rerank" model type metadata from the config API, including label, description, color, and icon.
- Update frontend model group and config table UIs to display and select the new "rerank" model type.

Enhancements:
- Extend model type literals and validation to recognize the new "rerank" type in backend config utilities.
- Add i18n entries for the "rerank" model type in both Chinese and English locales.

</details>

新功能：
- 在后端配置中，为模型组和模型引用新增 `rerank` 作为合法的模型类型。
- 通过 model-types API 暴露 `rerank` 模型类型的元数据，以便在 UI 中使用。
- 在设置页面和配置表中启用 `rerank` 模型组的选择和展示。

文档：
- 更新 i18n 资源，在中文和英文中补充 `rerank` 模型类型的标签和描述。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在配置和 UI 中新增对全新「rerank」模型类型的支持，作为未来重排（reranking）功能的占位符。

新功能：
- 在模型组配置中引入「rerank」选项，用于对检索结果进行重新排序的模型。
- 通过配置 API 暴露「rerank」模型类型的元数据，包括标签、描述、颜色和图标。
- 更新前端的模型组和配置表格 UI，以展示并支持选择新的「rerank」模型类型。

增强改进：
- 扩展模型类型字面量和校验逻辑，使后端配置工具能够识别新的「rerank」类型。
- 为「rerank」模型类型在中英文语言环境中新增 i18n 文本条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a new "rerank" model type in configuration and UI as a placeholder for future reranking features.

New Features:
- Introduce a "rerank" option to model group configuration for models that reorder retrieval results.
- Expose the "rerank" model type metadata from the config API, including label, description, color, and icon.
- Update frontend model group and config table UIs to display and select the new "rerank" model type.

Enhancements:
- Extend model type literals and validation to recognize the new "rerank" type in backend config utilities.
- Add i18n entries for the "rerank" model type in both Chinese and English locales.

</details>

</details>