### PR TITLE
fix(frontend): clamp elapsed seconds to non-negative on live status card

### DIFF
--- a/frontend/src/components/common/AgentActivityCard.tsx
+++ b/frontend/src/components/common/AgentActivityCard.tsx
@@ -57,10 +57,10 @@ const DONE_LINGER_MS = 1200
 // ── 通用计时 hook ─────────────────────────────────────────────────────────────
 
 function useElapsedSeconds(startTime: number) {
-  const [elapsed, setElapsed] = useState(Math.floor((Date.now() - startTime) / 1000))
+  const [elapsed, setElapsed] = useState(Math.max(0, Math.floor((Date.now() - startTime) / 1000)))
   useEffect(() => {
     const id = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - startTime) / 1000))
+      setElapsed(Math.max(0, Math.floor((Date.now() - startTime) / 1000)))
     }, 1000)
     return () => clearInterval(id)
   }, [startTime])


### PR DESCRIPTION
## 问题

AgentActivityCard 的实时状态卡片里「已处理」时长显示为负数（如 `-26s` / `-50s`）。

## 根因

`AgentActivityCard.tsx` 的 `useElapsedSeconds` 用浏览器时钟减去服务端下发的 `started_at` 时间戳：

```ts
Math.floor((Date.now() - startTime) / 1000)
```

`startTime` 来自服务端的 `started_at`（epoch ms，经 `normalizeStartedAt` 仅做了 `>0` 校验，未做服务端-浏览器时钟补偿）。当服务器时钟超前浏览器时钟时，`Date.now() - startTime` 为负，UI 直接显示负的已处理时长。

## 改动

给初始 state 与 setInterval 更新两处都加上 `Math.max(0, ...)` 保底，使该计数器绝不会显示负数。

```ts
const [elapsed, setElapsed] = useState(Math.max(0, Math.floor((Date.now() - startTime) / 1000)))
...
setElapsed(Math.max(0, Math.floor((Date.now() - startTime) / 1000)))
```

## 说明

这是最小化的症状修复；时钟偏移最干净的解法是服务端事件下发一个单调 elapsed 或服务端 now，不做跨时钟相减。若后续要彻底解决，可以再单独跟进。

## Sourcery 总结

错误修复：
- 防止因服务器时钟与浏览器时钟不一致，导致实时活动卡片显示负的经过时长。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the live activity card from displaying negative elapsed durations when server and browser clocks differ.

</details>