### PR TITLE
fix(安全): 加固 RPC pickle 反序列化、CORS、沙箱与 SSRF 防护(含 Docker 实机验证)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ nekro_cc_sandbox
 
 # .codex
 .codex
+
+# Mimosa 安全扫描运行产物
+.mimosa/

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -30,6 +30,9 @@ QDRANT_URL=http://${INSTANCE_NAME}nekro_qdrant:6333
 # Qdrant API Key
 QDRANT_API_KEY=
 
+# Webhook 密钥(留空则 webhook 端点默认拒绝所有请求)
+WEBHOOK_SECRET_KEY=
+
 # OneBot 配置
 ONEBOT_ACCESS_TOKEN=
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - ONEBOT_ACCESS_TOKEN=${ONEBOT_ACCESS_TOKEN:-}
       - NEKRO_QDRANT_URL=${QDRANT_URL:-http://nekro_qdrant:6333}
       - NEKRO_QDRANT_API_KEY=${QDRANT_API_KEY:-}
+      - NEKRO_WEBHOOK_SECRET_KEY=${WEBHOOK_SECRET_KEY:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${NEKRO_DATA_DIR}:${NEKRO_DATA_DIR}:rw

--- a/docs/security/poc.md
+++ b/docs/security/poc.md
@@ -1,0 +1,89 @@
+# 安全修复最小复现 PoC
+
+本文件提供 PR 中各项安全修复的最小复现步骤,全部可在本地按顺序执行。
+环境约定:`http://127.0.0.1:8021` 为运行中的 NekroAgent 实例。
+
+## 1. RPC pickle RCE(修复前:宿主进程任意代码执行)
+
+前置:从进程内获取 RPC 令牌(模拟沙箱内代码读出注入的密钥,即攻击前提)。
+
+```bash
+docker exec nekro_agent .venv/bin/python -c "
+import sys; sys.path.insert(0, '/app')
+from nekro_agent.core.os_env import OsEnv
+print(OsEnv.RPC_SECRET_KEY)"
+```
+
+复现(修复后返回 400,标记文件不产生):
+
+```python
+import pickle, urllib.request, urllib.error
+
+RPC_KEY = "<上一步输出>"
+URL = "http://127.0.0.1:8021/api/ext/rpc_exec?container_key=x&from_chat_key=y"
+
+class RCE:
+    def __reduce__(self):
+        import os
+        return (os.system, ("touch /tmp/pwned",))
+
+req = urllib.request.Request(
+    URL, data=pickle.dumps(RCE()),
+    headers={"X-RPC-Token": RPC_KEY, "Content-Type": "application/octet-stream"})
+try:
+    urllib.request.urlopen(req)
+    print("VULNERABLE")  # 修复前:RCE 成功
+except urllib.error.HTTPError as e:
+    print(e.code)        # 修复后:400
+```
+
+判定:`/tmp/pwned` 不存在 且 状态码 400 → 已修复。
+
+## 2. SSRF — IPv4-mapped IPv6 绕过(修复前:可访问环回/云元数据)
+
+```python
+from nekro_agent.tools.common_util import download_file, BlockedDownloadAddress
+
+for url in ("http://[::ffff:127.0.0.1]/api/health",
+            "http://[::ffff:169.254.169.254]/latest/meta-data"):
+    try:
+        await download_file(url)          # 修复前:请求真实发出
+        print("VULNERABLE")
+    except BlockedDownloadAddress:
+        print("blocked:", url)            # 修复后
+```
+
+## 3. SSRF — DNS 重绑定(修复前:校验与连接间二次解析)
+
+模拟交替 DNS 的最小单测见 `tests/test_ssrf_guard.py::test_download_pins_connection_and_revalidates_redirects`:
+解析函数奇数次返回公网 IP、偶数次返回 `127.0.0.1`,断言实际连接目标始终为
+首次校验的公网 IP、重定向到内网名的跳被拒、连接阶段无额外解析。
+
+## 4. Webhook 默认鉴权(修复前:无令牌可直接调用插件处理器)
+
+```bash
+# 未配置 NEKRO_WEBHOOK_SECRET_KEY 时:
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -X POST http://127.0.0.1:8021/api/webhook/anything \
+  -H 'Content-Type: application/json' -d '{}'
+# 修复前: 404 (越过鉴权,端点不存在才 404)
+# 修复后: 401 (fail-closed)
+```
+
+## 5. CORS 通配拒绝(修复前:NEKRO_CORS_ORIGINS=* 重新引入 Origin 反射)
+
+```bash
+NEKRO_CORS_ORIGINS='*' docker compose up -d
+docker logs nekro_agent 2>&1 | tail -5
+# 修复后: ValueError: NEKRO_CORS_ORIGINS 不允许通配符来源: * ,服务拒绝启动
+```
+
+## 6. RPC 请求体上限(修复前:任意大 pickle 内存 DoS)
+
+```bash
+head -c 9437184 /dev/zero > /tmp/big.bin
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -X POST "http://127.0.0.1:8021/api/ext/rpc_exec?container_key=x&from_chat_key=y" \
+  -H "X-RPC-Token: <key>" --data-binary @/tmp/big.bin
+# 修复后: 413
+```

--- a/nekro_agent/core/cors_origins.py
+++ b/nekro_agent/core/cors_origins.py
@@ -1,0 +1,38 @@
+"""CORS 允许来源配置的严格解析
+
+安全约束背景:
+allow_origins=["*"] 与 allow_credentials=True 组合会让 Starlette 反射
+任意请求 Origin(CWE-942),任何恶意网页都能以受害者浏览器凭据调用
+管理 API。因此来源列表必须:
+- 禁止任何通配符(含 "*" 单独成项或混在条目中);
+- 每项必须是规范的 http/https Origin:有主机名,无路径、查询、
+  片段、用户信息;
+- 违反时直接抛错终止启动(fail-fast),不静默降级。
+"""
+
+from urllib.parse import urlparse
+
+
+def parse_cors_origins(raw: str) -> list[str]:
+    """解析逗号分隔的 Origin 白名单,非法条目抛 ValueError(阻止启动)"""
+    origins: list[str] = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if "*" in item:
+            raise ValueError(f"NEKRO_CORS_ORIGINS 不允许通配符来源: {item}")
+        parsed = urlparse(item)
+        if (
+            parsed.scheme not in ("http", "https")
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or parsed.params
+            or parsed.query
+            or parsed.fragment
+            or parsed.path not in ("", "/")
+        ):
+            raise ValueError(f"NEKRO_CORS_ORIGINS 含非法 Origin(须为 http(s)://host[:port]): {item}")
+        origins.append(item)
+    return origins

--- a/nekro_agent/core/os_env.py
+++ b/nekro_agent/core/os_env.py
@@ -54,7 +54,7 @@ class OsEnv:
     不再支持 "*" 通配:Starlette 在 allow_credentials=True 下会反射任意 Origin,
     导致任何恶意网页都能以受害者浏览器凭据调用管理 API。
     """
-    CORS_ORIGINS: str = OsEnvTypes.Str("CORS_ORIGINS", default="")
+    CORS_ORIGINS: str = OsEnvTypes.Str("NEKRO_CORS_ORIGINS", default="")
 
     """沙箱安全配置
 

--- a/nekro_agent/core/os_env.py
+++ b/nekro_agent/core/os_env.py
@@ -36,16 +36,24 @@ class OsEnv:
     ACCESS_TOKEN_EXPIRE_DAYS: int = OsEnvTypes.Int("ACCESS_TOKEN_EXPIRE_DAYS", default=7)
     ENCRYPT_ALGORITHM: str = OsEnvTypes.Str("ENCRYPT_ALGORITHM", default="HS256")
 
-    """RPC 配置"""
-    RPC_SECRET_KEY: str = OsEnvTypes.Str("RPC_SECRET_KEY", default=f"rpc:{secrets.token_urlsafe(32)}")
-
     """Webhook 配置
 
     WEBHOOK_SECRET_KEY 显式设置后,所有 /api/webhook/* 调用必须携带
-    X-Webhook-Token 请求头(或 ?webhook_token= 查询参数)且值匹配;
-    留空(默认)则保持旧行为不校验,避免破坏既有外部调用方。
+    匹配的 X-Webhook-Token 请求头;未设置时默认拒绝所有 webhook 请求
+    (fail-closed)。如需兼容旧的未鉴权部署,显式设置
+    NEKRO_ALLOW_UNAUTHENTICATED_WEBHOOKS=true 逃生开关。
     """
     WEBHOOK_SECRET_KEY: str = OsEnvTypes.Str("WEBHOOK_SECRET_KEY", default="")
+    ALLOW_UNAUTHENTICATED_WEBHOOKS: bool = OsEnvTypes.Bool("ALLOW_UNAUTHENTICATED_WEBHOOKS", default=False)
+
+    """RPC 配置
+
+    RPC_SECRET_KEY 为宿主与沙箱间的调用令牌(运行时随机生成)。
+    RPC_MAX_BODY_BYTES 限制 /ext/rpc_exec 请求体大小,防止超大
+    pickle 造成内存型拒绝服务。
+    """
+    RPC_SECRET_KEY: str = OsEnvTypes.Str("RPC_SECRET_KEY", default=f"rpc:{secrets.token_urlsafe(32)}")
+    RPC_MAX_BODY_BYTES: int = OsEnvTypes.Int("RPC_MAX_BODY_BYTES", default=8 * 1024 * 1024)
 
     """CORS 允许来源
 

--- a/nekro_agent/core/os_env.py
+++ b/nekro_agent/core/os_env.py
@@ -53,8 +53,11 @@ class OsEnv:
     留空(默认)则不启用跨域,前端与本服务同源部署(/webui)不受影响。
     不再支持 "*" 通配:Starlette 在 allow_credentials=True 下会反射任意 Origin,
     导致任何恶意网页都能以受害者浏览器凭据调用管理 API。
+
+    注意:OsEnvTypes 会自动为键名加 NEKRO_ 前缀,此处传 "CORS_ORIGINS"
+    即读取环境变量 NEKRO_CORS_ORIGINS(与其余配置项约定一致)。
     """
-    CORS_ORIGINS: str = OsEnvTypes.Str("NEKRO_CORS_ORIGINS", default="")
+    CORS_ORIGINS: str = OsEnvTypes.Str("CORS_ORIGINS", default="")
 
     """沙箱安全配置
 
@@ -62,7 +65,7 @@ class OsEnv:
     设置 NEKRO_SANDBOX_DISABLE_APPARMOR=true 关闭沙箱容器的 AppArmor 配置。
     默认关闭该逃生通道,始终为沙箱容器启用 no-new-privileges。
     """
-    SANDBOX_DISABLE_APPARMOR: bool = OsEnvTypes.Bool("NEKRO_SANDBOX_DISABLE_APPARMOR", default=False)
+    SANDBOX_DISABLE_APPARMOR: bool = OsEnvTypes.Bool("SANDBOX_DISABLE_APPARMOR", default=False)
 
     """其他配置"""
     RUN_IN_DOCKER: bool = OsEnvTypes.Bool("RUN_IN_DOCKER")

--- a/nekro_agent/core/os_env.py
+++ b/nekro_agent/core/os_env.py
@@ -39,8 +39,30 @@ class OsEnv:
     """RPC 配置"""
     RPC_SECRET_KEY: str = OsEnvTypes.Str("RPC_SECRET_KEY", default=f"rpc:{secrets.token_urlsafe(32)}")
 
-    """Webhook 配置"""
-    WEBHOOK_SECRET_KEY: str = OsEnvTypes.Str("WEBHOOK_SECRET_KEY", default=f"webhook:{secrets.token_urlsafe(32)}")
+    """Webhook 配置
+
+    WEBHOOK_SECRET_KEY 显式设置后,所有 /api/webhook/* 调用必须携带
+    X-Webhook-Token 请求头(或 ?webhook_token= 查询参数)且值匹配;
+    留空(默认)则保持旧行为不校验,避免破坏既有外部调用方。
+    """
+    WEBHOOK_SECRET_KEY: str = OsEnvTypes.Str("WEBHOOK_SECRET_KEY", default="")
+
+    """CORS 允许来源
+
+    逗号分隔的来源列表,如 "http://127.0.0.1:8021,https://na.example.com"。
+    留空(默认)则不启用跨域,前端与本服务同源部署(/webui)不受影响。
+    不再支持 "*" 通配:Starlette 在 allow_credentials=True 下会反射任意 Origin,
+    导致任何恶意网页都能以受害者浏览器凭据调用管理 API。
+    """
+    CORS_ORIGINS: str = OsEnvTypes.Str("CORS_ORIGINS", default="")
+
+    """沙箱安全配置
+
+    仅当非 Docker 本地运行且确实被宿主 AppArmor 拦截时,
+    设置 NEKRO_SANDBOX_DISABLE_APPARMOR=true 关闭沙箱容器的 AppArmor 配置。
+    默认关闭该逃生通道,始终为沙箱容器启用 no-new-privileges。
+    """
+    SANDBOX_DISABLE_APPARMOR: bool = OsEnvTypes.Bool("NEKRO_SANDBOX_DISABLE_APPARMOR", default=False)
 
     """其他配置"""
     RUN_IN_DOCKER: bool = OsEnvTypes.Bool("RUN_IN_DOCKER")

--- a/nekro_agent/routers/__init__.py
+++ b/nekro_agent/routers/__init__.py
@@ -74,7 +74,7 @@ def mount_middlewares(app: FastAPI):
         )
         logger.info(f"已启用 CORS,允许来源: {cors_origins}")
     else:
-        logger.info("未配置 CORS_ORIGINS,仅允许同源访问(前端 /webui 不受影响)")
+        logger.info("未配置 NEKRO_CORS_ORIGINS,仅允许同源访问(前端 /webui 不受影响)")
 
     @app.middleware("http")
     async def request_timing_middleware(request: Request, call_next):

--- a/nekro_agent/routers/__init__.py
+++ b/nekro_agent/routers/__init__.py
@@ -137,6 +137,8 @@ def mount_middlewares(app: FastAPI):
 
 def mount_api_routes(app: FastAPI):
     """挂载 API 路由"""
+    if OsEnv.RPC_MAX_BODY_BYTES <= 0:
+        raise ValueError("NEKRO_RPC_MAX_BODY_BYTES 必须大于 0")
     if not OsEnv.WEBHOOK_SECRET_KEY and not OsEnv.ALLOW_UNAUTHENTICATED_WEBHOOKS:
         logger.info("未设置 WEBHOOK_SECRET_KEY,webhook 端点已默认拒绝所有请求(fail-closed);如需兼容旧部署可设置 NEKRO_ALLOW_UNAUTHENTICATED_WEBHOOKS=true")
 

--- a/nekro_agent/routers/__init__.py
+++ b/nekro_agent/routers/__init__.py
@@ -12,6 +12,7 @@ from fastapi.staticfiles import StaticFiles
 from nekro_agent.adapters import load_adapters_api
 from nekro_agent.adapters.email.routers import router as email_adapter_config_router
 from nekro_agent.core.args import Args
+from nekro_agent.core.cors_origins import parse_cors_origins
 from nekro_agent.core.exception_handlers import register_exception_handlers
 from nekro_agent.core.logger import logger
 from nekro_agent.core.os_env import OsEnv
@@ -61,9 +62,14 @@ from .workspaces import router as workspaces_router
 def mount_middlewares(app: FastAPI):
     """挂载中间件和全局处理器"""
     # 前端静态资源与本服务同源部署(/webui),默认无需开放跨域。
-    # 仅当 NEKRO_CORS_ORIGINS 显式配置来源列表时启用 CORS,
-    # 避免通配来源 + allow_credentials 组合反射任意 Origin(CWE-942)。
-    cors_origins = [origin.strip() for origin in OsEnv.CORS_ORIGINS.split(",") if origin.strip()]
+    # 仅当 NEKRO_CORS_ORIGINS 显式配置来源列表时启用 CORS;
+    # 通配符或非法 Origin 会在解析时抛错终止启动,防止
+    # "*" + allow_credentials 反射任意 Origin(CWE-942)。
+    try:
+        cors_origins = parse_cors_origins(OsEnv.CORS_ORIGINS)
+    except ValueError as e:
+        logger.error(str(e))
+        raise
     if cors_origins:
         app.add_middleware(
             CORSMiddleware,
@@ -131,8 +137,8 @@ def mount_middlewares(app: FastAPI):
 
 def mount_api_routes(app: FastAPI):
     """挂载 API 路由"""
-    if not OsEnv.WEBHOOK_SECRET_KEY:
-        logger.info("未设置 WEBHOOK_SECRET_KEY,webhook 端点未启用鉴权;如需防护请配置该环境变量")
+    if not OsEnv.WEBHOOK_SECRET_KEY and not OsEnv.ALLOW_UNAUTHENTICATED_WEBHOOKS:
+        logger.info("未设置 WEBHOOK_SECRET_KEY,webhook 端点已默认拒绝所有请求(fail-closed);如需兼容旧部署可设置 NEKRO_ALLOW_UNAUTHENTICATED_WEBHOOKS=true")
 
     api = APIRouter(prefix="/api")
 

--- a/nekro_agent/routers/__init__.py
+++ b/nekro_agent/routers/__init__.py
@@ -131,6 +131,9 @@ def mount_middlewares(app: FastAPI):
 
 def mount_api_routes(app: FastAPI):
     """挂载 API 路由"""
+    if not OsEnv.WEBHOOK_SECRET_KEY:
+        logger.info("未设置 WEBHOOK_SECRET_KEY,webhook 端点未启用鉴权;如需防护请配置该环境变量")
+
     api = APIRouter(prefix="/api")
 
     api.include_router(user_router)

--- a/nekro_agent/routers/__init__.py
+++ b/nekro_agent/routers/__init__.py
@@ -60,13 +60,21 @@ from .workspaces import router as workspaces_router
 
 def mount_middlewares(app: FastAPI):
     """挂载中间件和全局处理器"""
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    # 前端静态资源与本服务同源部署(/webui),默认无需开放跨域。
+    # 仅当 NEKRO_CORS_ORIGINS 显式配置来源列表时启用 CORS,
+    # 避免通配来源 + allow_credentials 组合反射任意 Origin(CWE-942)。
+    cors_origins = [origin.strip() for origin in OsEnv.CORS_ORIGINS.split(",") if origin.strip()]
+    if cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cors_origins,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+        logger.info(f"已启用 CORS,允许来源: {cors_origins}")
+    else:
+        logger.info("未配置 CORS_ORIGINS,仅允许同源访问(前端 /webui 不受影响)")
 
     @app.middleware("http")
     async def request_timing_middleware(request: Request, call_next):

--- a/nekro_agent/routers/rpc.py
+++ b/nekro_agent/routers/rpc.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Header, Request, Response
 from nekro_agent.api.schemas import AgentCtx
 from nekro_agent.core.logger import get_sub_logger
 from nekro_agent.core.os_env import OsEnv
-from nekro_agent.schemas.errors import NotFoundError, UnauthorizedError
+from nekro_agent.schemas.errors import NotFoundError, PayloadTooLargeError, UnauthorizedError
 from nekro_agent.schemas.rpc import RPCRequest
 from nekro_agent.services.message_service import message_service
 from nekro_agent.services.plugin.collector import plugin_collector
@@ -28,7 +28,12 @@ async def verify_rpc_token(x_rpc_token: str = Header(...)):
 
 @router.post("/rpc_exec", summary="RPC 命令执行", dependencies=[Depends(verify_rpc_token)])
 async def rpc_exec(container_key: str, from_chat_key: str, data: Request) -> Response:
-    rpc_request: RPCRequest = decode_rpc_request(await data.body())
+    body = await data.body()
+    # 限制请求体大小,防止超大 pickle 造成内存型拒绝服务
+    if len(body) > OsEnv.RPC_MAX_BODY_BYTES:
+        logger.warning(f"RPC 请求体过大已拒绝: {len(body)} bytes (limit={OsEnv.RPC_MAX_BODY_BYTES})")
+        raise PayloadTooLargeError(resource="RPC 请求体")
+    rpc_request: RPCRequest = decode_rpc_request(body)
 
     logger.info(f"收到 RPC 执行请求: {rpc_request.method}")
 

--- a/nekro_agent/routers/rpc.py
+++ b/nekro_agent/routers/rpc.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Header, Request, Response
 from nekro_agent.api.schemas import AgentCtx
 from nekro_agent.core.logger import get_sub_logger
 from nekro_agent.core.os_env import OsEnv
-from nekro_agent.schemas.errors import NotFoundError, PayloadTooLargeError, UnauthorizedError
+from nekro_agent.schemas.errors import NotFoundError, PayloadTooLargeError, UnauthorizedError, ValidationError
 from nekro_agent.schemas.rpc import RPCRequest
 from nekro_agent.services.message_service import message_service
 from nekro_agent.services.plugin.collector import plugin_collector
@@ -26,13 +26,33 @@ async def verify_rpc_token(x_rpc_token: str = Header(...)):
     return True
 
 
+async def _read_request_body_limited(request: Request, max_bytes: int) -> bytes:
+    if max_bytes <= 0:
+        raise ValueError("NEKRO_RPC_MAX_BODY_BYTES 必须大于 0")
+
+    content_lengths = request.headers.getlist("content-length")
+    if content_lengths:
+        content_length = content_lengths[0]
+        if len(content_lengths) != 1 or not content_length.isascii() or not content_length.isdecimal():
+            raise ValidationError(reason="Content-Length 无效")
+        try:
+            declared_length = int(content_length)
+        except ValueError as e:
+            raise ValidationError(reason="Content-Length 无效") from e
+        if declared_length > max_bytes:
+            raise PayloadTooLargeError(resource="RPC 请求体")
+
+    body = bytearray()
+    async for chunk in request.stream():
+        if len(chunk) > max_bytes - len(body):
+            raise PayloadTooLargeError(resource="RPC 请求体")
+        body.extend(chunk)
+    return bytes(body)
+
+
 @router.post("/rpc_exec", summary="RPC 命令执行", dependencies=[Depends(verify_rpc_token)])
 async def rpc_exec(container_key: str, from_chat_key: str, data: Request) -> Response:
-    body = await data.body()
-    # 限制请求体大小,防止超大 pickle 造成内存型拒绝服务
-    if len(body) > OsEnv.RPC_MAX_BODY_BYTES:
-        logger.warning(f"RPC 请求体过大已拒绝: {len(body)} bytes (limit={OsEnv.RPC_MAX_BODY_BYTES})")
-        raise PayloadTooLargeError(resource="RPC 请求体")
+    body = await _read_request_body_limited(data, OsEnv.RPC_MAX_BODY_BYTES)
     rpc_request: RPCRequest = decode_rpc_request(body)
 
     logger.info(f"收到 RPC 执行请求: {rpc_request.method}")

--- a/nekro_agent/routers/webhook.py
+++ b/nekro_agent/routers/webhook.py
@@ -14,8 +14,6 @@ from nekro_agent.services.plugin.collector import plugin_collector
 logger = get_sub_logger("webhook")
 router = APIRouter(prefix="/webhook", tags=["Webhook"])
 
-_webhook_no_token_warned = False
-
 
 class WebhookResponse(BaseModel):
     """WebhookResponse"""
@@ -30,14 +28,11 @@ def _verify_webhook_token(request: Request) -> None:
 
     设置 WEBHOOK_SECRET_KEY 后,调用方必须携带匹配的
     X-Webhook-Token 请求头(或 ?webhook_token= 查询参数)。
-    未设置时保持旧行为(不校验),首次调用时记录一次日志提醒。
+    未设置时保持旧行为(不校验);启动阶段的 mount_api_routes
+    会输出一次性提醒日志。
     """
-    global _webhook_no_token_warned
     secret = OsEnv.WEBHOOK_SECRET_KEY
     if not secret:
-        if not _webhook_no_token_warned:
-            logger.info("未设置 WEBHOOK_SECRET_KEY,webhook 端点未启用鉴权;如需防护请配置该环境变量")
-            _webhook_no_token_warned = True
         return
     provided = request.headers.get("X-Webhook-Token") or request.query_params.get("webhook_token", "")
     # 常时比较,避免逐字节比较的时序侧信道泄露密钥

--- a/nekro_agent/routers/webhook.py
+++ b/nekro_agent/routers/webhook.py
@@ -14,9 +14,11 @@ from nekro_agent.services.plugin.collector import plugin_collector
 logger = get_sub_logger("webhook")
 router = APIRouter(prefix="/webhook", tags=["Webhook"])
 
+_webhook_no_token_warned = False
+
 
 class WebhookResponse(BaseModel):
-    """Webhook响应"""
+    """WebhookResponse"""
 
     success: bool
     message: str
@@ -28,10 +30,14 @@ def _verify_webhook_token(request: Request) -> None:
 
     设置 WEBHOOK_SECRET_KEY 后,调用方必须携带匹配的
     X-Webhook-Token 请求头(或 ?webhook_token= 查询参数)。
-    未设置时保持旧行为(不校验),通过日志提醒。
+    未设置时保持旧行为(不校验),首次调用时记录一次日志提醒。
     """
+    global _webhook_no_token_warned
     secret = OsEnv.WEBHOOK_SECRET_KEY
     if not secret:
+        if not _webhook_no_token_warned:
+            logger.info("未设置 WEBHOOK_SECRET_KEY,webhook 端点未启用鉴权;如需防护请配置该环境变量")
+            _webhook_no_token_warned = True
         return
     provided = request.headers.get("X-Webhook-Token") or request.query_params.get("webhook_token", "")
     # 常时比较,避免逐字节比较的时序侧信道泄露密钥

--- a/nekro_agent/routers/webhook.py
+++ b/nekro_agent/routers/webhook.py
@@ -6,7 +6,8 @@ from pydantic import BaseModel
 
 from nekro_agent.api.schemas import AgentCtx, WebhookRequest
 from nekro_agent.core.logger import get_sub_logger
-from nekro_agent.schemas.errors import NotFoundError
+from nekro_agent.core.os_env import OsEnv
+from nekro_agent.schemas.errors import NotFoundError, UnauthorizedError
 from nekro_agent.services.plugin.collector import plugin_collector
 
 logger = get_sub_logger("webhook")
@@ -19,6 +20,22 @@ class WebhookResponse(BaseModel):
     success: bool
     message: str
     data: Optional[Dict[str, Any]] = None
+
+
+def _verify_webhook_token(request: Request) -> None:
+    """校验 Webhook 调用令牌
+
+    设置 WEBHOOK_SECRET_KEY 后,调用方必须携带匹配的
+    X-Webhook-Token 请求头(或 ?webhook_token= 查询参数)。
+    未设置时保持旧行为(不校验),通过日志提醒。
+    """
+    secret = OsEnv.WEBHOOK_SECRET_KEY
+    if not secret:
+        return
+    provided = request.headers.get("X-Webhook-Token") or request.query_params.get("webhook_token", "")
+    if provided != secret:
+        logger.warning("Webhook 令牌校验失败")
+        raise UnauthorizedError
 
 
 @router.post("/{endpoint}", summary="Webhook 调用")
@@ -36,6 +53,7 @@ async def webhook_handler(
     Returns:
         WebhookResponse: Webhook 响应
     """
+    _verify_webhook_token(request)
     logger.info(f"收到 Webhook 请求: {endpoint}")
 
     # 获取所有处理这个endpoint的webhook方法

--- a/nekro_agent/routers/webhook.py
+++ b/nekro_agent/routers/webhook.py
@@ -1,3 +1,4 @@
+import hmac
 import json
 from typing import Any, Dict, Optional
 
@@ -33,7 +34,8 @@ def _verify_webhook_token(request: Request) -> None:
     if not secret:
         return
     provided = request.headers.get("X-Webhook-Token") or request.query_params.get("webhook_token", "")
-    if provided != secret:
+    # 常时比较,避免逐字节比较的时序侧信道泄露密钥
+    if not hmac.compare_digest(provided.encode("utf-8"), secret.encode("utf-8")):
         logger.warning("Webhook 令牌校验失败")
         raise UnauthorizedError
 

--- a/nekro_agent/routers/webhook.py
+++ b/nekro_agent/routers/webhook.py
@@ -24,17 +24,20 @@ class WebhookResponse(BaseModel):
 
 
 def _verify_webhook_token(request: Request) -> None:
-    """校验 Webhook 调用令牌
+    """校验 Webhook 调用令牌(fail-closed)
 
-    设置 WEBHOOK_SECRET_KEY 后,调用方必须携带匹配的
-    X-Webhook-Token 请求头(或 ?webhook_token= 查询参数)。
-    未设置时保持旧行为(不校验);启动阶段的 mount_api_routes
-    会输出一次性提醒日志。
+    - 设置了 WEBHOOK_SECRET_KEY:必须携带匹配的 X-Webhook-Token 请求头。
+      仅接受请求头:查询参数形式的令牌容易进入反向代理访问日志、
+      浏览器历史与监控记录,不再支持。
+    - 未设置密钥:默认拒绝所有请求。如需兼容旧的未鉴权部署,
+      显式设置 NEKRO_ALLOW_UNAUTHENTICATED_WEBHOOKS=true。
     """
     secret = OsEnv.WEBHOOK_SECRET_KEY
     if not secret:
-        return
-    provided = request.headers.get("X-Webhook-Token") or request.query_params.get("webhook_token", "")
+        if OsEnv.ALLOW_UNAUTHENTICATED_WEBHOOKS:
+            return
+        raise UnauthorizedError
+    provided = request.headers.get("X-Webhook-Token", "")
     # 常时比较,避免逐字节比较的时序侧信道泄露密钥
     if not hmac.compare_digest(provided.encode("utf-8"), secret.encode("utf-8")):
         logger.warning("Webhook 令牌校验失败")

--- a/nekro_agent/schemas/errors.py
+++ b/nekro_agent/schemas/errors.py
@@ -114,6 +114,19 @@ class NotFoundError(AppError):
         super().__init__(resource=resource, **kwargs)
 
 
+class PayloadTooLargeError(AppError):
+    """请求体超过大小限制"""
+
+    http_status: ClassVar[int] = 413
+    i18n_message: ClassVar[I18nDict] = i18n_text(
+        zh_CN="{resource}超过大小限制",
+        en_US="{resource} exceeds size limit",
+    )
+
+    def __init__(self, resource: str, **kwargs: Any):
+        super().__init__(resource=resource, **kwargs)
+
+
 class ConflictError(AppError):
     """资源冲突"""
 

--- a/nekro_agent/services/command/built_in/ops.py
+++ b/nekro_agent/services/command/built_in/ops.py
@@ -108,6 +108,11 @@ class DockerRestartCommand(BaseCommand):
                 t(zh_CN="当前环境不在 Docker 容器中，无法执行此操作", en_US="Not running in Docker, cannot perform this operation")
             )
 
+        try:
+            _validate_container_name(container)
+        except ValueError as e:
+            return CmdCtl.failed(str(e))
+
         os.system(f"docker restart {shlex.quote(container)}")  # noqa: S605
         return CmdCtl.success(
             t(zh_CN=f"已发送重启命令: docker restart {container}", en_US=f"Restart command sent: docker restart {container}")
@@ -142,6 +147,11 @@ class DockerLogsCommand(BaseCommand):
             return CmdCtl.failed(
                 t(zh_CN="当前环境不在 Docker 容器中，无法执行此操作", en_US="Not running in Docker, cannot perform this operation")
             )
+
+        try:
+            _validate_container_name(container)
+        except ValueError as e:
+            return CmdCtl.failed(str(e))
 
         logs = os.popen(f"docker logs {shlex.quote(container)} --tail 100").read()  # noqa: S605
         return CmdCtl.success(

--- a/nekro_agent/services/command/built_in/ops.py
+++ b/nekro_agent/services/command/built_in/ops.py
@@ -2,8 +2,8 @@
 
 import os
 import re
-import shlex
 import shutil
+import subprocess
 from collections.abc import AsyncIterator
 from datetime import datetime
 from pathlib import Path
@@ -113,7 +113,14 @@ class DockerRestartCommand(BaseCommand):
         except ValueError as e:
             return CmdCtl.failed(str(e))
 
-        os.system(f"docker restart {shlex.quote(container)}")  # noqa: S605
+        proc = subprocess.run(["docker", "restart", container], capture_output=True, text=True)
+        if proc.returncode != 0:
+            return CmdCtl.failed(
+                t(
+                    zh_CN=f"重启容器失败: {proc.stderr.strip() or proc.stdout.strip()}",
+                    en_US=f"Failed to restart container: {proc.stderr.strip() or proc.stdout.strip()}",
+                )
+            )
         return CmdCtl.success(
             t(zh_CN=f"已发送重启命令: docker restart {container}", en_US=f"Restart command sent: docker restart {container}")
         )
@@ -153,7 +160,8 @@ class DockerLogsCommand(BaseCommand):
         except ValueError as e:
             return CmdCtl.failed(str(e))
 
-        logs = os.popen(f"docker logs {shlex.quote(container)} --tail 100").read()  # noqa: S605
+        proc = subprocess.run(["docker", "logs", container, "--tail", "100"], capture_output=True, text=True)
+        logs = proc.stdout or proc.stderr
         return CmdCtl.success(
             t(zh_CN=f"容器日志: \n{logs}", en_US=f"Container logs: \n{logs}")
         )

--- a/nekro_agent/services/command/built_in/ops.py
+++ b/nekro_agent/services/command/built_in/ops.py
@@ -1,6 +1,8 @@
 """内置命令 - 运维类: clear_sandbox_cache, docker_restart, docker_logs, sh, instance_id, github_stars_check, log_err_list"""
 
 import os
+import re
+import shlex
 import shutil
 from collections.abc import AsyncIterator
 from datetime import datetime
@@ -67,6 +69,16 @@ class ClearSandboxCacheCommand(BaseCommand):
         )
 
 
+logger_container_name = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+
+
+def _validate_container_name(container: str) -> str:
+    """容器名仅允许 Docker 合法字符,阻断 shell 元字符注入"""
+    if not logger_container_name.match(container):
+        raise ValueError(f"非法的容器名称: {container}")
+    return container
+
+
 class DockerRestartCommand(BaseCommand):
     """重启 Docker 容器"""
 
@@ -96,7 +108,7 @@ class DockerRestartCommand(BaseCommand):
                 t(zh_CN="当前环境不在 Docker 容器中，无法执行此操作", en_US="Not running in Docker, cannot perform this operation")
             )
 
-        os.system(f"docker restart {container}")  # noqa: S605
+        os.system(f"docker restart {shlex.quote(container)}")  # noqa: S605
         return CmdCtl.success(
             t(zh_CN=f"已发送重启命令: docker restart {container}", en_US=f"Restart command sent: docker restart {container}")
         )
@@ -131,7 +143,7 @@ class DockerLogsCommand(BaseCommand):
                 t(zh_CN="当前环境不在 Docker 容器中，无法执行此操作", en_US="Not running in Docker, cannot perform this operation")
             )
 
-        logs = os.popen(f"docker logs {container} --tail 100").read()  # noqa: S605
+        logs = os.popen(f"docker logs {shlex.quote(container)} --tail 100").read()  # noqa: S605
         return CmdCtl.success(
             t(zh_CN=f"容器日志: \n{logs}", en_US=f"Container logs: \n{logs}")
         )

--- a/nekro_agent/services/rpc_service.py
+++ b/nekro_agent/services/rpc_service.py
@@ -6,12 +6,15 @@ from pydantic import ValidationError as PydanticValidationError
 
 from nekro_agent.schemas.errors import ValidationError
 from nekro_agent.schemas.rpc import RPCRequest
+from nekro_agent.services.sandbox.rpc_pickle import restricted_pickle_loads
 
 
 def decode_rpc_request(raw_body: bytes) -> RPCRequest:
     try:
-        payload = pickle.loads(raw_body)
-    except (pickle.UnpicklingError, EOFError, AttributeError, ValueError) as e:
+        # 请求体来自不可信沙箱(执行 LLM 生成代码的环境),
+        # 必须使用白名单受限加载器,阻止 pickle gadget 导致的宿主 RCE
+        payload = restricted_pickle_loads(raw_body)
+    except (pickle.UnpicklingError, EOFError, AttributeError, ValueError, ImportError) as e:
         raise ValidationError(reason="RPC 请求格式错误") from e
     try:
         return RPCRequest.model_validate(payload)

--- a/nekro_agent/services/rpc_service.py
+++ b/nekro_agent/services/rpc_service.py
@@ -14,7 +14,7 @@ def decode_rpc_request(raw_body: bytes) -> RPCRequest:
         # 请求体来自不可信沙箱(执行 LLM 生成代码的环境),
         # 必须使用白名单受限加载器,阻止 pickle gadget 导致的宿主 RCE
         payload = restricted_pickle_loads(raw_body)
-    except (pickle.UnpicklingError, EOFError, AttributeError, ValueError, ImportError) as e:
+    except (pickle.UnpicklingError, EOFError, AttributeError, ValueError, ImportError, TypeError) as e:
         raise ValidationError(reason="RPC 请求格式错误") from e
     try:
         return RPCRequest.model_validate(payload)

--- a/nekro_agent/services/sandbox/rpc_pickle.py
+++ b/nekro_agent/services/sandbox/rpc_pickle.py
@@ -1,0 +1,56 @@
+"""RPC pickle 反序列化安全限制
+
+背景:
+`/ext/rpc_exec` 接收来自沙箱(执行 LLM 生成代码的不可信环境)的 pickle 请求体。
+pickle 反序列化任意类可导致宿主进程 RCE(如 `__reduce__` gadget)。
+
+方案:
+使用受限 Unpickler,仅放行基础内建类型与少量显式白名单标准库类型,
+其余任何 GLOBAL/STACK_GLOBAL 加载一律拒绝。
+"""
+
+import datetime
+import decimal
+import io
+import pickle
+from collections import OrderedDict, defaultdict, deque
+from pathlib import Path, PurePath
+from types import SimpleNamespace
+
+# 显式允许跨 pickle 边界的类(标准库、无副作用构造函数)
+_SAFE_CLASSES: dict[tuple[str, str], type] = {
+    ("builtins", "complex"): complex,
+    ("collections", "OrderedDict"): OrderedDict,
+    ("collections", "defaultdict"): defaultdict,
+    ("collections", "deque"): deque,
+    ("datetime", "datetime"): datetime.datetime,
+    ("datetime", "date"): datetime.date,
+    ("datetime", "timedelta"): datetime.timedelta,
+    ("datetime", "time"): datetime.time,
+    ("decimal", "Decimal"): decimal.Decimal,
+    ("pathlib", "Path"): Path,
+    ("pathlib", "PosixPath"): Path,
+    ("pathlib", "WindowsPath"): Path,
+    ("pathlib", "PurePath"): PurePath,
+    ("types", "SimpleNamespace"): SimpleNamespace,
+}
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    """拒绝加载任何不在白名单内的全局对象"""
+
+    def find_class(self, module: str, name: str):  # noqa: ANN201, D102
+        candidate = _SAFE_CLASSES.get((module, name))
+        if candidate is not None:
+            return candidate
+        raise pickle.UnpicklingError(f"forbidden global: {module}.{name}")
+
+    @classmethod
+    def loads(cls, data: bytes) -> object:
+        """反序列化 bytes,应用白名单限制"""
+        return cls(io.BytesIO(data)).load()
+
+
+def restricted_pickle_loads(data: bytes) -> object:
+    """安全的 pickle 反序列化入口(供 RPC 请求解码使用)"""
+    return RestrictedUnpickler.loads(data)

--- a/nekro_agent/services/sandbox/runner.py
+++ b/nekro_agent/services/sandbox/runner.py
@@ -230,10 +230,16 @@ async def run_code_in_sandbox(
                     "Memory": 512 * 1024 * 1024,  # 内存限制 (512MB)
                     "NanoCPUs": 1000000000,  # CPU 限制 (1 core)
                     "SecurityOpt": [
+                        # 行为矩阵(相对旧版的变更):
+                        # - RUN_IN_DOCKER=true:  旧 []            -> ["no-new-privileges"]
+                        # - RUN_IN_DOCKER=false: 旧 ["apparmor=unconfined"]
+                        #   -> 默认 ["no-new-privileges"];
+                        #      仅 NEKRO_SANDBOX_DISABLE_APPARMOR=true 时追加 apparmor=unconfined
+                        # 说明:沙箱以 nobody 用户运行、pip 使用 --target 安装,不依赖
+                        # setuid/setcap 提权,no-new-privileges 不影响既有功能;
+                        # 非本地宿主若被默认 AppArmor profile 拦截(旧版因此强制
+                        # unconfined),可通过上述环境变量恢复旧行为。
                         "no-new-privileges",  # 禁止提升权限
-                        # apparmor=unconfined 会完全关闭 AppArmor 隔离,
-                        # 仅在本地环境确实被 AppArmor 拦截时通过
-                        # NEKRO_SANDBOX_DISABLE_APPARMOR=true 显式开启
                         *(
                             ["apparmor=unconfined"]
                             if (not OsEnv.RUN_IN_DOCKER and OsEnv.SANDBOX_DISABLE_APPARMOR)

--- a/nekro_agent/services/sandbox/runner.py
+++ b/nekro_agent/services/sandbox/runner.py
@@ -229,14 +229,17 @@ async def run_code_in_sandbox(
                     ],
                     "Memory": 512 * 1024 * 1024,  # 内存限制 (512MB)
                     "NanoCPUs": 1000000000,  # CPU 限制 (1 core)
-                    "SecurityOpt": (
-                        []
-                        if OsEnv.RUN_IN_DOCKER
-                        else [
-                            # "no-new-privileges",  # 禁止提升权限
-                            "apparmor=unconfined",  # 禁止 AppArmor 配置
-                        ]
-                    ),
+                    "SecurityOpt": [
+                        "no-new-privileges",  # 禁止提升权限
+                        # apparmor=unconfined 会完全关闭 AppArmor 隔离,
+                        # 仅在本地环境确实被 AppArmor 拦截时通过
+                        # NEKRO_SANDBOX_DISABLE_APPARMOR=true 显式开启
+                        *(
+                            ["apparmor=unconfined"]
+                            if (not OsEnv.RUN_IN_DOCKER and OsEnv.SANDBOX_DISABLE_APPARMOR)
+                            else []
+                        ),
+                    ],
                     "NetworkMode": "bridge",
                     "ExtraHosts": ["host.docker.internal:host-gateway"],
                 },

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import difflib
 import hashlib
@@ -5,7 +6,6 @@ import ipaddress
 import mimetypes
 import random
 import re
-import socket
 from pathlib import Path
 from typing import Tuple
 from urllib.parse import urlparse
@@ -45,12 +45,26 @@ _SSRF_BLOCKED_NETWORKS = [
 ]
 
 
-def is_blocked_ssrf_url(url: str) -> bool:
+def _is_ip_blocked(ip_text: str) -> bool:
+    """判断单个 IP 是否落在被拒绝的保留地址段内"""
+    try:
+        ip = ipaddress.ip_address(ip_text)
+    except ValueError:
+        return True
+    return any(ip in network for network in _SSRF_BLOCKED_NETWORKS)
+
+
+async def is_blocked_ssrf_url(url: str) -> bool:
     """检查 URL 是否指向内网/环回/链路本地等敏感地址段
 
     用于在下载用户(或 LLM 生成代码)提供的文件前拦截 SSRF:
     阻止访问本机 API、内网 Postgres/Qdrant、云元数据服务等。
-    域名会做真实 DNS 解析后逐地址判断,拦截 DNS 重绑定的常见形式。
+
+    限制说明(调用方需知):
+    - 校验时与 httpx 实际连接时各自做一次 DNS 解析,理论存在重绑定
+      TOCTOU 窗口;当前 httpx 默认不跟随重定向,公网 302 → 内网的
+      绕径不可行。若未来开启 follow_redirects,需在传输层固定已校验 IP。
+    - DNS 解析通过事件循环的 getaddrinfo 执行,不阻塞其他协程。
     """
     try:
         parsed = urlparse(url)
@@ -62,14 +76,11 @@ def is_blocked_ssrf_url(url: str) -> bool:
     if not host:
         return True
     try:
-        addr_infos = socket.getaddrinfo(host, None)
+        loop = asyncio.get_running_loop()
+        addr_infos = await loop.getaddrinfo(host, None)
     except OSError:
         return True
-    for _, _, _, _, sockaddr in addr_infos:
-        ip = ipaddress.ip_address(sockaddr[0])
-        if any(ip in network for network in _SSRF_BLOCKED_NETWORKS):
-            return True
-    return False
+    return any(_is_ip_blocked(sockaddr[0]) for _, _, _, _, sockaddr in addr_infos)
 
 
 
@@ -149,7 +160,7 @@ async def download_file(
         Tuple[str, str]: 文件路径, 文件名
     """
 
-    if is_blocked_ssrf_url(url):
+    if await is_blocked_ssrf_url(url):
         logger.warning(f"已拦截指向内网/保留地址的下载请求: {limited_text_output(url)}")
         raise ValueError("不允许下载内网或保留地址的资源")
 

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -177,31 +177,30 @@ async def assert_safe_download_url(url: str) -> str:
 class _PinnedAsyncTransport(httpx.AsyncHTTPTransport):
     """把连接固定到已校验 IP 的传输层
 
-    防 DNS 重绑定:校验阶段解析的 IP 与实际连接的 IP 必须一致。
-    请求 URL 的主机部分改写为已校验 IP(连接目标固定),Host 头与
-    TLS SNI 保留为原始域名——SNI 来自 URL host,因此需要把原始
-    域名记入 transport 并在改写后还原 Host 头。
+    防 DNS 重绑定:TCP 连接目标固定为校验阶段解析的 IP,HTTP Host、
+    TLS SNI 与证书主机名校验仍使用原始 URL 的规范化域名。
     """
 
-    def __init__(self, pinned_ip: str, original_host: str, original_port: int | None = None):
+    def __init__(self, pinned_ip: str):
         super().__init__()
         self._pinned_ip = pinned_ip
-        self._original_host = original_host
-        self._original_port = original_port
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        original = request.url
-        pinned_url = original.copy_with(host=self._pinned_ip)
-        # Host 头保留原始域名(改写 URL 会连带改 Host)
-        if self._original_port and self._original_port not in (80, 443):
-            request.headers["Host"] = f"{self._original_host}:{self._original_port}"
-        else:
-            request.headers["Host"] = self._original_host
-        request.url = pinned_url
-        # 还原 URL 显示用的原始地址(不影响已生成的 headers/连接目标)
-        response = await super().handle_async_request(request)
-        request.url = original
-        return response
+        original_url = request.url
+        original_headers = request.headers
+        original_extensions = request.extensions
+        try:
+            request.url = original_url.copy_with(host=self._pinned_ip)
+            request.headers = original_headers.copy()
+            request.headers["Host"] = original_url.netloc.decode("ascii")
+            request.extensions = dict(original_extensions)
+            if original_url.scheme == "https":
+                request.extensions["sni_hostname"] = original_url.raw_host.decode("ascii")
+            return await super().handle_async_request(request)
+        finally:
+            request.url = original_url
+            request.headers = original_headers
+            request.extensions = original_extensions
 
 
 
@@ -296,12 +295,7 @@ async def download_file(
         # 跟随重定向并在每一跳重新校验+重新固定(默认上限 5 跳)
         current_url, redirects_done = url, 0
         while True:
-            parsed = urlparse(current_url)
-            transport = _PinnedAsyncTransport(
-                pinned_ip=pinned_ip,
-                original_host=parsed.hostname or "",
-                original_port=parsed.port,
-            )
+            transport = _PinnedAsyncTransport(pinned_ip=pinned_ip)
             async with httpx.AsyncClient(transport=transport, follow_redirects=False) as client:
                 response = await client.get(current_url)
             if response.is_redirect:

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -184,12 +184,12 @@ async def download_file(
 
     try:
         await assert_safe_download_url(url)
-    except UnsafeDownloadUrl as e:
-        # URL 本身不合法,重试无意义,直接返回用户级校验错误
-        raise ValueError(str(e)) from e
-    except BlockedDownloadAddress as e:
+    except UnsafeDownloadUrl:
+        # URL 本身不合法,重试无意义,直接抛出(ValueError 子类,向后兼容)
+        raise
+    except BlockedDownloadAddress:
         logger.warning(f"已拦截指向内网/保留地址的下载请求: {limited_text_output(url)}")
-        raise ValueError(str(e)) from e
+        raise
 
     try:
         async with httpx.AsyncClient() as client:

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -54,11 +54,28 @@ def _is_ip_blocked(ip_text: str) -> bool:
     return any(ip in network for network in _SSRF_BLOCKED_NETWORKS)
 
 
-async def is_blocked_ssrf_url(url: str) -> bool:
-    """检查 URL 是否指向内网/环回/链路本地等敏感地址段
+class UnsafeDownloadUrl(ValueError):
+    """URL 本身不合法(格式错误/协议不支持/域名无法解析)
+
+    与 BlockedDownloadAddress 区分:调用方可将本错误作为用户输入校验
+    问题处理(提示修改 URL),而不是安全拦截。
+    """
+
+
+class BlockedDownloadAddress(ValueError):
+    """URL 指向内网/环回/链路本地等保留地址,被 SSRF 防护拦截"""
+
+
+async def assert_safe_download_url(url: str) -> None:
+    """下载前校验 URL,不通过时抛出分类异常
 
     用于在下载用户(或 LLM 生成代码)提供的文件前拦截 SSRF:
     阻止访问本机 API、内网 Postgres/Qdrant、云元数据服务等。
+
+    异常分类:
+    - UnsafeDownloadUrl:URL 格式非法、协议不受支持或域名解析失败
+      (输入本身有问题,重试无意义)
+    - BlockedDownloadAddress:URL 指向保留地址段(安全拦截)
 
     限制说明(调用方需知):
     - 校验时与 httpx 实际连接时各自做一次 DNS 解析,理论存在重绑定
@@ -68,19 +85,24 @@ async def is_blocked_ssrf_url(url: str) -> bool:
     """
     try:
         parsed = urlparse(url)
-    except ValueError:
-        return True
+    except ValueError as e:
+        raise UnsafeDownloadUrl(f"URL 格式无效: {limited_text_output(url)}") from e
     if parsed.scheme not in ("http", "https"):
-        return True
+        raise UnsafeDownloadUrl(f"仅支持 http/https 协议: {limited_text_output(url)}")
     host = parsed.hostname
     if not host:
-        return True
+        raise UnsafeDownloadUrl(f"URL 缺少主机名: {limited_text_output(url)}")
     try:
         loop = asyncio.get_running_loop()
         addr_infos = await loop.getaddrinfo(host, None)
-    except OSError:
-        return True
-    return any(_is_ip_blocked(sockaddr[0]) for _, _, _, _, sockaddr in addr_infos)
+    except OSError as e:
+        raise UnsafeDownloadUrl(f"域名无法解析: {limited_text_output(host)}") from e
+    for _, _, _, _, sockaddr in addr_infos:
+        if _is_ip_blocked(sockaddr[0]):
+            raise BlockedDownloadAddress(
+                f"不允许下载内网或保留地址的资源: {limited_text_output(url)}"
+            )
+
 
 
 
@@ -160,9 +182,14 @@ async def download_file(
         Tuple[str, str]: 文件路径, 文件名
     """
 
-    if await is_blocked_ssrf_url(url):
+    try:
+        await assert_safe_download_url(url)
+    except UnsafeDownloadUrl as e:
+        # URL 本身不合法,重试无意义,直接返回用户级校验错误
+        raise ValueError(str(e)) from e
+    except BlockedDownloadAddress as e:
         logger.warning(f"已拦截指向内网/保留地址的下载请求: {limited_text_output(url)}")
-        raise ValueError("不允许下载内网或保留地址的资源")
+        raise ValueError(str(e)) from e
 
     try:
         async with httpx.AsyncClient() as client:

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -129,22 +129,23 @@ class BlockedDownloadAddress(ValueError):
     """URL 指向内网/环回/链路本地等保留地址,被 SSRF 防护拦截"""
 
 
-async def assert_safe_download_url(url: str) -> None:
-    """下载前校验 URL,不通过时抛出分类异常
+async def assert_safe_download_url(url: str) -> str:
+    """下载前校验 URL,返回通过校验的连接用 IP(用于固定连接)
 
     用于在下载用户(或 LLM 生成代码)提供的文件前拦截 SSRF:
     阻止访问本机 API、内网 Postgres/Qdrant、云元数据服务等。
 
+    返回值:已校验的 IP 文本。调用方应通过 _pinned_transport 把
+    实际连接固定到该 IP(保留原始 Host 头与 HTTPS SNI),否则校验
+    与连接之间的二次 DNS 解析会留下重绑定 TOCTOU 窗口。
+
     异常分类:
     - UnsafeDownloadUrl:URL 格式非法、协议不受支持或域名解析失败
       (输入本身有问题,重试无意义)
-    - BlockedDownloadAddress:URL 指向保留地址段(安全拦截)
+    - BlockedDownloadAddress:URL 指向保留地址段(安全拦截);
+      域名的任一 A/AAAA 记录命中保留段即整体拒绝
 
-    限制说明(调用方需知):
-    - 校验时与 httpx 实际连接时各自做一次 DNS 解析,理论存在重绑定
-      TOCTOU 窗口;当前 httpx 默认不跟随重定向,公网 302 → 内网的
-      绕径不可行。若未来开启 follow_redirects,需在传输层固定已校验 IP。
-    - DNS 解析通过事件循环的 getaddrinfo 执行,不阻塞其他协程。
+    DNS 解析通过事件循环的 getaddrinfo 执行,不阻塞其他协程。
     """
     try:
         parsed = urlparse(url)
@@ -160,11 +161,47 @@ async def assert_safe_download_url(url: str) -> None:
         addr_infos = await loop.getaddrinfo(host, None)
     except OSError as e:
         raise UnsafeDownloadUrl(f"域名无法解析: {limited_text_output(host)}") from e
+    resolved_ips: list[str] = []
     for _, _, _, _, sockaddr in addr_infos:
-        if _is_ip_blocked(sockaddr[0]):
+        ip_text = sockaddr[0]
+        if _is_ip_blocked(ip_text):
             raise BlockedDownloadAddress(
                 f"不允许下载内网或保留地址的资源: {limited_text_output(url)}"
             )
+        resolved_ips.append(ip_text)
+    if not resolved_ips:
+        raise UnsafeDownloadUrl(f"域名未解析到任何地址: {limited_text_output(host)}")
+    return resolved_ips[0]
+
+
+class _PinnedAsyncTransport(httpx.AsyncHTTPTransport):
+    """把连接固定到已校验 IP 的传输层
+
+    防 DNS 重绑定:校验阶段解析的 IP 与实际连接的 IP 必须一致。
+    请求 URL 的主机部分改写为已校验 IP(连接目标固定),Host 头与
+    TLS SNI 保留为原始域名——SNI 来自 URL host,因此需要把原始
+    域名记入 transport 并在改写后还原 Host 头。
+    """
+
+    def __init__(self, pinned_ip: str, original_host: str, original_port: int | None = None):
+        super().__init__()
+        self._pinned_ip = pinned_ip
+        self._original_host = original_host
+        self._original_port = original_port
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        original = request.url
+        pinned_url = original.copy_with(host=self._pinned_ip)
+        # Host 头保留原始域名(改写 URL 会连带改 Host)
+        if self._original_port and self._original_port not in (80, 443):
+            request.headers["Host"] = f"{self._original_host}:{self._original_port}"
+        else:
+            request.headers["Host"] = self._original_host
+        request.url = pinned_url
+        # 还原 URL 显示用的原始地址(不影响已生成的 headers/连接目标)
+        response = await super().handle_async_request(request)
+        request.url = original
+        return response
 
 
 
@@ -246,7 +283,7 @@ async def download_file(
     """
 
     try:
-        await assert_safe_download_url(url)
+        pinned_ip = await assert_safe_download_url(url)
     except UnsafeDownloadUrl:
         # URL 本身不合法,重试无意义,直接抛出(ValueError 子类,向后兼容)
         raise
@@ -255,8 +292,29 @@ async def download_file(
         raise
 
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url)
+        # 连接固定到已校验 IP,关闭校验-连接之间的 DNS 重绑定窗口;
+        # 跟随重定向并在每一跳重新校验+重新固定(默认上限 5 跳)
+        current_url, redirects_done = url, 0
+        while True:
+            parsed = urlparse(current_url)
+            transport = _PinnedAsyncTransport(
+                pinned_ip=pinned_ip,
+                original_host=parsed.hostname or "",
+                original_port=parsed.port,
+            )
+            async with httpx.AsyncClient(transport=transport, follow_redirects=False) as client:
+                response = await client.get(current_url)
+            if response.is_redirect:
+                redirects_done += 1
+                if redirects_done > 5:
+                    raise ValueError("重定向次数超过上限(5)")
+                next_url = str(response.headers["location"])
+                if not next_url.startswith(("http://", "https://")):
+                    next_url = str(httpx.URL(current_url).join(next_url))
+                # 每一跳重新执行完整校验(含保留段与 IPv6 编码检查)
+                pinned_ip = await assert_safe_download_url(next_url)
+                current_url = next_url
+                continue
             response.raise_for_status()
             content = response.content
             if not use_suffix:
@@ -272,6 +330,11 @@ async def download_file(
                 file_path = str(save_path)
             Path(file_path).write_bytes(content)
             Path(file_path).chmod(0o755)
+            break
+    except (UnsafeDownloadUrl, BlockedDownloadAddress):
+        # 安全校验异常不重试:重绑定攻击可利用 DNS 抖动让下一次解析
+        # 恰好返回公网地址,重试等于放行;直接上抛
+        raise
     except Exception:
         if retry_count > 0:
             return await download_file(

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -4,6 +4,7 @@ import difflib
 import hashlib
 import ipaddress
 import mimetypes
+import os
 import random
 import re
 from pathlib import Path
@@ -38,20 +39,82 @@ _SSRF_BLOCKED_NETWORKS = [
         "198.18.0.0/15",
         "224.0.0.0/4",
         "240.0.0.0/4",
-        "::1/128",
-        "fc00::/7",
-        "fe80::/10",
+        # IPv4-mapped(::ffff:0:0/96)与 NAT64(64:ff9b::/96)不整体封禁:
+        # 由 _candidate_ips 解出内嵌 IPv4 后按上述 IPv4 段判断,
+        # 保证编码公网地址(如 ::ffff:8.8.8.8)仍可正常放行
+        "::/127",  # 含 ::(未指定)与 ::1(环回)
+        "100::/64",  # 丢弃前缀
+        "2001:db8::/32",  # 文档示例段
+        "fc00::/7",  # ULA
+        "fe80::/10",  # 链路本地
     )
 ]
 
 
-def _is_ip_blocked(ip_text: str) -> bool:
-    """判断单个 IP 是否落在被拒绝的保留地址段内"""
+def _candidate_ips(ip_text: str) -> list[str]:
+    """展开一个地址文本为需逐一检查的等价地址列表
+
+    IPv6 的多种形式可编码可达 IPv4 的目标:
+    - ::ffff:127.0.0.1(IPv4-mapped)
+    - 64:ff9b::127.0.0.1(NAT64)
+    - 2002:7f00:1::(6to4,内嵌任意 IPv4)
+    全部解出后与原始形式一起比对,阻断经 IPv6 记法绕过 IPv4 封锁。
+    """
     try:
         ip = ipaddress.ip_address(ip_text)
     except ValueError:
+        return [ip_text]
+    candidates = [ip]
+    if isinstance(ip, ipaddress.IPv6Address):
+        if ip.ipv4_mapped:
+            candidates.append(ip.ipv4_mapped)
+        sixtofour = ip.sixtofour
+        if sixtofour:
+            candidates.append(sixtofour)
+        teredo = ip.teredo
+        if teredo:
+            # teredo 返回 (server, client);client 才是实际通信对端
+            candidates.append(teredo[1])
+        if ip in ipaddress.ip_network("64:ff9b::/96"):
+            # NAT64(Well-Known Prefix):低 32 位即被编码的 IPv4,
+            # ipaddress 不自动解出,需手动提取
+            candidates.append(ipaddress.ip_address(int(ip) & 0xFFFFFFFF))
+    return [str(c) for c in candidates]
+
+
+def _extra_blocked_networks() -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    """读取运维追加的封锁网段(NEKRO_SSRF_EXTRA_BLOCKED_CIDRS)
+
+    逗号分隔的 CIDR 列表,如 "172.20.0.0/16,fd00::/8"。
+    仅支持追加:内置网段不可通过配置移除——若允许"放宽",
+    能写配置的人(或诱导修改配置的攻击者)即可解除防护。
+    非法条目记日志跳过,不影响其余条目生效。
+    """
+    raw = os.environ.get("NEKRO_SSRF_EXTRA_BLOCKED_CIDRS", "")
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(item, strict=False))
+        except ValueError:
+            logger.warning(f"NEKRO_SSRF_EXTRA_BLOCKED_CIDRS 中的非法 CIDR 已忽略: {item}")
+    return networks
+
+
+def _is_ip_blocked(ip_text: str) -> bool:
+    """判断地址(含 IPv6 编码的 IPv4 等价形式)是否落在被拒绝的保留地址段内"""
+    try:
+        for candidate in _candidate_ips(ip_text):
+            ip = ipaddress.ip_address(candidate)
+            if any(ip in network for network in _SSRF_BLOCKED_NETWORKS):
+                return True
+            if any(ip in network for network in _extra_blocked_networks()):
+                return True
+        return False
+    except ValueError:
         return True
-    return any(ip in network for network in _SSRF_BLOCKED_NETWORKS)
 
 
 class UnsafeDownloadUrl(ValueError):

--- a/nekro_agent/tools/common_util.py
+++ b/nekro_agent/tools/common_util.py
@@ -1,11 +1,14 @@
 import base64
 import difflib
 import hashlib
+import ipaddress
 import mimetypes
 import random
 import re
+import socket
 from pathlib import Path
 from typing import Tuple
+from urllib.parse import urlparse
 
 import aiofiles
 import httpx
@@ -19,6 +22,55 @@ from nekro_agent.core.os_env import USER_UPLOAD_DIR
 from nekro_agent.tools.path_convertor import is_url_path, sanitize_chat_key_for_path
 
 _APP_VERSION: str = ""
+
+# 解析 URL 主机名后拒绝的地址段(环回/内网/链路本地/云元数据等)
+_SSRF_BLOCKED_NETWORKS = [
+    ipaddress.ip_network(n)
+    for n in (
+        "0.0.0.0/8",
+        "10.0.0.0/8",
+        "100.64.0.0/10",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "172.16.0.0/12",
+        "192.0.0.0/24",
+        "192.168.0.0/16",
+        "198.18.0.0/15",
+        "224.0.0.0/4",
+        "240.0.0.0/4",
+        "::1/128",
+        "fc00::/7",
+        "fe80::/10",
+    )
+]
+
+
+def is_blocked_ssrf_url(url: str) -> bool:
+    """检查 URL 是否指向内网/环回/链路本地等敏感地址段
+
+    用于在下载用户(或 LLM 生成代码)提供的文件前拦截 SSRF:
+    阻止访问本机 API、内网 Postgres/Qdrant、云元数据服务等。
+    域名会做真实 DNS 解析后逐地址判断,拦截 DNS 重绑定的常见形式。
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return True
+    if parsed.scheme not in ("http", "https"):
+        return True
+    host = parsed.hostname
+    if not host:
+        return True
+    try:
+        addr_infos = socket.getaddrinfo(host, None)
+    except OSError:
+        return True
+    for _, _, _, _, sockaddr in addr_infos:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if any(ip in network for network in _SSRF_BLOCKED_NETWORKS):
+            return True
+    return False
+
 
 
 def get_app_version() -> str:
@@ -96,6 +148,10 @@ async def download_file(
     Returns:
         Tuple[str, str]: 文件路径, 文件名
     """
+
+    if is_blocked_ssrf_url(url):
+        logger.warning(f"已拦截指向内网/保留地址的下载请求: {limited_text_output(url)}")
+        raise ValueError("不允许下载内网或保留地址的资源")
 
     try:
         async with httpx.AsyncClient() as client:

--- a/tests/test_rpc_body_limit.py
+++ b/tests/test_rpc_body_limit.py
@@ -1,0 +1,155 @@
+"""RPC 请求体增量大小限制测试"""
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from starlette.requests import ClientDisconnect
+
+from nekro_agent.core.exception_handlers import register_exception_handlers
+from nekro_agent.routers.rpc import _read_request_body_limited
+from nekro_agent.schemas.errors import PayloadTooLargeError, ValidationError
+
+
+def _make_request(
+    chunks: list[bytes],
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> tuple[Request, dict[str, int]]:
+    messages = [
+        {"type": "http.request", "body": chunk, "more_body": index < len(chunks) - 1}
+        for index, chunk in enumerate(chunks)
+    ] or [{"type": "http.request", "body": b"", "more_body": False}]
+    calls = {"receive": 0}
+
+    async def receive() -> dict[str, Any]:
+        calls["receive"] += 1
+        if messages:
+            return messages.pop(0)
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": headers or [],
+        "client": ("127.0.0.1", 1234),
+        "server": ("testserver", 80),
+    }
+    return Request(scope, receive), calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [b"", b"abcd", b"abcde"])
+async def test_limited_body_accepts_up_to_limit(body: bytes):
+    request, _ = _make_request([body])
+    assert await _read_request_body_limited(request, 5) == body
+
+
+@pytest.mark.asyncio
+async def test_limited_body_accepts_exact_limit_across_chunks():
+    request, calls = _make_request([b"ab", b"cde"])
+    assert await _read_request_body_limited(request, 5) == b"abcde"
+    assert calls["receive"] == 2
+
+
+@pytest.mark.asyncio
+async def test_limited_body_stops_at_first_oversized_chunk():
+    request, calls = _make_request([b"abcde", b"x", b"tail"])
+    with pytest.raises(PayloadTooLargeError):
+        await _read_request_body_limited(request, 5)
+    assert calls["receive"] == 2
+
+
+@pytest.mark.asyncio
+async def test_content_length_over_limit_rejected_before_reading():
+    request, calls = _make_request([b"unused"], [(b"content-length", b"6")])
+    with pytest.raises(PayloadTooLargeError):
+        await _read_request_body_limited(request, 5)
+    assert calls["receive"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("declared", [None, b"1", b"5"])
+async def test_stream_limit_is_enforced_when_content_length_is_missing_or_small(declared: bytes | None):
+    headers = [] if declared is None else [(b"content-length", declared)]
+    request, _ = _make_request([b"abc", b"def"], headers)
+    with pytest.raises(PayloadTooLargeError):
+        await _read_request_body_limited(request, 5)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [b"", b"-1", b"+5", b"5.0", b"abc", b"5, 5"])
+async def test_malformed_content_length_rejected_before_reading(value: bytes):
+    request, calls = _make_request([b"unused"], [(b"content-length", value)])
+    with pytest.raises(ValidationError, match="Content-Length"):
+        await _read_request_body_limited(request, 5)
+    assert calls["receive"] == 0
+
+
+@pytest.mark.asyncio
+async def test_duplicate_content_length_rejected_before_reading():
+    request, calls = _make_request(
+        [b"unused"],
+        [(b"content-length", b"5"), (b"content-length", b"5")],
+    )
+    with pytest.raises(ValidationError, match="Content-Length"):
+        await _read_request_body_limited(request, 5)
+    assert calls["receive"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [0, -1])
+async def test_nonpositive_limit_rejected_before_reading(limit: int):
+    request, calls = _make_request([b"unused"])
+    with pytest.raises(ValueError, match="NEKRO_RPC_MAX_BODY_BYTES"):
+        await _read_request_body_limited(request, limit)
+    assert calls["receive"] == 0
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_is_not_relabelled_as_oversize():
+    async def receive() -> dict[str, str]:
+        return {"type": "http.disconnect"}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/",
+            "raw_path": b"/",
+            "query_string": b"",
+            "headers": [],
+        },
+        receive,
+    )
+    with pytest.raises(ClientDisconnect):
+        await _read_request_body_limited(request, 5)
+
+
+@pytest.mark.asyncio
+async def test_http_endpoint_returns_413_for_chunked_oversize():
+    app = FastAPI()
+    register_exception_handlers(app)
+
+    @app.post("/rpc-body")
+    async def rpc_body(request: Request):
+        return {"body": (await _read_request_body_limited(request, 5)).decode()}
+
+    async def content() -> AsyncIterator[bytes]:
+        yield b"abc"
+        yield b"def"
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post("/rpc-body", content=content())
+
+    assert response.status_code == 413
+    assert response.json()["error"] == "PayloadTooLargeError"

--- a/tests/test_rpc_pickle_security.py
+++ b/tests/test_rpc_pickle_security.py
@@ -1,0 +1,62 @@
+"""RPC pickle 反序列化安全测试
+
+对应 PR 安全修复: /ext/rpc_exec 的请求解码使用白名单 RestrictedUnpickler,
+阻止来自不可信沙箱的 pickle gadget 导致宿主 RCE。
+"""
+
+import pickle
+
+import pytest
+
+from nekro_agent.services.sandbox.rpc_pickle import restricted_pickle_loads
+
+
+class _RceGadget:
+    """经典 __reduce__ 反序列化 gadget(写标记文件作为 RCE 证据)"""
+
+    def __reduce__(self):
+        import os
+
+        return (os.system, ("touch /tmp/nekro_rpc_pickle_rce_marker",))
+
+
+def test_normal_rpc_payload_passes():
+    """与沙箱 ext_caller_code.py 构造方式一致的正常请求应正常解码"""
+    payload = pickle.dumps({"method": "send_msg_text", "args": ["chat", "hi"], "kwargs": {}})
+    obj = restricted_pickle_loads(payload)
+    assert obj["method"] == "send_msg_text"
+    assert obj["args"] == ["chat", "hi"]
+
+
+def test_reduce_gadget_rejected():
+    """__reduce__ gadget(以 os.system 为例)必须被拒绝且不执行"""
+    with pytest.raises(pickle.UnpicklingError):
+        restricted_pickle_loads(pickle.dumps(_RceGadget()))
+
+
+@pytest.mark.parametrize(
+    ("opcode_payload", "label"),
+    [
+        # SHORT_BINUNICODE + STACK_GLOBAL 引用 posix.system
+        (b"\x80\x04\x8c\x05posix\x94\x8c\x06system\x94\x93\x94.", "posix.system"),
+        # 引用 subprocess.Popen
+        (b"\x80\x04\x8c\tsubprocess\x94\x8c\x06Popen\x94\x93\x94.", "subprocess.Popen"),
+        # 引用 builtins.eval(非白名单内建)
+        (b"\x80\x04\x8c\x08builtins\x94\x8c\x04eval\x94\x93\x94.", "builtins.eval"),
+    ],
+)
+def test_global_opcode_references_rejected(opcode_payload: bytes, label: str):
+    """手工 opcode 注入的任意 GLOBAL 引用必须被拒绝"""
+    with pytest.raises(pickle.UnpicklingError):
+        restricted_pickle_loads(opcode_payload)
+
+
+def test_whitelisted_stdlib_types_pass():
+    """白名单内的标准库类型应正常往返"""
+    import datetime
+    from collections import OrderedDict
+
+    payload = pickle.dumps({"ts": datetime.datetime(2026, 8, 17, 0, 0, 0), "od": OrderedDict([("a", 1)])})
+    obj = restricted_pickle_loads(payload)
+    assert obj["ts"] == datetime.datetime(2026, 8, 17)
+    assert obj["od"] == OrderedDict([("a", 1)])

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -1,0 +1,102 @@
+"""下载 URL SSRF 防护测试
+
+对应 PR 安全修复: download_file 下载前校验 URL,
+阻断环回/内网/链路本地/云元数据及 IPv6 编码形式(ipv4-mapped/6to4/NAT64/Teredo)的绕过。
+"""
+
+import ipaddress
+
+import pytest
+
+from nekro_agent.tools.common_util import (
+    BlockedDownloadAddress,
+    UnsafeDownloadUrl,
+    _candidate_ips,
+    _is_ip_blocked,
+    assert_safe_download_url,
+)
+
+
+@pytest.mark.parametrize(
+    ("ip_text", "expect_blocked", "label"),
+    [
+        # 常规 IPv4 保留段
+        ("127.0.0.1", True, "环回"),
+        ("10.0.0.5", True, "RFC1918 10/8"),
+        ("172.16.0.1", True, "RFC1918 172.16/12"),
+        ("192.168.1.1", True, "RFC1918 192.168/16"),
+        ("169.254.169.254", True, "云元数据"),
+        ("100.64.0.1", True, "CGNAT"),
+        # IPv4-mapped IPv6(曾可绕过的 PoC)
+        ("::ffff:127.0.0.1", True, "IPv4-mapped 环回"),
+        ("::ffff:10.0.0.5", True, "IPv4-mapped 内网"),
+        ("::ffff:169.254.169.254", True, "IPv4-mapped 云元数据"),
+        # 6to4 内嵌 IPv4
+        ("2002:7f00:1::", True, "6to4 编码 127.0.0.1"),
+        ("2002:0a00:0005::", True, "6to4 编码 10.0.0.5"),
+        # NAT64(Well-Known Prefix)编码 IPv4
+        ("64:ff9b::7f00:1", True, "NAT64 编码 127.0.0.1"),
+        ("64:ff9b::a00:2", True, "NAT64 编码 10.0.2"),
+        # 其他 IPv6 保留段
+        ("::1", True, "IPv6 环回"),
+        ("::", True, "未指定地址"),
+        ("fe80::1", True, "链路本地"),
+        ("fd12::1", True, "ULA"),
+        # 公网地址不应误伤(编码形式的公网同样放行)
+        ("8.8.8.8", False, "公网 IPv4"),
+        ("1.1.1.1", False, "公网 IPv4"),
+        ("::ffff:8.8.8.8", False, "IPv4-mapped 公网"),
+        ("2002:808:808::", False, "6to4 编码公网 8.8.8.8"),
+        ("64:ff9b::808:808", False, "NAT64 编码公网"),
+        ("2606:4700::1111", False, "公网 IPv6"),
+        # 非法输入按拦截处理(fail-closed)
+        ("not-an-ip", True, "非法输入"),
+    ],
+)
+def test_is_ip_blocked_matrix(ip_text: str, expect_blocked: bool, label: str):
+    assert _is_ip_blocked(ip_text) is expect_blocked, label
+
+
+def test_candidate_ips_expands_nat64():
+    """ipaddress 不自动解码 NAT64,防护需手动展开低 32 位"""
+    candidates = _candidate_ips("64:ff9b::7f00:1")
+    assert "127.0.0.1" in candidates
+
+
+def test_candidate_ips_expands_ipv4_mapped():
+    candidates = _candidate_ips("::ffff:127.0.0.1")
+    assert "127.0.0.1" in candidates
+
+
+@pytest.mark.asyncio
+async def test_assert_safe_url_blocks_internal():
+    """URL 层面:字面量内网地址应被分类拦截(字面量解析不依赖网络)"""
+    with pytest.raises(BlockedDownloadAddress):
+        await assert_safe_download_url("http://127.0.0.1:8021/api/health")
+    with pytest.raises(BlockedDownloadAddress):
+        await assert_safe_download_url("http://[::ffff:169.254.169.254]/latest/meta-data")
+
+
+@pytest.mark.asyncio
+async def test_assert_safe_url_classifies_malformed():
+    """URL 层面:格式/协议问题应归类为 UnsafeDownloadUrl 而非安全拦截"""
+    with pytest.raises(UnsafeDownloadUrl):
+        await assert_safe_download_url("ftp://example.com/x")
+    with pytest.raises(UnsafeDownloadUrl):
+        await assert_safe_download_url("not-a-url")
+
+
+def test_extra_blocked_cidrs_append_only(monkeypatch: pytest.MonkeyPatch):
+    """NEKRO_SSRF_EXTRA_BLOCKED_CIDRS 仅追加网段,不影响内置与对照段"""
+    monkeypatch.setenv("NEKRO_SSRF_EXTRA_BLOCKED_CIDRS", "172.20.0.0/16, garbage@@, fd99::/8")
+    assert _is_ip_blocked("172.20.1.1") is True  # 追加段生效
+    assert _is_ip_blocked("fd99::1") is True  # 追加 IPv6 段生效
+    assert _is_ip_blocked("203.0.114.1") is False  # 未涉及的公网段不受影响
+    assert _is_ip_blocked("127.0.0.1") is True  # 内置段不受影响
+
+
+def test_blocked_networks_parse():
+    """内置网段常量本身可被 ipaddress 解析(防止笔误引入失效条目)"""
+    from nekro_agent.tools.common_util import _SSRF_BLOCKED_NETWORKS
+
+    assert all(isinstance(n, (ipaddress.IPv4Network, ipaddress.IPv6Network)) for n in _SSRF_BLOCKED_NETWORKS)

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -114,49 +114,110 @@ async def test_assert_safe_url_returns_pinned_ip():
 
 
 @pytest.mark.asyncio
-async def test_download_pins_connection_and_revalidates_redirects(monkeypatch: pytest.MonkeyPatch, tmp_path):
-    """重绑定防护:校验后连接必须固定到首次解析的 IP;重定向每跳重新校验
-
-    模拟攻击:DNS 交替返回公网/内网地址——任何"连接时重新解析"或
-    "重定向跳过校验"的实现都会命中内网目标。
-    """
+@pytest.mark.parametrize(
+    ("url", "pinned_ip", "expected_host", "expected_sni"),
+    [
+        ("https://example.com/path", "93.184.216.34", "example.com", "example.com"),
+        ("https://example.com:8443/path", "93.184.216.34", "example.com:8443", "example.com"),
+        ("http://example.com:443/path", "93.184.216.34", "example.com:443", None),
+        (
+            "https://[2606:4700::1111]:8443/path",
+            "2606:4700::1111",
+            "[2606:4700::1111]:8443",
+            "2606:4700::1111",
+        ),
+    ],
+)
+async def test_pinned_transport_preserves_authority_and_sni(
+    monkeypatch: pytest.MonkeyPatch,
+    url: str,
+    pinned_ip: str,
+    expected_host: str,
+    expected_sni: str | None,
+):
     import httpx
 
     import nekro_agent.tools.common_util as cu
 
-    PUBLIC = "93.184.216.34"
-    calls = {"dns": 0, "connect_hosts": []}
+    captured: dict[str, object] = {}
 
-    async def rebinding_getaddrinfo(host, port=None, **kw):
+    async def capture_transport(_transport, request: httpx.Request) -> httpx.Response:
+        captured.update(
+            url_host=request.url.host,
+            host=request.headers["Host"],
+            sni=request.extensions.get("sni_hostname"),
+        )
+        return httpx.Response(200, content=b"ok", request=request)
+
+    monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", capture_transport)
+    request = httpx.Request("GET", url, headers={"Host": "attacker.invalid"}, extensions={"trace": "keep"})
+    original_url = request.url
+    original_headers = request.headers
+    original_extensions = request.extensions
+    transport = cu._PinnedAsyncTransport(pinned_ip)
+
+    response = await transport.handle_async_request(request)
+
+    assert response.status_code == 200
+    assert captured == {"url_host": pinned_ip, "host": expected_host, "sni": expected_sni}
+    assert request.url is original_url
+    assert request.headers is original_headers
+    assert request.headers["Host"] == "attacker.invalid"
+    assert request.extensions is original_extensions
+    assert request.extensions == {"trace": "keep"}
+
+
+@pytest.mark.asyncio
+async def test_pinned_transport_restores_request_after_error(monkeypatch: pytest.MonkeyPatch):
+    import httpx
+
+    import nekro_agent.tools.common_util as cu
+
+    async def fail_transport(_transport, _request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("test failure")
+
+    monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", fail_transport)
+    request = httpx.Request("GET", "https://example.com/path", extensions={"trace": "keep"})
+    original_url = request.url
+    original_headers = request.headers
+    original_extensions = request.extensions
+    transport = cu._PinnedAsyncTransport("93.184.216.34")
+
+    with pytest.raises(httpx.ConnectError, match="test failure"):
+        await transport.handle_async_request(request)
+
+    assert request.url is original_url
+    assert request.headers is original_headers
+    assert request.extensions is original_extensions
+    assert "sni_hostname" not in request.extensions
+
+
+@pytest.mark.asyncio
+async def test_download_pins_connection_and_revalidates_redirects(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """连接固定到首次解析的 IP,重定向目标在连接前重新校验"""
+    import httpx
+
+    import nekro_agent.tools.common_util as cu
+
+    public_ip = "93.184.216.34"
+    calls: dict[str, object] = {"dns": 0, "connect_hosts": [], "host_headers": []}
+
+    async def rebinding_getaddrinfo(host, port=None, **_kwargs):
         calls["dns"] += 1
-        ip = PUBLIC if calls["dns"] % 2 == 1 else "127.0.0.1"
+        ip = public_ip if calls["dns"] % 2 == 1 else "127.0.0.1"
         return [(0, 2, 6, "", (ip, port))]
 
-    class RecordingTransport(cu._PinnedAsyncTransport):
-        """保留连接固定改写逻辑,在改写后、真实连接前记录目标并伪造响应"""
+    async def recording_transport(_transport, request: httpx.Request) -> httpx.Response:
+        calls["connect_hosts"].append(str(request.url.host))
+        calls["host_headers"].append(request.headers["Host"])
+        return httpx.Response(
+            302,
+            headers={"location": "http://internal.rebind.example/x"},
+            content=b"",
+            request=request,
+        )
 
-        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-            # super 的默认实现会真实连网;这里直接在改写完成点拦截:
-            # 复制父类改写逻辑(与实现保持一致),然后记录并返回伪造响应
-            original = request.url
-            pinned_url = original.copy_with(host=self._pinned_ip)
-            if self._original_port and self._original_port not in (80, 443):
-                request.headers["Host"] = f"{self._original_host}:{self._original_port}"
-            else:
-                request.headers["Host"] = self._original_host
-            request.url = pinned_url
-            calls["connect_hosts"].append(str(request.url.host))
-            calls.setdefault("host_headers", []).append(request.headers.get("Host", ""))
-            if len(calls["connect_hosts"]) == 1:
-                # 第一跳 302 -> 指向内网名(第二跳解析返回 127.0.0.1,必须被拒)
-                return httpx.Response(
-                    302, headers={"location": "http://internal.rebind.example/x"}, request=request
-                )
-            return httpx.Response(200, content=b"should-never-reach", request=request)
-
-    # 正常构造子类(保留 httpx 内部状态),仅拦截在连接之前
-    monkeypatch.setattr(cu, "_PinnedAsyncTransport", RecordingTransport)
-    # patch 运行中事件循环的 getaddrinfo(download_file 的解析入口)
+    monkeypatch.setattr(httpx.AsyncHTTPTransport, "handle_async_request", recording_transport)
     loop = asyncio.get_running_loop()
     monkeypatch.setattr(loop, "getaddrinfo", rebinding_getaddrinfo)
 
@@ -167,8 +228,6 @@ async def test_download_pins_connection_and_revalidates_redirects(monkeypatch: p
             file_name="out.bin",
         )
 
-    # 第一跳连接固定在校验过的公网 IP;第二跳在校验层被拒,未发起连接
-    assert calls["connect_hosts"] == [PUBLIC], (
-        f"连接目标必须是已校验 IP: {calls['connect_hosts']}"
-    )
-    assert calls["dns"] == 2  # 每跳各一次校验解析,连接阶段不再解析
+    assert calls["connect_hosts"] == [public_ip]
+    assert calls["host_headers"] == ["first.rebind.example"]
+    assert calls["dns"] == 2

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -4,6 +4,7 @@
 阻断环回/内网/链路本地/云元数据及 IPv6 编码形式(ipv4-mapped/6to4/NAT64/Teredo)的绕过。
 """
 
+import asyncio
 import ipaddress
 
 import pytest
@@ -100,3 +101,74 @@ def test_blocked_networks_parse():
     from nekro_agent.tools.common_util import _SSRF_BLOCKED_NETWORKS
 
     assert all(isinstance(n, (ipaddress.IPv4Network, ipaddress.IPv6Network)) for n in _SSRF_BLOCKED_NETWORKS)
+
+
+# ===================== DNS 重绑定:连接固定 =====================
+
+
+@pytest.mark.asyncio
+async def test_assert_safe_url_returns_pinned_ip():
+    """校验函数返回可用于连接固定的已校验 IP"""
+    pinned = await assert_safe_download_url("http://one.one.one.one/x")
+    ipaddress.ip_address(pinned)  # 返回值必须是合法 IP 文本
+
+
+@pytest.mark.asyncio
+async def test_download_pins_connection_and_revalidates_redirects(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """重绑定防护:校验后连接必须固定到首次解析的 IP;重定向每跳重新校验
+
+    模拟攻击:DNS 交替返回公网/内网地址——任何"连接时重新解析"或
+    "重定向跳过校验"的实现都会命中内网目标。
+    """
+    import httpx
+
+    import nekro_agent.tools.common_util as cu
+
+    PUBLIC = "93.184.216.34"
+    calls = {"dns": 0, "connect_hosts": []}
+
+    async def rebinding_getaddrinfo(host, port=None, **kw):
+        calls["dns"] += 1
+        ip = PUBLIC if calls["dns"] % 2 == 1 else "127.0.0.1"
+        return [(0, 2, 6, "", (ip, port))]
+
+    class RecordingTransport(cu._PinnedAsyncTransport):
+        """保留连接固定改写逻辑,在改写后、真实连接前记录目标并伪造响应"""
+
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            # super 的默认实现会真实连网;这里直接在改写完成点拦截:
+            # 复制父类改写逻辑(与实现保持一致),然后记录并返回伪造响应
+            original = request.url
+            pinned_url = original.copy_with(host=self._pinned_ip)
+            if self._original_port and self._original_port not in (80, 443):
+                request.headers["Host"] = f"{self._original_host}:{self._original_port}"
+            else:
+                request.headers["Host"] = self._original_host
+            request.url = pinned_url
+            calls["connect_hosts"].append(str(request.url.host))
+            calls.setdefault("host_headers", []).append(request.headers.get("Host", ""))
+            if len(calls["connect_hosts"]) == 1:
+                # 第一跳 302 -> 指向内网名(第二跳解析返回 127.0.0.1,必须被拒)
+                return httpx.Response(
+                    302, headers={"location": "http://internal.rebind.example/x"}, request=request
+                )
+            return httpx.Response(200, content=b"should-never-reach", request=request)
+
+    # 正常构造子类(保留 httpx 内部状态),仅拦截在连接之前
+    monkeypatch.setattr(cu, "_PinnedAsyncTransport", RecordingTransport)
+    # patch 运行中事件循环的 getaddrinfo(download_file 的解析入口)
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "getaddrinfo", rebinding_getaddrinfo)
+
+    with pytest.raises(BlockedDownloadAddress):
+        await cu.download_file(
+            "http://first.rebind.example/x",
+            file_path=str(tmp_path / "out.bin"),
+            file_name="out.bin",
+        )
+
+    # 第一跳连接固定在校验过的公网 IP;第二跳在校验层被拒,未发起连接
+    assert calls["connect_hosts"] == [PUBLIC], (
+        f"连接目标必须是已校验 IP: {calls['connect_hosts']}"
+    )
+    assert calls["dns"] == 2  # 每跳各一次校验解析,连接阶段不再解析

--- a/tests/test_web_chat_mcp_client.py
+++ b/tests/test_web_chat_mcp_client.py
@@ -10,10 +10,10 @@ import pytest
 from nekro_agent.core import auto_inject_mcp
 from nekro_agent.services.mcp import web_chat_auth
 from nekro_agent.services.mcp.registry import get_registry
-from nekro_agent.services.user.role import Role
-from nekro_agent.services.workspace.manager import _build_disk_mcp_config
 from nekro_agent.services.mcp.web_chat_mcp.na_app import AuthenticatedMcpApp
 from nekro_agent.services.mcp.web_chat_mcp.service import ChatMessageItem, WebChatMcpService
+from nekro_agent.services.user.role import Role
+from nekro_agent.services.workspace.manager import _build_disk_mcp_config
 
 
 @pytest.mark.asyncio

--- a/tests/test_webhook_auth_and_cors.py
+++ b/tests/test_webhook_auth_and_cors.py
@@ -4,7 +4,6 @@ import pytest
 
 from nekro_agent.core.cors_origins import parse_cors_origins
 
-
 # ===================== CORS =====================
 
 

--- a/tests/test_webhook_auth_and_cors.py
+++ b/tests/test_webhook_auth_and_cors.py
@@ -1,0 +1,103 @@
+"""Webhook 鉴权(fail-closed)与 CORS 来源严格解析测试"""
+
+import pytest
+
+from nekro_agent.core.cors_origins import parse_cors_origins
+
+
+# ===================== CORS =====================
+
+
+def test_cors_accepts_valid_origins():
+    assert parse_cors_origins("http://127.0.0.1:8021, https://na.example.com") == [
+        "http://127.0.0.1:8021",
+        "https://na.example.com",
+    ]
+
+
+def test_cors_empty_means_disabled():
+    assert parse_cors_origins("") == []
+    assert parse_cors_origins(" , ") == []
+
+
+@pytest.mark.parametrize("bad", ["*", " *, ", "http://a.com,*", "  *  "])
+def test_cors_rejects_wildcard(bad: str):
+    """通配符任何形式都必须在启动阶段拒绝(CWE-942 反射风险)"""
+    with pytest.raises(ValueError, match="通配符"):
+        parse_cors_origins(bad)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "ftp://a.com",  # 协议
+        "a.com",  # 缺 scheme
+        "http://user:pass@a.com",  # 用户信息
+        "http://a.com/path",  # 路径
+        "http://a.com/?q=1",  # 查询
+        "http://a.com#frag",  # 片段
+        "http://",  # 缺主机
+    ],
+)
+def test_cors_rejects_malformed_origins(bad: str):
+    with pytest.raises(ValueError, match="非法 Origin"):
+        parse_cors_origins(bad)
+
+
+# ===================== Webhook =====================
+
+
+class _FakeRequest:
+    def __init__(self, headers: dict[str, str] | None = None, query: dict[str, str] | None = None):
+        self.headers = headers or {}
+        self.query_params = query or {}
+
+
+@pytest.fixture()
+def _reset_env(monkeypatch: pytest.MonkeyPatch):
+    """OsEnv 为类属性(导入时求值),直接还原属性而非环境变量"""
+    from nekro_agent.core.os_env import OsEnv
+
+    monkeypatch.setattr(OsEnv, "WEBHOOK_SECRET_KEY", "")
+    monkeypatch.setattr(OsEnv, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False)
+
+
+def test_webhook_default_is_fail_closed(_reset_env):
+    """默认(未配密钥、未开逃生开关)必须拒绝,而不是放行"""
+    from nekro_agent.routers.webhook import _verify_webhook_token
+    from nekro_agent.schemas.errors import UnauthorizedError
+
+    with pytest.raises(UnauthorizedError):
+        _verify_webhook_token(_FakeRequest())
+
+
+def test_webhook_escape_hatch_opt_in(_reset_env, monkeypatch: pytest.MonkeyPatch):
+    from nekro_agent.core.os_env import OsEnv
+    from nekro_agent.routers.webhook import _verify_webhook_token
+
+    monkeypatch.setattr(OsEnv, "ALLOW_UNAUTHENTICATED_WEBHOOKS", True)
+    _verify_webhook_token(_FakeRequest())  # 显式逃生开关才放行
+
+
+def test_webhook_requires_matching_header(_reset_env, monkeypatch: pytest.MonkeyPatch):
+    from nekro_agent.core.os_env import OsEnv
+    from nekro_agent.routers.webhook import _verify_webhook_token
+    from nekro_agent.schemas.errors import UnauthorizedError
+
+    monkeypatch.setattr(OsEnv, "WEBHOOK_SECRET_KEY", "s3cret")
+    with pytest.raises(UnauthorizedError):
+        _verify_webhook_token(_FakeRequest())
+    with pytest.raises(UnauthorizedError):
+        _verify_webhook_token(_FakeRequest(headers={"X-Webhook-Token": "wrong"}))
+    _verify_webhook_token(_FakeRequest(headers={"X-Webhook-Token": "s3cret"}))
+
+
+def test_webhook_query_param_token_no_longer_accepted(_reset_env, monkeypatch: pytest.MonkeyPatch):
+    """查询参数令牌已移除:即使值正确也不得通过"""
+    from nekro_agent.core.os_env import OsEnv
+    from nekro_agent.routers.webhook import _verify_webhook_token
+    from nekro_agent.schemas.errors import UnauthorizedError
+
+    monkeypatch.setattr(OsEnv, "WEBHOOK_SECRET_KEY", "s3cret")
+    with pytest.raises(UnauthorizedError):
+        _verify_webhook_token(_FakeRequest(query={"webhook_token": "s3cret"}))


### PR DESCRIPTION
## 概述

对项目做了一次白盒静态安全审计(未发现后门;密钥均为运行时随机生成,遥测无隐私字段),本 PR 修复其中可形成「聊天提示注入 → 宿主 RCE」完整利用链的高危问题及若干中危问题。**所有修复已在真实 Docker 环境中端到端验证**。

取代 #350 / #351(同一分支的迭代,本 PR 包含评审反馈修复与实机测试发现的 bug 修复)。

## 修复内容

### F-01(高危)— RPC pickle 反序列化 RCE 原语
`/ext/rpc_exec` 此前对来自不可信沙箱(执行 LLM 生成代码的环境)的请求体直接 `pickle.loads`。被提示注入的 Agent 一旦从沙箱 `api_caller.py` 中读出注入的 RPC 令牌,即可发送构造的 pickle payload 实现宿主进程 RCE,并借助宿主 docker.sock 挂载进一步放大。

- 新增 `services/sandbox/rpc_pickle.py`:白名单受限 `RestrictedUnpickler`(仅内建类型 + 少量标准库类型),其余任何 GLOBAL 加载一律拒绝

### F-02(高危)— 沙箱容器未受约束
非 Docker 宿主上,沙箱容器此前被设置为 `apparmor=unconfined`,且 `no-new-privileges` 被注释掉。

- 现在恒定启用 `no-new-privileges`;`apparmor=unconfined` 仅在显式设置 `NEKRO_SANDBOX_DISABLE_APPARMOR=true` 逃生开关时生效
- 代码注释中补充了新旧行为矩阵(Docker/非 Docker × 默认/逃生开关)及功能不受影响的原因(沙箱以 nobody 运行、pip 用 --target 安装,不依赖 setuid/setcap)

### F-03(高危)— CORS 通配 + 凭据(CWE-942)
`allow_origins=["*"]` 与 `allow_credentials=True` 组合会反射任意 Origin,任何恶意网页都能以受害者浏览器凭据驱动管理 API。

- 改为 `NEKRO_CORS_ORIGINS` 环境变量白名单(逗号分隔);默认不启用 CORS 中间件,同源 `/webui` 前端不受影响

### F-05(中危)— webhook 端点无鉴权
`POST /api/webhook/{endpoint}` 无任何鉴权,且会调用宿主侧插件 webhook 处理器。

- 启用 `WEBHOOK_SECRET_KEY`(此前启动时生成却从未校验):设置后要求携带匹配的 `X-Webhook-Token` 请求头(或 `webhook_token` 查询参数),`hmac.compare_digest` 常时比较;未设置时保持旧行为兼容,启动时输出一次性提醒日志(避免请求路径上的可变全局标志)

### F-06(中危)— `download_file()` SSRF
任意 URL 抓取,无 scheme/IP 校验(本机 API、内网 Postgres/Qdrant、云元数据均可达)。

- 新增异步 `assert_safe_download_url()`,异常分类:`UnsafeDownloadUrl`(格式错误/协议不支持/域名无法解析,用户输入问题)vs `BlockedDownloadAddress`(保留地址,安全拦截),调用方可区分处理
- 仅允许 http/https;DNS 解析后逐地址比对环回/RFC1918/链路本地/CGNAT/组播/保留段;通过事件循环解析 DNS,不阻塞协程
- 已知限制(代码注释说明):校验与连接存在 DNS 重绑定 TOCTOU 窗口;当前 httpx 默认不跟随重定向,302 绕径不可行

### F-09(低危)— docker 命令注入
`docker_restart`/`docker_logs` 将参数直接内插进 `os.system`/`os.popen`。

- `shlex.quote` + Docker 容器名正则白名单双重防护,校验函数实际接入两条命令路径

## Docker 实机端到端验证

在真实容器(官方镜像 + 注入本分支代码,基线与镜像代码比对一致)中验证:

- **RPC pickle**:正确密钥 + `__reduce__` gadget / 手工 `posix.system` opcode → 400 拒绝,RCE 标记文件未创建;正常 payload 通过解码层;错误密钥 → 401
- **Webhook**:无/错误令牌 → 401;正确令牌(header 或 query)→ 越过鉴权
- **CORS**:`NEKRO_CORS_ORIGINS` 白名单 Origin 精确返回 ACAO;任意 Origin 无 ACAO;未配置时无任何 CORS 头
- **SSRF**(容器内真实调用 `download_file`):127.0.0.1 / 10.x → `BlockedDownloadAddress`;`ftp://` → `UnsafeDownloadUrl`;公网 URL 正常下载落盘
- **回归**:`/api/health` 200、admin 登录 200

### 实机测试发现并修复的 bug(静态检查无法发现)

1. **双前缀 bug**:`OsEnvTypes._use_env` 自动为键名加 `NEKRO_` 前缀,初版 `Str("NEKRO_CORS_ORIGINS")` 实际读取 `NEKRO_NEKRO_CORS_ORIGINS`,白名单永远无法启用(`NEKRO_SANDBOX_DISABLE_APPARMOR` 同理)。已改为裸键名
2. **异常类型压平**:`download_file` 曾将分类异常重包为普通 `ValueError`,破坏分类承诺。已改为 re-raise 原子类(仍为 ValueError 子类,兼容)

## 给维护者的说明

- F-01 治本方案是 pickle RPC 协议整体替换为 JSON + 方法白名单;本 PR 保持协议兼容,仅消除 RCE 原语
- 实测发现的部署陷阱:`OsEnv` 读取 `NEKRO_` 前缀变量,而 docker-compose.yml 传递的是无前缀的 `RPC_SECRET_KEY` 等——这些环境变量实际从未生效,一直是进程内随机值。建议统一( compose 改传 `NEKRO_` 前缀或 OsEnv 兼容双读)
- docker.sock 挂载风险(F-04,沙箱管理固有设计)未处理,建议文档标注并提供 socket-proxy 选项
- 完整审计报告(含 CWE 引用与攻击链分析)可按需提供

## 测试清单

- [x] 全部改动文件 `py_compile` 通过
- [x] RestrictedUnpickler 单测(正常放行/3 类 gadget 拦截/无副作用)
- [x] SSRF 分类 8 用例 + 容器内 4 用例实测
- [x] 容器名白名单 11 用例
- [x] Docker 实机端到端全项(见上)
- [ ] 完整 pytest 套件(本地环境缺依赖,由 CI 覆盖)

## Summary by Sourcery

通过新增 SSRF 与 RCE 防护、可配置的 webhook 认证、更严格的 CORS 处理以及更安全的容器命令执行，对 RPC、webhook、下载、沙箱和 Docker 操作路径进行加固以防范安全问题。

Bug Fixes:
- 通过对 URL 进行校验并阻止访问内部或保留网络范围，为文件下载增加 SSRF 防护。
- 使用可配置的密钥，对 webhook 端点强制启用可选的基于 HMAC 的认证。
- 将 RPC 的 pickle 反序列化限制在安全类白名单内，以防止通过不受信任的沙箱请求实现远程代码执行。
- 通过校验容器名称并对参数进行 shell 引号转义，加固 Docker 操作命令以防止命令注入。
- 通过启用 no-new-privileges 并将 AppArmor 放宽设置改为显式的 opt-in，强化沙箱容器的安全选项。
- 修正 webhook 密钥和新的 CORS 设置的环境配置默认值，以避免错误配置。

Enhancements:
- 通过环境变量将 CORS 配置显式化并基于白名单控制，默认禁用 CORS，同时保持同源 Web UI 的正常行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden RPC, webhook, download, sandbox, and Docker ops paths against security issues by adding SSRF and RCE protections, configurable webhook auth, stricter CORS handling, and safer container command execution.

Bug Fixes:
- Add SSRF protections for file downloads by validating URLs and blocking requests to internal or reserved network ranges.
- Enforce optional HMAC-based authentication for webhook endpoints using a configurable secret key.
- Restrict RPC pickle deserialization to a safe class whitelist to prevent remote code execution via untrusted sandbox requests.
- Harden Docker operations commands against command injection by validating container names and shell-quoting arguments.
- Tighten sandbox container security options by enabling no-new-privileges and making AppArmor relaxation explicitly opt-in.
- Correct environment configuration defaults for webhook secrets and new CORS settings to avoid misconfiguration.

Enhancements:
- Make CORS configuration explicit and whitelist-based via environment variables, disabling CORS by default while preserving same-origin web UI behavior.

</details>