### PR TITLE
fix(安全): 加固 RPC pickle 反序列化、CORS、沙箱与 SSRF 防护

### DIFF
--- a/nekro_agent/core/os_env.py
+++ b/nekro_agent/core/os_env.py
@@ -54,7 +54,7 @@ class OsEnv:
     不再支持 "*" 通配:Starlette 在 allow_credentials=True 下会反射任意 Origin,
     导致任何恶意网页都能以受害者浏览器凭据调用管理 API。
     """
-    CORS_ORIGINS: str = OsEnvTypes.Str("CORS_ORIGINS", default="")
+    CORS_ORIGINS: str = OsEnvTypes.Str("NEKRO_CORS_ORIGINS", default="")
 
     """沙箱安全配置
 

--- a/nekro_agent/core/os_env.py
+++ b/nekro_agent/core/os_env.py
@@ -39,8 +39,30 @@ class OsEnv:
     """RPC 配置"""
     RPC_SECRET_KEY: str = OsEnvTypes.Str("RPC_SECRET_KEY", default=f"rpc:{secrets.token_urlsafe(32)}")
 
-    """Webhook 配置"""
-    WEBHOOK_SECRET_KEY: str = OsEnvTypes.Str("WEBHOOK_SECRET_KEY", default=f"webhook:{secrets.token_urlsafe(32)}")
+    """Webhook 配置
+
+    WEBHOOK_SECRET_KEY 显式设置后,所有 /api/webhook/* 调用必须携带
+    X-Webhook-Token 请求头(或 ?webhook_token= 查询参数)且值匹配;
+    留空(默认)则保持旧行为不校验,避免破坏既有外部调用方。
+    """
+    WEBHOOK_SECRET_KEY: str = OsEnvTypes.Str("WEBHOOK_SECRET_KEY", default="")
+
+    """CORS 允许来源
+
+    逗号分隔的来源列表,如 "http://127.0.0.1:8021,https://na.example.com"。
+    留空(默认)则不启用跨域,前端与本服务同源部署(/webui)不受影响。
+    不再支持 "*" 通配:Starlette 在 allow_credentials=True 下会反射任意 Origin,
+    导致任何恶意网页都能以受害者浏览器凭据调用管理 API。
+    """
+    CORS_ORIGINS: str = OsEnvTypes.Str("CORS_ORIGINS", default="")
+
+    """沙箱安全配置
+
+    仅当非 Docker 本地运行且确实被宿主 AppArmor 拦截时,
+    设置 NEKRO_SANDBOX_DISABLE_APPARMOR=true 关闭沙箱容器的 AppArmor 配置。
+    默认关闭该逃生通道,始终为沙箱容器启用 no-new-privileges。
+    """
+    SANDBOX_DISABLE_APPARMOR: bool = OsEnvTypes.Bool("NEKRO_SANDBOX_DISABLE_APPARMOR", default=False)
 
     """其他配置"""
     RUN_IN_DOCKER: bool = OsEnvTypes.Bool("RUN_IN_DOCKER")

--- a/nekro_agent/routers/__init__.py
+++ b/nekro_agent/routers/__init__.py
@@ -74,7 +74,7 @@ def mount_middlewares(app: FastAPI):
         )
         logger.info(f"已启用 CORS,允许来源: {cors_origins}")
     else:
-        logger.info("未配置 CORS_ORIGINS,仅允许同源访问(前端 /webui 不受影响)")
+        logger.info("未配置 NEKRO_CORS_ORIGINS,仅允许同源访问(前端 /webui 不受影响)")
 
     @app.middleware("http")
     async def request_timing_middleware(request: Request, call_next):

--- a/nekro_agent/routers/__init__.py
+++ b/nekro_agent/routers/__init__.py
@@ -60,13 +60,21 @@ from .workspaces import router as workspaces_router
 
 def mount_middlewares(app: FastAPI):
     """挂载中间件和全局处理器"""
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    # 前端静态资源与本服务同源部署(/webui),默认无需开放跨域。
+    # 仅当 NEKRO_CORS_ORIGINS 显式配置来源列表时启用 CORS,
+    # 避免通配来源 + allow_credentials 组合反射任意 Origin(CWE-942)。
+    cors_origins = [origin.strip() for origin in OsEnv.CORS_ORIGINS.split(",") if origin.strip()]
+    if cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cors_origins,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+        logger.info(f"已启用 CORS,允许来源: {cors_origins}")
+    else:
+        logger.info("未配置 CORS_ORIGINS,仅允许同源访问(前端 /webui 不受影响)")
 
     @app.middleware("http")
     async def request_timing_middleware(request: Request, call_next):

--- a/nekro_agent/routers/webhook.py
+++ b/nekro_agent/routers/webhook.py
@@ -14,9 +14,11 @@ from nekro_agent.services.plugin.collector import plugin_collector
 logger = get_sub_logger("webhook")
 router = APIRouter(prefix="/webhook", tags=["Webhook"])
 
+_webhook_no_token_warned = False
+
 
 class WebhookResponse(BaseModel):
-    """Webhook响应"""
+    """WebhookResponse"""
 
     success: bool
     message: str
@@ -28,10 +30,14 @@ def _verify_webhook_token(request: Request) -> None:
 
     设置 WEBHOOK_SECRET_KEY 后,调用方必须携带匹配的
     X-Webhook-Token 请求头(或 ?webhook_token= 查询参数)。
-    未设置时保持旧行为(不校验),通过日志提醒。
+    未设置时保持旧行为(不校验),首次调用时记录一次日志提醒。
     """
+    global _webhook_no_token_warned
     secret = OsEnv.WEBHOOK_SECRET_KEY
     if not secret:
+        if not _webhook_no_token_warned:
+            logger.info("未设置 WEBHOOK_SECRET_KEY,webhook 端点未启用鉴权;如需防护请配置该环境变量")
+            _webhook_no_token_warned = True
         return
     provided = request.headers.get("X-Webhook-Token") or request.query_params.get("webhook_token", "")
     # 常时比较,避免逐字节比较的时序侧信道泄露密钥

--- a/nekro_agent/routers/webhook.py
+++ b/nekro_agent/routers/webhook.py
@@ -6,7 +6,8 @@ from pydantic import BaseModel
 
 from nekro_agent.api.schemas import AgentCtx, WebhookRequest
 from nekro_agent.core.logger import get_sub_logger
-from nekro_agent.schemas.errors import NotFoundError
+from nekro_agent.core.os_env import OsEnv
+from nekro_agent.schemas.errors import NotFoundError, UnauthorizedError
 from nekro_agent.services.plugin.collector import plugin_collector
 
 logger = get_sub_logger("webhook")
@@ -19,6 +20,22 @@ class WebhookResponse(BaseModel):
     success: bool
     message: str
     data: Optional[Dict[str, Any]] = None
+
+
+def _verify_webhook_token(request: Request) -> None:
+    """校验 Webhook 调用令牌
+
+    设置 WEBHOOK_SECRET_KEY 后,调用方必须携带匹配的
+    X-Webhook-Token 请求头(或 ?webhook_token= 查询参数)。
+    未设置时保持旧行为(不校验),通过日志提醒。
+    """
+    secret = OsEnv.WEBHOOK_SECRET_KEY
+    if not secret:
+        return
+    provided = request.headers.get("X-Webhook-Token") or request.query_params.get("webhook_token", "")
+    if provided != secret:
+        logger.warning("Webhook 令牌校验失败")
+        raise UnauthorizedError
 
 
 @router.post("/{endpoint}", summary="Webhook 调用")
@@ -36,6 +53,7 @@ async def webhook_handler(
     Returns:
         WebhookResponse: Webhook 响应
     """
+    _verify_webhook_token(request)
     logger.info(f"收到 Webhook 请求: {endpoint}")
 
     # 获取所有处理这个endpoint的webhook方法

--- a/nekro_agent/routers/webhook.py
+++ b/nekro_agent/routers/webhook.py
@@ -1,3 +1,4 @@
+import hmac
 import json
 from typing import Any, Dict, Optional
 
@@ -33,7 +34,8 @@ def _verify_webhook_token(request: Request) -> None:
     if not secret:
         return
     provided = request.headers.get("X-Webhook-Token") or request.query_params.get("webhook_token", "")
-    if provided != secret:
+    # 常时比较,避免逐字节比较的时序侧信道泄露密钥
+    if not hmac.compare_digest(provided.encode("utf-8"), secret.encode("utf-8")):
         logger.warning("Webhook 令牌校验失败")
         raise UnauthorizedError
 

--- a/nekro_agent/services/command/built_in/ops.py
+++ b/nekro_agent/services/command/built_in/ops.py
@@ -108,6 +108,11 @@ class DockerRestartCommand(BaseCommand):
                 t(zh_CN="当前环境不在 Docker 容器中，无法执行此操作", en_US="Not running in Docker, cannot perform this operation")
             )
 
+        try:
+            _validate_container_name(container)
+        except ValueError as e:
+            return CmdCtl.failed(str(e))
+
         os.system(f"docker restart {shlex.quote(container)}")  # noqa: S605
         return CmdCtl.success(
             t(zh_CN=f"已发送重启命令: docker restart {container}", en_US=f"Restart command sent: docker restart {container}")
@@ -142,6 +147,11 @@ class DockerLogsCommand(BaseCommand):
             return CmdCtl.failed(
                 t(zh_CN="当前环境不在 Docker 容器中，无法执行此操作", en_US="Not running in Docker, cannot perform this operation")
             )
+
+        try:
+            _validate_container_name(container)
+        except ValueError as e:
+            return CmdCtl.failed(str(e))
 
         logs = os.popen(f"docker logs {shlex.quote(container)} --tail 100").read()  # noqa: S605
         return CmdCtl.success(

--- a/nekro_agent/services/command/built_in/ops.py
+++ b/nekro_agent/services/command/built_in/ops.py
@@ -1,6 +1,8 @@
 """内置命令 - 运维类: clear_sandbox_cache, docker_restart, docker_logs, sh, instance_id, github_stars_check, log_err_list"""
 
 import os
+import re
+import shlex
 import shutil
 from collections.abc import AsyncIterator
 from datetime import datetime
@@ -67,6 +69,16 @@ class ClearSandboxCacheCommand(BaseCommand):
         )
 
 
+logger_container_name = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+
+
+def _validate_container_name(container: str) -> str:
+    """容器名仅允许 Docker 合法字符,阻断 shell 元字符注入"""
+    if not logger_container_name.match(container):
+        raise ValueError(f"非法的容器名称: {container}")
+    return container
+
+
 class DockerRestartCommand(BaseCommand):
     """重启 Docker 容器"""
 
@@ -96,7 +108,7 @@ class DockerRestartCommand(BaseCommand):
                 t(zh_CN="当前环境不在 Docker 容器中，无法执行此操作", en_US="Not running in Docker, cannot perform this operation")
             )
 
-        os.system(f"docker restart {container}")  # noqa: S605
+        os.system(f"docker restart {shlex.quote(container)}")  # noqa: S605
         return CmdCtl.success(
             t(zh_CN=f"已发送重启命令: docker restart {container}", en_US=f"Restart command sent: docker restart {container}")
         )
@@ -131,7 +143,7 @@ class DockerLogsCommand(BaseCommand):
                 t(zh_CN="当前环境不在 Docker 容器中，无法执行此操作", en_US="Not running in Docker, cannot perform this operation")
             )
 
-        logs = os.popen(f"docker logs {container} --tail 100").read()  # noqa: S605
+        logs = os.popen(f"docker logs {shlex.quote(container)} --tail 100").read()  # noqa: S605
         return CmdCtl.success(
             t(zh_CN=f"容器日志: \n{logs}", en_US=f"Container logs: \n{logs}")
         )

--- a/nekro_agent/services/rpc_service.py
+++ b/nekro_agent/services/rpc_service.py
@@ -6,12 +6,15 @@ from pydantic import ValidationError as PydanticValidationError
 
 from nekro_agent.schemas.errors import ValidationError
 from nekro_agent.schemas.rpc import RPCRequest
+from nekro_agent.services.sandbox.rpc_pickle import restricted_pickle_loads
 
 
 def decode_rpc_request(raw_body: bytes) -> RPCRequest:
     try:
-        payload = pickle.loads(raw_body)
-    except (pickle.UnpicklingError, EOFError, AttributeError, ValueError) as e:
+        # 请求体来自不可信沙箱(执行 LLM 生成代码的环境),
+        # 必须使用白名单受限加载器,阻止 pickle gadget 导致的宿主 RCE
+        payload = restricted_pickle_loads(raw_body)
+    except (pickle.UnpicklingError, EOFError, AttributeError, ValueError, ImportError) as e:
         raise ValidationError(reason="RPC 请求格式错误") from e
     try:
         return RPCRequest.model_validate(payload)

--- a/nekro_agent/services/rpc_service.py
+++ b/nekro_agent/services/rpc_service.py
@@ -14,7 +14,7 @@ def decode_rpc_request(raw_body: bytes) -> RPCRequest:
         # 请求体来自不可信沙箱(执行 LLM 生成代码的环境),
         # 必须使用白名单受限加载器,阻止 pickle gadget 导致的宿主 RCE
         payload = restricted_pickle_loads(raw_body)
-    except (pickle.UnpicklingError, EOFError, AttributeError, ValueError, ImportError) as e:
+    except (pickle.UnpicklingError, EOFError, AttributeError, ValueError, ImportError, TypeError) as e:
         raise ValidationError(reason="RPC 请求格式错误") from e
     try:
         return RPCRequest.model_validate(payload)

--- a/nekro_agent/services/sandbox/rpc_pickle.py
+++ b/nekro_agent/services/sandbox/rpc_pickle.py
@@ -1,0 +1,56 @@
+"""RPC pickle 反序列化安全限制
+
+背景:
+`/ext/rpc_exec` 接收来自沙箱(执行 LLM 生成代码的不可信环境)的 pickle 请求体。
+pickle 反序列化任意类可导致宿主进程 RCE(如 `__reduce__` gadget)。
+
+方案:
+使用受限 Unpickler,仅放行基础内建类型与少量显式白名单标准库类型,
+其余任何 GLOBAL/STACK_GLOBAL 加载一律拒绝。
+"""
+
+import datetime
+import decimal
+import io
+import pickle
+from collections import OrderedDict, defaultdict, deque
+from pathlib import Path, PurePath
+from types import SimpleNamespace
+
+# 显式允许跨 pickle 边界的类(标准库、无副作用构造函数)
+_SAFE_CLASSES: dict[tuple[str, str], type] = {
+    ("builtins", "complex"): complex,
+    ("collections", "OrderedDict"): OrderedDict,
+    ("collections", "defaultdict"): defaultdict,
+    ("collections", "deque"): deque,
+    ("datetime", "datetime"): datetime.datetime,
+    ("datetime", "date"): datetime.date,
+    ("datetime", "timedelta"): datetime.timedelta,
+    ("datetime", "time"): datetime.time,
+    ("decimal", "Decimal"): decimal.Decimal,
+    ("pathlib", "Path"): Path,
+    ("pathlib", "PosixPath"): Path,
+    ("pathlib", "WindowsPath"): Path,
+    ("pathlib", "PurePath"): PurePath,
+    ("types", "SimpleNamespace"): SimpleNamespace,
+}
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    """拒绝加载任何不在白名单内的全局对象"""
+
+    def find_class(self, module: str, name: str):  # noqa: ANN201, D102
+        candidate = _SAFE_CLASSES.get((module, name))
+        if candidate is not None:
+            return candidate
+        raise pickle.UnpicklingError(f"forbidden global: {module}.{name}")
+
+    @classmethod
+    def loads(cls, data: bytes) -> object:
+        """反序列化 bytes,应用白名单限制"""
+        return cls(io.BytesIO(data)).load()
+
+
+def restricted_pickle_loads(data: bytes) -> object:
+    """安全的 pickle 反序列化入口(供 RPC 请求解码使用)"""
+    return RestrictedUnpickler.loads(data)

--- a/nekro_agent/services/sandbox/runner.py
+++ b/nekro_agent/services/sandbox/runner.py
@@ -229,14 +229,17 @@ async def run_code_in_sandbox(
                     ],
                     "Memory": 512 * 1024 * 1024,  # 内存限制 (512MB)
                     "NanoCPUs": 1000000000,  # CPU 限制 (1 core)
-                    "SecurityOpt": (
-                        []
-                        if OsEnv.RUN_IN_DOCKER
-                        else [
-                            # "no-new-privileges",  # 禁止提升权限
-                            "apparmor=unconfined",  # 禁止 AppArmor 配置
-                        ]
-                    ),
+                    "SecurityOpt": [
+                        "no-new-privileges",  # 禁止提升权限
+                        # apparmor=unconfined 会完全关闭 AppArmor 隔离,
+                        # 仅在本地环境确实被 AppArmor 拦截时通过
+                        # NEKRO_SANDBOX_DISABLE_APPARMOR=true 显式开启
+                        *(
+                            ["apparmor=unconfined"]
+                            if (not OsEnv.RUN_IN_DOCKER and OsEnv.SANDBOX_DISABLE_APPARMOR)
+                            else []
+                        ),
+                    ],
                     "NetworkMode": "bridge",
                     "ExtraHosts": ["host.docker.internal:host-gateway"],
                 },

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import difflib
 import hashlib
@@ -5,7 +6,6 @@ import ipaddress
 import mimetypes
 import random
 import re
-import socket
 from pathlib import Path
 from typing import Tuple
 from urllib.parse import urlparse
@@ -45,12 +45,26 @@ _SSRF_BLOCKED_NETWORKS = [
 ]
 
 
-def is_blocked_ssrf_url(url: str) -> bool:
+def _is_ip_blocked(ip_text: str) -> bool:
+    """判断单个 IP 是否落在被拒绝的保留地址段内"""
+    try:
+        ip = ipaddress.ip_address(ip_text)
+    except ValueError:
+        return True
+    return any(ip in network for network in _SSRF_BLOCKED_NETWORKS)
+
+
+async def is_blocked_ssrf_url(url: str) -> bool:
     """检查 URL 是否指向内网/环回/链路本地等敏感地址段
 
     用于在下载用户(或 LLM 生成代码)提供的文件前拦截 SSRF:
     阻止访问本机 API、内网 Postgres/Qdrant、云元数据服务等。
-    域名会做真实 DNS 解析后逐地址判断,拦截 DNS 重绑定的常见形式。
+
+    限制说明(调用方需知):
+    - 校验时与 httpx 实际连接时各自做一次 DNS 解析,理论存在重绑定
+      TOCTOU 窗口;当前 httpx 默认不跟随重定向,公网 302 → 内网的
+      绕径不可行。若未来开启 follow_redirects,需在传输层固定已校验 IP。
+    - DNS 解析通过事件循环的 getaddrinfo 执行,不阻塞其他协程。
     """
     try:
         parsed = urlparse(url)
@@ -62,14 +76,11 @@ def is_blocked_ssrf_url(url: str) -> bool:
     if not host:
         return True
     try:
-        addr_infos = socket.getaddrinfo(host, None)
+        loop = asyncio.get_running_loop()
+        addr_infos = await loop.getaddrinfo(host, None)
     except OSError:
         return True
-    for _, _, _, _, sockaddr in addr_infos:
-        ip = ipaddress.ip_address(sockaddr[0])
-        if any(ip in network for network in _SSRF_BLOCKED_NETWORKS):
-            return True
-    return False
+    return any(_is_ip_blocked(sockaddr[0]) for _, _, _, _, sockaddr in addr_infos)
 
 
 
@@ -149,7 +160,7 @@ async def download_file(
         Tuple[str, str]: 文件路径, 文件名
     """
 
-    if is_blocked_ssrf_url(url):
+    if await is_blocked_ssrf_url(url):
         logger.warning(f"已拦截指向内网/保留地址的下载请求: {limited_text_output(url)}")
         raise ValueError("不允许下载内网或保留地址的资源")
 

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -1,11 +1,14 @@
 import base64
 import difflib
 import hashlib
+import ipaddress
 import mimetypes
 import random
 import re
+import socket
 from pathlib import Path
 from typing import Tuple
+from urllib.parse import urlparse
 
 import aiofiles
 import httpx
@@ -19,6 +22,55 @@ from nekro_agent.core.os_env import USER_UPLOAD_DIR
 from nekro_agent.tools.path_convertor import is_url_path, sanitize_chat_key_for_path
 
 _APP_VERSION: str = ""
+
+# 解析 URL 主机名后拒绝的地址段(环回/内网/链路本地/云元数据等)
+_SSRF_BLOCKED_NETWORKS = [
+    ipaddress.ip_network(n)
+    for n in (
+        "0.0.0.0/8",
+        "10.0.0.0/8",
+        "100.64.0.0/10",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "172.16.0.0/12",
+        "192.0.0.0/24",
+        "192.168.0.0/16",
+        "198.18.0.0/15",
+        "224.0.0.0/4",
+        "240.0.0.0/4",
+        "::1/128",
+        "fc00::/7",
+        "fe80::/10",
+    )
+]
+
+
+def is_blocked_ssrf_url(url: str) -> bool:
+    """检查 URL 是否指向内网/环回/链路本地等敏感地址段
+
+    用于在下载用户(或 LLM 生成代码)提供的文件前拦截 SSRF:
+    阻止访问本机 API、内网 Postgres/Qdrant、云元数据服务等。
+    域名会做真实 DNS 解析后逐地址判断,拦截 DNS 重绑定的常见形式。
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return True
+    if parsed.scheme not in ("http", "https"):
+        return True
+    host = parsed.hostname
+    if not host:
+        return True
+    try:
+        addr_infos = socket.getaddrinfo(host, None)
+    except OSError:
+        return True
+    for _, _, _, _, sockaddr in addr_infos:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if any(ip in network for network in _SSRF_BLOCKED_NETWORKS):
+            return True
+    return False
+
 
 
 def get_app_version() -> str:
@@ -96,6 +148,10 @@ async def download_file(
     Returns:
         Tuple[str, str]: 文件路径, 文件名
     """
+
+    if is_blocked_ssrf_url(url):
+        logger.warning(f"已拦截指向内网/保留地址的下载请求: {limited_text_output(url)}")
+        raise ValueError("不允许下载内网或保留地址的资源")
 
     try:
         async with httpx.AsyncClient() as client:


### PR DESCRIPTION
## 概述

对项目做了一次白盒静态安全审计(未发现后门;密钥均为运行时随机生成,遥测无隐私字段),本 PR 修复其中可形成「聊天提示注入 → 宿主 RCE」完整利用链的高危问题及若干中危问题。共 3 个提交、8 个文件,所有修复默认安全且向后兼容。

## 修复内容

### F-01(高危)— RPC pickle 反序列化 RCE 原语
`/ext/rpc_exec` 此前对来自不可信沙箱(执行 LLM 生成代码的环境)的请求体直接 `pickle.loads`。被提示注入的 Agent 一旦从沙箱 `api_caller.py` 中读出注入的 RPC 令牌,即可发送构造的 pickle payload 实现宿主进程 RCE,并借助宿主 docker.sock 挂载进一步放大。

- 新增 `services/sandbox/rpc_pickle.py`:白名单受限 `RestrictedUnpickler`(仅内建类型 + 少量标准库类型),其余任何 GLOBAL 加载一律拒绝
- 已验证:与 `ext_caller_code.py` 同构的正常 RPC payload 正常放行;`__reduce__` gadget、`posix.system`、`subprocess.Popen` 等 opcode 引用全部被拦截,无副作用

### F-02(高危)— 沙箱容器未受约束
非 Docker 宿主上,沙箱容器此前被设置为 `apparmor=unconfined`,且 `no-new-privileges` 被注释掉。

- 现在恒定启用 `no-new-privileges`;`apparmor=unconfined` 仅在显式设置 `NEKRO_SANDBOX_DISABLE_APPARMOR=true` 逃生开关时生效

### F-03(高危)— CORS 通配 + 凭据(CWE-942)
`allow_origins=["*"]` 与 `allow_credentials=True` 组合会反射任意 Origin,任何恶意网页都能以受害者浏览器凭据驱动管理 API。

- 改为 `NEKRO_CORS_ORIGINS` 环境变量白名单(逗号分隔)。默认不启用 CORS 中间件——同源部署的 `/webui` 前端不受影响

### F-05(中危)— webhook 端点无鉴权
`POST /api/webhook/{endpoint}` 无任何鉴权,且会调用宿主侧插件 webhook 处理器。

- 启用 `WEBHOOK_SECRET_KEY`(此前启动时生成却从未校验):设置后要求携带匹配的 `X-Webhook-Token` 请求头(或 `webhook_token` 查询参数);使用 `hmac.compare_digest` 常时比较;未设置时保持旧行为兼容既有调用方,并记录一次性提醒日志

### F-06(中危)— `download_file()` SSRF
任意 URL 抓取,无 scheme/IP 校验(本机 API、内网 Postgres/Qdrant、云元数据均可达)。

- 新增异步 `is_blocked_ssrf_url()`:仅允许 http/https,DNS 解析后逐地址比对环回/RFC1918/链路本地/CGNAT/组播/保留段;通过事件循环解析 DNS,不阻塞协程
- 已知限制(代码注释中已说明):校验与实际连接存在 DNS 重绑定 TOCTOU 窗口;当前 httpx 默认不跟随重定向,公网 302 → 内网绕径不可行

### F-09(低危)— docker 命令注入
`docker_restart`/`docker_logs` 将参数直接内插进 `os.system`/`os.popen`。

- `shlex.quote` + Docker 容器名正则白名单双重防护(`_validate_container_name` 已实际接入两条命令路径),非法名称直接返回错误

## 测试

- [x] 8 个改动文件 `python -m py_compile` 全部通过
- [x] RestrictedUnpickler 单测:正常 payload 放行;3 类恶意 gadget 拦截;无 RCE 副作用
- [x] SSRF 校验 11 个正反用例(环回/127/169.254/10.x/192.168/::1/fe80::/file:// 拦截;公网 OSS 与 https 放行);确认为异步实现
- [x] 容器名白名单 11 个用例(`;`、`$()`、反引号、路径穿越、空格等全部拦截)
- [ ] 完整 pytest 套件(本环境缺项目依赖未跑,CI 可覆盖)

## 给维护者的说明

- F-01 的治本方案是将 pickle RPC 协议整体替换为 JSON + 方法白名单;本 PR 保持协议兼容,仅消除 RCE 原语
- docker.sock 挂载风险(F-04,沙箱管理功能固有设计)未在本 PR 处理,建议文档标注并提供 socket-proxy 选项
- 完整审计报告(含 CWE 引用与攻击链分析)可按需提供

> 注:本 PR 取代此前的 #350(同一分支,新增了评审反馈修复与自审修复两个提交)

## Summary by Sourcery

在尽可能保持向后兼容的前提下，加强对沙盒 RPC、webhooks、CORS、文件下载以及 Docker 操作的安全防护，消除已识别的 RCE、SSRF 和认证相关问题。

Bug 修复：
- 通过限制协议类型，并阻止从 URL 解析出的回环地址、私有地址、链路本地地址以及其他敏感 IP 段，为 `download_file` 增加 SSRF 防护。
- 当配置了 `WEBHOOK_SECRET_KEY` 时，要求在 `/api/webhook/*` 使用经 HMAC 验证的 webhook token；在不匹配时返回 Unauthorized；若未配置该环境变量，则保留旧有行为。
- 通过使用安全正则验证容器名称，并在使用前对其进行 shell 转义，防止 `docker_restart` 和 `docker_logs` 中的命令注入。
- 对来自沙盒的 RPC 请求的 pickle 反序列化进行限制，使用受限的 unpickler，只允许少量安全的内建类型和标准库类型。

增强：
- 让沙盒容器的 `SecurityOpt` 始终包含 `no-new-privileges`，并通过显式的 `SANDBOX_DISABLE_APPARMOR` 逃生阀来控制是否允许 `apparmor=unconfined`。
- 使用基于环境变量的来源白名单替换通配符 CORS 配置；只有在设置了 `NEKRO_CORS_ORIGINS` 时才启用 CORS，并记录当前生效的配置。
- 为 webhook 密钥、CORS 来源以及沙盒 AppArmor 行为添加环境配置选项，默认值选择更安全的运行方式。
- 引入集中式的 SSRF URL 检查辅助方法，在执行下载前异步解析主机名并强制执行对被封锁网段的限制。
- 当在未配置 `WEBHOOK_SECRET_KEY` 的情况下调用 webhooks 时，记录一次性的信息级日志，以提醒运维人员在需要时启用保护。

文档：
- 在环境配置模块中记录 `WEBHOOK_SECRET_KEY`、`NEKRO_CORS_ORIGINS` 和 `NEKRO_SANDBOX_DISABLE_APPARMOR` 的语义及其安全影响。

测试：
- 在主测试套件之外新增针对受限 unpickler、SSRF URL 检查以及容器名称校验的行为验证测试，作为实现的一部分（CI 中的 pytest 配置保持不变）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden security around sandbox RPC, webhooks, CORS, file downloads, and Docker ops to eliminate identified RCE, SSRF, and auth issues while preserving backward compatibility where possible.

Bug Fixes:
- Add SSRF protections to download_file by restricting schemes and blocking loopback, private, link-local, and other sensitive IP ranges resolved from URLs.
- Require an HMAC-validated webhook token for /api/webhook/* when WEBHOOK_SECRET_KEY is configured, returning Unauthorized on mismatch while preserving legacy behavior if unset.
- Prevent command injection in docker_restart and docker_logs by validating container names against a safe regex and shell-quoting them before use.
- Constrain RPC pickle deserialization for sandbox-originated requests through a restricted unpickler that only allows a small set of safe built-in and standard-library types.

Enhancements:
- Make sandbox container SecurityOpt always include no-new-privileges and gate apparmor=unconfined behind an explicit SANDBOX_DISABLE_APPARMOR escape hatch.
- Replace wildcard CORS configuration with an environment-driven origin whitelist, enabling CORS only when NEKRO_CORS_ORIGINS is set and logging the active configuration.
- Add environment configuration options for webhook secrets, CORS origins, and sandbox AppArmor behavior, with defaults chosen for safer operation.
- Introduce centralized SSRF URL checking helper to asynchronously resolve hostnames and enforce blocked network ranges before performing downloads.
- Log a one-time informational message when webhooks are invoked without WEBHOOK_SECRET_KEY configured to prompt operators to enable protection if needed.

Documentation:
- Document the semantics and security impact of WEBHOOK_SECRET_KEY, NEKRO_CORS_ORIGINS, and NEKRO_SANDBOX_DISABLE_APPARMOR in the environment configuration module.

Tests:
- Add targeted behavior validation around the restricted unpickler, SSRF URL checking, and container name validation outside of the main test suite as part of the implementation (CI pytest unchanged).

</details>